### PR TITLE
docs: add OSS hygiene docs and release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report a reproducible defect in Vantage
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide a small, reproducible report with the exact command, prompt, or workflow that failed.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Concise description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction
+      description: List the exact steps to reproduce the issue.
+      placeholder: |
+        1. Run ...
+        2. Ask ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error output if relevant.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Vantage version
+      description: npm version, git commit, or local branch
+      placeholder: 0.1.0 or commit SHA
+    validations:
+      required: true
+  - type: input
+    id: runtime
+    attributes:
+      label: Environment
+      description: Node version and OS
+      placeholder: Node 22 on macOS 15
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, relevant provider setup, or anything else maintainers should know

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new capability or a meaningful change to existing behavior
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use this form for non-trivial feature work. Start here before opening a large PR so scope and tradeoffs can be discussed first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What user problem should this solve?
+      placeholder: Describe the workflow gap, pain point, or unmet need.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should Vantage do?
+      placeholder: Describe the intended behavior at a user level.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider, and why are they worse?
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks or tradeoffs
+      description: Call out complexity, maintenance cost, API/provider constraints, or user confusion risk
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: How would we know this feature is working well?
+      placeholder: Tests, user flows, acceptance checks, or rollout signals

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+Describe the change in a few sentences.
+
+## Why
+
+Explain the problem being solved and the user or maintainer impact.
+
+## Validation
+
+- [ ] `npm test`
+- [ ] Docs updated if behavior or workflow changed
+- [ ] Tests added or updated for behavior changes
+
+List any other checks you ran.
+
+## Risks / Follow-ups
+
+Call out edge cases, rollout concerns, or follow-up work.
+
+## Issue / Discussion
+
+Link the issue or discussion for non-trivial work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-30
+
+- Initial Vantage release baseline before public npm packaging work.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+Vantage is committed to a respectful, technically serious, and inclusive collaboration environment.
+
+## Expected Behavior
+
+Participants in this project are expected to:
+
+- be respectful in code review and issue discussions
+- focus criticism on ideas, code, and behavior rather than people
+- assume good intent while still being direct about technical problems
+- welcome contributors with different backgrounds and levels of experience
+- accept feedback and course-correct when needed
+
+## Unacceptable Behavior
+
+The following behavior is not acceptable in project spaces, including issues, pull requests, review comments, and other public collaboration channels:
+
+- harassment, intimidation, or discrimination
+- personal attacks, insults, or demeaning language
+- doxxing or sharing private information without permission
+- sexualized language or unwanted sexual attention
+- threats of violence or self-harm encouragement
+- repeated bad-faith disruption after moderator or maintainer direction
+
+## Maintainer Responsibilities
+
+Maintainers may edit, remove, or reject comments, issues, pull requests, and other contributions that violate this policy. They may also temporarily or permanently restrict participation when needed to protect the project and its contributors.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, contact the project maintainer privately using the repository owner's available contact channel. Do not open a public issue with sensitive personal safety details.
+
+Maintainers will review reports promptly and handle them with discretion to the extent possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to Vantage
+
+Vantage is a financial data analysis agent built with TypeScript, Vitest, and Pi. Contributions should keep the runtime small, the data flow explicit, and the quality bar high enough for a public npm package.
+
+## Before You Start
+
+- For non-trivial features, start with an issue or discussion before opening a PR.
+- Bug fixes should include a clear reproduction in the PR description.
+- Behavior-changing work must include tests.
+- Keep user-facing claims factual. Do not document or imply package behavior that does not exist yet.
+
+## Local Setup
+
+```bash
+npm install
+cp .env.example .env
+npm start
+```
+
+If you need provider keys for manual testing, prefer `.env` for local work. Unit tests must continue to run without live API access.
+
+## Development Commands
+
+```bash
+npm start
+npm test
+npm run test:watch
+npm run test:e2e
+npm run test:e2e:cli
+npm run test:e2e:providers
+```
+
+`npm test` is the required baseline validation after changes.
+
+## Contribution Rules
+
+### TDD is mandatory
+
+Write or update the failing test first, then implement the change.
+
+This is not optional for runtime behavior. If a change affects behavior and has no test coverage, it is incomplete.
+
+### Keep tool boundaries clean
+
+- Tools fetch and format data
+- Analysts and prompts synthesize
+- Do not move analysis logic into tools
+
+### Keep provider tests fixture-based
+
+- Unit tests must mock `globalThis.fetch`
+- Do not make live API calls in unit tests
+- Add fixture JSON under `tests/fixtures/<provider>/` for new provider responses
+
+### Keep typing strict
+
+- Avoid `any` except for raw provider payloads at the API boundary
+- Use `.js` extensions on relative imports
+- Use `node:` prefixes for built-in modules
+
+## Pull Requests
+
+Open focused PRs with enough context for review.
+
+Every PR should explain:
+
+- what changed
+- why it changed
+- user or maintainer impact
+- test coverage added or updated
+- risks, follow-ups, or known gaps
+
+For non-trivial work, link the issue or design discussion that established scope.
+
+## Release Notes and Changelog Discipline
+
+Vantage follows Pi's release style where possible: manual semver bump scripts, a maintained `CHANGELOG.md` with an `Unreleased` section, and explicit release commands.
+
+Prefer clear prefixes such as:
+
+- `feat:`
+- `fix:`
+- `docs:`
+- `refactor:`
+- `test:`
+
+Release notes should describe user-visible impact, not just implementation detail.
+
+Release commands:
+
+```bash
+npm run version:patch
+npm run version:minor
+npm run version:major
+npm run publish:dry
+npm run release:patch
+npm run release:minor
+npm run release:major
+```
+
+The `release:*` scripts are intended for maintainers. They bump the version, update `CHANGELOG.md`, create a release commit and tag, restore the `Unreleased` section for the next cycle, and push both `main` and the release tag.
+
+The actual npm publish step runs in GitHub Actions from the pushed `v*` tag using trusted publishing. That keeps the local release flow minimal while avoiding laptop-based npm publishes.
+
+## Scope Boundaries
+
+Ask first before changing:
+
+- system prompt or analyst orchestration
+- Pi shell integration under `src/pi/`
+- memory SQLite schema
+- provider strategy that needs new rate-limit or fixture policy
+
+Do not:
+
+- guess financial numbers or metrics
+- hardcode mock data into tools
+- make live API calls in unit tests
+- blur the separation between Pi-owned config and Vantage-owned state
+
+## Where Things Live
+
+- Providers: `src/providers/`
+- Tools: `src/tools/`
+- Routing: `src/routing/`
+- Workflows: `src/workflows/`
+- Memory: `src/memory/`
+- Pi integration: `src/pi/`
+- Tests and fixtures: `tests/`
+
+The repo-level [AGENTS.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/AGENTS.md) remains the most specific implementation guide for code changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kahtaf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ npm test              # 208 unit tests
 npm run test:watch    # watch mode
 ```
 
+## Project Docs
+
+- OSS launch and npm release plan: [docs/production-plan.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/docs/production-plan.md)
+- Contributor guide: [CONTRIBUTING.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/CONTRIBUTING.md)
+- Security policy: [SECURITY.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/SECURITY.md)
+- Release history: [CHANGELOG.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/CHANGELOG.md)
+
 ## Tech Stack
 
 - **Runtime**: TypeScript, Node.js

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Until Vantage reaches `1.0.0`, security support is limited to the latest pre-1.0 release line.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest `0.x` release | Yes |
+| Older pre-1.0 releases | No |
+| Unreleased local forks | No |
+
+## Reporting a Vulnerability
+
+Do not open public GitHub issues for security vulnerabilities.
+
+Use GitHub Security Advisories or the repository's private vulnerability reporting channel to report suspected vulnerabilities to the maintainers.
+
+When reporting an issue, include:
+
+- affected version or commit
+- impact summary
+- reproduction steps or proof of concept
+- any suggested mitigation if known
+
+Maintainers will acknowledge valid reports, investigate them privately, and coordinate a fix and release before public disclosure when practical.

--- a/docs/production-plan.md
+++ b/docs/production-plan.md
@@ -1,87 +1,278 @@
-# Vantage: Productionization Plan
+# Vantage OSS Launch Plan
 
-## 1. Overview & Vision
-The goal is to evolve Vantage from a local script (`tsx src/index.ts`) into a globally distributable CLI/TUI application that users can install via `npm install -g vantage-agent`. It will feature a rich Text User Interface (TUI), automated CI/CD for reliable releases, and comprehensive documentation for both end-users and contributors.
+## 1. Purpose
 
----
+This document is the canonical plan for taking Vantage from a local development project to a public npm package with a credible open source maintenance baseline.
 
-## 2. Distribution Strategy (npm)
+The goal is not just "make it publish." The goal is to make the package installable, understandable, supportable, and safe to adopt:
 
-To make the agent easily installable by anyone with Node.js:
+- Public npm package: `@kahtaf/vantage`
+- User-facing executable: `vantage`
+- Supported install mode: global npm install
+- Pi-owned config remains in `~/.pi/agent/...`
+- Vantage-owned state remains in `~/.vantage/`
 
-1. **Bundling**: Introduce a bundler like `tsup` or `esbuild`. This compiles the TypeScript codebase into a fast, standalone ES Module (ESM) bundle, minimizing installation time and resolving import issues.
-2. **Binary Wrapper**: Update `package.json` with a `bin` entry:
-   ```json
-   "bin": {
-     "vantage": "./dist/cli.js"
-   }
-   ```
-3. **Configuration Management**: Keep Pi-managed auth/model config in `~/.pi/agent/...` and use `~/.vantage/` only for Vantage-owned user state such as watchlists, portfolios, predictions, logs, and memory.
+Vantage should follow Pi's minimal CLI-first posture where possible: keep the runtime surface small, keep the config model explicit, and avoid process overhead that does not help the first public release.
 
----
+## 2. Current State and Gaps
 
-## 3. User Interface: The TUI (Text User Interface)
+### 2.1. What already exists
 
-Since Vantage is built on Pi, giving users visibility into the agent's "thought process" and tool execution is critical for trust and UX.
+- A working TypeScript codebase with Vitest coverage and mocked provider fixtures
+- A user-facing [README](/Users/kahtaf/.codex/worktrees/dc41/vantage/README.md)
+- A clear runtime-state separation between Pi config and Vantage-owned data
+- A draft production plan focused on packaging/TUI/CI concerns
 
-**Recommendation:** Reuse Pi's existing TUI and interactive runtime rather than building a separate Ink or Clack shell.
-**Core TUI Features:**
-- **Streaming Responses**: Render the LLM's streaming output with real-time markdown parsing.
-- **Thought / Status Indicators**: Spinners showing active tool executions (e.g., `⠋ Fetching TSLA option chain...`, `⠙ Running Black-Scholes local computation...`).
-- **Configuration Flow**: Pi-native `/login` and `/model` flows for LLM access, plus Vantage-specific setup for finance provider keys when needed.
-- **Error Boundaries**: Graceful, readable error handling if rate limits (e.g., Yahoo Finance) are hit or Camoufox stealth sessions fail.
+### 2.2. Current OSS hygiene gaps
 
----
+The repository currently has only `README.md` and `.gitignore` as top-level OSS-facing hygiene files.
 
-## 4. CI/CD Pipeline (GitHub Actions)
+Missing launch-baseline artifacts:
 
-A robust pipeline ensures code quality and automates releases.
+- `LICENSE`
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- GitHub issue forms for bugs and feature requests
+- GitHub pull request template
+
+Current npm tarball hygiene also fails the target public-release bar. A dry run currently includes repository docs, tests, fixtures, and internal project files. Public release must ship a dist-focused tarball plus standard metadata files, not the full source repository by default.
+
+## 3. Public npm Contract
+
+This section defines the package contract the repository must support before the first public npm release.
+
+### 3.1. Package identity
+
+- Package name: `@kahtaf/vantage`
+- Executable: `vantage`
+- Install command: `npm install -g @kahtaf/vantage`
+- Update command: `npm install -g @kahtaf/vantage@latest`
+
+### 3.2. Runtime and state boundaries
+
+- Pi manages model/auth configuration in `~/.pi/agent/...`
+- Vantage manages finance-provider config and user state in `~/.vantage/`
+- The published CLI must work from any directory
+- The published CLI must not depend on a repo-local `.pi/extensions/...` path
+
+### 3.3. Runtime support target
+
+- Node.js `>=20`
+- Validate against active LTS lines in CI before public release
+
+### 3.4. Versioning policy
+
+- Stay pre-1.0 until the npm package contract and CLI behavior are stable
+- Every user-visible release must have a generated changelog entry
+- Release notes must be readable without opening the diff
+
+## 4. OSS Hygiene Baseline
+
+The following repository artifacts are required before launch.
+
+| File | Purpose | Launch requirement |
+|------|---------|--------------------|
+| `LICENSE` | Legal reuse terms | MIT |
+| `CONTRIBUTING.md` | Contributor workflow and quality bar | Required |
+| `CODE_OF_CONDUCT.md` | Collaboration expectations and reporting path | Required |
+| `SECURITY.md` | Vulnerability reporting and supported versions | Required |
+| `.github/ISSUE_TEMPLATE/bug-report.yml` | Repro-friendly bug intake | Required |
+| `.github/ISSUE_TEMPLATE/feature-request.yml` | Scope-first feature intake | Required |
+| `.github/pull_request_template.md` | Standardize PR context and validation | Required |
+
+### 4.1. Maintainer policy
+
+Use a lightweight but explicit maintainer bar modeled after projects like Pi and Vitest:
+
+- Non-trivial features should start with an issue or discussion before implementation
+- Behavior-changing PRs must include tests
+- Bug reports should require reproduction detail
+- PRs should explain user impact, risk, and validation
+- Commit and release note conventions must stay structured enough to generate useful changelogs
+
+### 4.2. Support surface
+
+For v1, keep support intentionally narrow:
+
+- Public support surface: GitHub Issues
+- Private security reporting surface: GitHub Security Advisories / private vulnerability reporting
+- No required Discord, Discussions board, or separate support queue for the first public release
+
+## 5. Documentation Matrix
+
+The minimum doc set should be split by audience.
+
+| Document | Audience | Required content |
+|----------|----------|------------------|
+| [README.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/README.md) | Users | Install, first run, config, supported providers, common commands, architecture summary |
+| [CONTRIBUTING.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/CONTRIBUTING.md) | Contributors | Local setup, test commands, TDD rule, fixture-first provider testing, PR expectations |
+| [SECURITY.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/SECURITY.md) | Users and maintainers | Supported versions and private reporting path |
+| [docs/production-plan.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/docs/production-plan.md) | Maintainers | Release policy, launch checklist, CI/CD, npm distribution contract |
+
+Documentation should stay factual about current behavior. The release plan can define future packaging work, but user-facing docs should not claim public npm availability until the package is actually published.
+
+## 6. npm Packaging and Tarball Hygiene
+
+Public release requires an explicit packaging policy.
+
+### 6.1. Required package metadata
+
+Before publishing, `package.json` must define:
+
+- `name`
+- `bin`
+- `files` allowlist or `.npmignore`
+- `engines`
+- `repository`
+- `homepage`
+- `bugs`
+- `keywords`
+- `license`
+
+### 6.2. Publish footprint
+
+Release tarballs should include:
+
+- Built CLI/runtime artifacts under `dist/`
+- Required package metadata
+- User-facing docs that materially help package consumers, if intentionally included
+
+Release tarballs should not include by default:
+
+- `tests/`
+- `docs/` planning material
+- internal fixtures
+- local-only repo support files
+- source files that are not required for runtime or intended source distribution
+
+### 6.3. Release blocker
+
+`npm pack --dry-run` is a hard gate for launch.
+
+The dry-run output must show a dist-focused footprint that matches the intended public package. If docs, tests, fixtures, or internal repo files are still present, release work is not complete.
+
+## 7. CI/CD and Release Policy
+
+### 7.1. Pull request quality gate
+
+Every PR to `main` should pass:
+
+- install
+- typecheck
+- `npm test`
+- packaging validation where applicable
+
+Behavior-changing work should fail review if it does not include matching tests.
+
+### 7.2. Release mechanism
+
+Use a hybrid release flow:
+
+- `npm run version:patch|minor|major` for semver bumps
+- a committed `CHANGELOG.md` with a top-level `Unreleased` section
+- `npm run release:patch|minor|major` for the maintainer preparation flow
+- GitHub Actions publish from pushed `v*` tags using npm trusted publishing
+
+For Vantage, this is simpler than Changesets because the repo currently publishes a single package, not a multi-package workspace.
+
+### 7.3. Publish pipeline
+
+The target release flow is:
 
 ```mermaid
 flowchart LR
-    PR[Pull Request] --> Lint[ESLint/Prettier]
-    Lint --> Test[Vitest Unit/E2E]
-    Test --> Merge[Merge to Main]
-    Merge --> Release[Semantic Release]
-    Release --> NPM[npm publish]
+    PR["Pull request"] --> Checks["Install, typecheck, test, package checks"]
+    Checks --> Merge["Merge to main"]
+    Merge --> Version["Manual version bump + changelog update"]
+    Version --> Tag["Push release tag"]
+    Tag --> Publish["GitHub Actions publish to npm"]
 ```
 
-### 4.1. Pull Request Checks (The Quality Gate)
-- **Linting & Formatting**: Enforce strict TypeScript checks, ESLint, and Prettier formatting.
-- **Automated Testing**: Run `npm test` via Vitest. As per the project's strict conventions, **Red/Green TDD is mandatory**. The pipeline will fail if coverage drops or if tests fail. Live API calls are strictly mocked via `tests/fixtures/`.
+### 7.4. Supply-chain policy
 
-### 4.2. Automated Releases
-- Implement **Semantic Release** or **Changesets**.
-- When a PR is merged into `main`, GitHub Actions will:
-  1. Determine the next semantic version number based on commit messages (e.g., `feat:`, `fix:`).
-  2. Generate an automated `CHANGELOG.md`.
-  3. Build the project via `tsup`.
-  4. Publish the package directly to the npm registry.
+- Keep Pi-style local versioning and changelog handling while the project remains a single package
+- Run release commands from a clean working tree only
+- Publish to npm from GitHub Actions via trusted publishing instead of a maintainer laptop
+- Enable npm provenance on tagged releases
 
----
+## 8. Launch Phases
 
-## 5. Documentation Strategy
+### Phase 1. OSS baseline docs and repo metadata
 
-To ensure adoption and easy onboarding:
+Deliverables:
 
-1. **`README.md` (User-Facing)**
-   - **Quickstart**: `npm install -g @kahtaf/vantage && vantage`
-   - **Configuration**: Explain that Pi manages LLM auth/models, while Vantage stores user data in `~/.vantage/`.
-   - **Features & Examples**: Demonstrating the financial, macro, and sentiment capabilities.
-2. **`CONTRIBUTING.md` (Developer-Facing)**
-   - Clear instructions on the architecture (tools vs providers vs analysts).
-   - Strict outline of the **TDD MANDATORY** policy.
-   - Guide on how to add a new tool or provider and create the corresponding mock fixtures.
-3. **`ARCHITECTURE.md` / Diagrams**
-   - Detailed diagrams showing the flow between the user, Gemini API, `pi-agent-core` loop, local computation modules, and stealth browser fallback (`camoufox-js`).
+- `LICENSE`
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- GitHub issue forms
+- PR template
 
----
+Exit criteria:
 
-## 6. Execution Phases
+- A new contributor can discover project norms without reading source files first
+- The repo has a clear public support path and private security path
 
-| Phase | Milestone | Description |
-|-------|-----------|-------------|
-| **Phase 1** | CLI & Config | Build the global config manager (key storage) and basic CLI entry point. Setup `tsup` build process. |
-| **Phase 2** | TUI Integration | Finish Pi-based TUI integration, finance-specific onboarding, and interactive setup polish. |
-| **Phase 3** | CI/CD | Add GitHub Actions for linting, strict Vitest execution, and Semantic Release automation. |
-| **Phase 4** | Documentation | Finalize README, CONTRIBUTING, and release v1.0.0 to npm. |
+### Phase 2. npm packaging contract and tarball cleanup
+
+Deliverables:
+
+- scoped npm package identity
+- `bin` entry
+- packaging allowlist
+- runtime support metadata
+- dist-focused tarball
+
+Exit criteria:
+
+- `npm pack --dry-run` includes only the intended publish footprint
+- Global install and update flow are documented and technically valid
+
+### Phase 3. CI/release automation and trusted publishing
+
+Deliverables:
+
+- GitHub Actions quality gate
+- Pi-style version and release scripts
+- tag-triggered npm publish workflow
+- trusted publishing and provenance
+
+Exit criteria:
+
+- A maintainer can run the documented release commands without manual version file editing, and a pushed release tag publishes from GitHub Actions
+
+### Phase 4. Launch validation and first public release
+
+Deliverables:
+
+- launch checklist execution
+- install/update validation
+- doc review against actual behavior
+- first public npm release
+
+Exit criteria:
+
+- A fresh machine can install and run `vantage`
+- Update instructions work as documented
+- User-facing docs match the published package behavior
+
+## 9. Acceptance Checks
+
+The launch is not complete until all of the following pass:
+
+1. `npm pack --dry-run` includes only the built CLI/runtime artifacts and standard metadata files.
+2. A fresh machine can install globally, run `vantage --help`, complete first-run setup, and update via npm without a repo-local `.pi/extensions/...`.
+3. [README.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/README.md) accurately describes the real config and state split between `~/.pi/agent` and `~/.vantage/`.
+4. A contributor can follow [CONTRIBUTING.md](/Users/kahtaf/.codex/worktrees/dc41/vantage/CONTRIBUTING.md), run `npm test`, and understand the test/fixture workflow without tribal knowledge.
+5. The documented release flow can generate a changelog, publish from a GitHub Actions tag workflow, and leave the changelog reset with a fresh `Unreleased` section.
+
+## 10. Reference Inspiration
+
+- Pi mono for CLI-first install/update posture and contributor entry points: [github.com/badlogic/pi-mono](https://github.com/badlogic/pi-mono)
+- Vitest for contributor discipline and test-first contribution norms: [CONTRIBUTING.md](https://raw.githubusercontent.com/vitest-dev/vitest/main/CONTRIBUTING.md)
+- pnpm for concise security policy structure: [SECURITY.md](https://raw.githubusercontent.com/pnpm/pnpm/main/SECURITY.md)
+- React for a direct vulnerability reporting policy: [SECURITY.md](https://raw.githubusercontent.com/facebook/react/main/SECURITY.md)
+- npm docs for package publishing details if the release flow is hardened later:
+  - [Trusted publishers](https://docs.npmjs.com/trusted-publishers/)
+  - [Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements/)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,19 @@
     "test:watch": "vitest",
     "test:e2e": "tsx tests/e2e/tools.test.ts",
     "test:e2e:cli": "tsx tests/e2e/cli.test.ts",
-    "test:e2e:providers": "tsx tests/e2e/providers.test.ts"
+    "test:e2e:providers": "tsx tests/e2e/providers.test.ts",
+    "version:patch": "npm version patch --no-git-tag-version",
+    "version:minor": "npm version minor --no-git-tag-version",
+    "version:major": "npm version major --no-git-tag-version",
+    "version:set": "npm version",
+    "prepublishOnly": "npm test",
+    "publish:dry": "npm publish --access public --dry-run",
+    "release:patch": "node scripts/release.mjs patch",
+    "release:minor": "node scripts/release.mjs minor",
+    "release:major": "node scripts/release.mjs major"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.63.1",

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+export function updateChangelogForRelease(changelogPath, version, date = new Date().toISOString().split("T")[0]) {
+  const content = readFileSync(changelogPath, "utf-8");
+  if (!content.includes("## [Unreleased]")) {
+    throw new Error(`Missing [Unreleased] section in ${changelogPath}`);
+  }
+
+  const updated = content.replace("## [Unreleased]", `## [${version}] - ${date}`);
+  writeFileSync(changelogPath, updated);
+}
+
+export function addUnreleasedSection(changelogPath) {
+  const content = readFileSync(changelogPath, "utf-8");
+  if (content.includes("## [Unreleased]")) {
+    return;
+  }
+
+  const updated = content.replace(/^(# Changelog\n\n)/, "$1## [Unreleased]\n\n");
+  if (updated === content) {
+    throw new Error(`Missing changelog header in ${changelogPath}`);
+  }
+
+  writeFileSync(changelogPath, updated);
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { addUnreleasedSection, updateChangelogForRelease } from "./release-lib.mjs";
+
+const bumpType = process.argv[2];
+const supportedBumpTypes = new Set(["major", "minor", "patch"]);
+
+if (!supportedBumpTypes.has(bumpType)) {
+  console.error("Usage: node scripts/release.mjs <major|minor|patch>");
+  process.exit(1);
+}
+
+function run(cmd, options = {}) {
+  console.log(`$ ${cmd}`);
+  try {
+    return execSync(cmd, {
+      encoding: "utf-8",
+      stdio: options.silent ? "pipe" : "inherit",
+      ...options,
+    });
+  } catch (error) {
+    if (!options.ignoreError) {
+      console.error(`Command failed: ${cmd}`);
+      process.exit(1);
+    }
+    return null;
+  }
+}
+
+function getVersion() {
+  const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+  return pkg.version;
+}
+
+console.log("\n=== Release Script ===\n");
+
+console.log("Checking for uncommitted changes...");
+const status = run("git status --porcelain", { silent: true });
+if (status && status.trim()) {
+  console.error("Error: Uncommitted changes detected. Commit or stash first.");
+  console.error(status);
+  process.exit(1);
+}
+console.log(" Working directory clean\n");
+
+console.log(`Bumping version (${bumpType})...`);
+run(`npm run version:${bumpType}`);
+const version = getVersion();
+console.log(` New version: ${version}\n`);
+
+console.log("Updating CHANGELOG.md...");
+updateChangelogForRelease("CHANGELOG.md", version);
+console.log(" Updated CHANGELOG.md\n");
+
+console.log("Committing and tagging...");
+run("git add package.json package-lock.json CHANGELOG.md");
+run(`git commit -m "Release v${version}"`);
+run(`git tag v${version}`);
+console.log();
+
+console.log("Adding [Unreleased] section for next cycle...");
+addUnreleasedSection("CHANGELOG.md");
+console.log(" Updated CHANGELOG.md\n");
+
+console.log("Committing changelog reset...");
+run("git add CHANGELOG.md");
+run('git commit -m "Add [Unreleased] section for next cycle"');
+console.log();
+
+console.log("Pushing to remote...");
+run("git push origin main");
+run(`git push origin v${version}`);
+console.log();
+
+console.log("GitHub Actions will publish the tagged release to npm.");
+console.log();
+
+console.log(`=== Prepared release v${version} ===`);

--- a/tests/unit/scripts/release-lib.test.ts
+++ b/tests/unit/scripts/release-lib.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { addUnreleasedSection, updateChangelogForRelease } from "../../../scripts/release-lib.mjs";
+
+function makeTempChangelog(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "vantage-release-lib-"));
+  const path = join(dir, "CHANGELOG.md");
+  writeFileSync(path, content);
+  return path;
+}
+
+describe("release-lib", () => {
+  it("replaces the unreleased heading with a versioned release heading", () => {
+    const path = makeTempChangelog("# Changelog\n\n## [Unreleased]\n\n- Pending item\n");
+
+    updateChangelogForRelease(path, "0.2.0", "2026-03-30");
+
+    expect(readFileSync(path, "utf-8")).toBe(
+      "# Changelog\n\n## [0.2.0] - 2026-03-30\n\n- Pending item\n",
+    );
+  });
+
+  it("re-inserts the unreleased section at the top of the changelog", () => {
+    const path = makeTempChangelog("# Changelog\n\n## [0.2.0] - 2026-03-30\n\n- Released item\n");
+
+    addUnreleasedSection(path);
+
+    expect(readFileSync(path, "utf-8")).toBe(
+      "# Changelog\n\n## [Unreleased]\n\n## [0.2.0] - 2026-03-30\n\n- Released item\n",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add the OSS hygiene baseline docs and GitHub issue/PR templates
- rewrite the production plan around public npm release readiness
- add a Pi-style changelog/versioning flow with release helpers and GitHub Actions CI/publish workflows

## Testing
- npm test