### PR TITLE
feat: add ask_user clarification tool with data-first response playbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-30
+
+- Use npm trusted publishing for releases
+- Avoid duplicate publish workflow runs
+
 ## [0.1.0] - 2026-03-30
 
 - Initial OpenCandle release baseline before public npm packaging work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-01
+
+- Add `ask_user` clarification tool — agent now asks targeted follow-up questions for vague or broad requests instead of making assumptions
+- Add data-first response playbooks — after clarification, agent fetches live market data (fear & greed, macro indicators, benchmark ETFs) before responding
+- System prompt guidance for when to ask vs. proceed with defaults
+
 ## [0.1.1] - 2026-03-30
 
 - Use npm trusted publishing for releases

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Type `analyze TSLA` and it runs a full 5-analyst breakdown — fundamentals, tec
 
 ## Getting Started
 
+**Requires Node.js ≥ 20.**
+
 ### Standalone CLI
 
 ```bash
@@ -22,7 +24,13 @@ opencandle
 npx opencandle@latest
 ```
 
-On first run, OpenCandle guides you through AI model setup before chat starts. If you want to rerun that flow later, use `/setup`.
+On first run, OpenCandle walks you through setup:
+
+1. **Connect an AI provider** — sign in with OAuth (Google, OpenAI, Anthropic) or paste an API key
+2. **Pick a model** — choose from the available models on your connected provider
+3. **Optional: add market-data keys** — Alpha Vantage and FRED for fundamentals and macro data (can skip)
+
+To rerun setup later, use `/setup`.
 
 ### From Source
 
@@ -65,7 +73,8 @@ Pi also supports OAuth-backed and custom providers through `~/.pi/agent/auth.jso
 ```
 
 - Environment variables still work and override `~/.opencandle/config.json`.
-- OpenCandle user data lives in `~/.opencandle/`:
+- Set `OPENCANDLE_HOME` to override the default `~/.opencandle/` data directory.
+- OpenCandle user data lives in `~/.opencandle/` (or `$OPENCANDLE_HOME`):
   - `~/.opencandle/watchlist.json`
   - `~/.opencandle/portfolio.json`
   - `~/.opencandle/predictions.json`
@@ -75,7 +84,7 @@ Pi also supports OAuth-backed and custom providers through `~/.pi/agent/auth.jso
 
 ## Usage
 
-OpenCandle now runs inside Pi's interactive TUI. Useful controls:
+OpenCandle runs inside Pi's interactive TUI. Useful controls:
 
 ```text
 /model          Switch provider/model
@@ -130,7 +139,7 @@ Key architectural choices:
 ## Test
 
 ```bash
-npm test              # 208 unit tests
+npm test              # unit tests
 npm run test:watch    # watch mode
 ```
 

--- a/src/pi/opencandle-extension.ts
+++ b/src/pi/opencandle-extension.ts
@@ -10,6 +10,7 @@ import type { CompareAssetsSlots, SlotResolution } from "../routing/types.js";
 import { buildCompareAssetsWorkflow, buildOptionsScreenerWorkflow, buildPortfolioWorkflow } from "../workflows/index.js";
 import { getOpenCandleToolDefinitions } from "./tool-adapter.js";
 import { getThirdPartyToolDescriptions } from "../tool-kit.js";
+import { registerAskUserTool } from "../tools/interaction/ask-user.js";
 import { runOpenCandleSetup } from "./setup.js";
 import { initDefaultDatabase, MemoryStorage, buildMemoryContext, extractPreferences } from "../memory/index.js";
 
@@ -135,6 +136,7 @@ export default function openCandleExtension(pi: ExtensionAPI): void {
   for (const tool of getOpenCandleToolDefinitions()) {
     pi.registerTool(tool);
   }
+  registerAskUserTool(pi);
 
   pi.registerCommand("analyze", {
     description: "Run the multi-analyst OpenCandle workflow for a ticker symbol",

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -20,6 +20,7 @@ You provide data-driven analysis for stocks, crypto, macro economics, and portfo
 - **Sentiment**: get_reddit_sentiment, get_reddit_discussions — retail sentiment from financial Reddit communities
 - **Options**: get_option_chain — full options chain with strikes, bids/asks, volume, OI, IV, and computed Greeks (delta, gamma, theta, vega, rho)
 - **Portfolio**: track_portfolio, analyze_risk, manage_watchlist, analyze_correlation, track_prediction — position tracking, P&L, Sharpe ratio, VaR, watchlist with price alerts, correlation matrix, and prediction tracking with accuracy scoring
+- **User Interaction**: ask_user — ask the user a clarification question when their request is ambiguous or missing key details
 
 ## Analytical Framework
 When analyzing a stock, follow these steps in order:
@@ -30,7 +31,7 @@ When analyzing a stock, follow these steps in order:
 5. **SYNTHESIS**: State your reasoning chain explicitly: "Because [data point] + [data point], I conclude [thesis]."
 
 ## Guidelines
-- Always fetch data with tools before stating prices, ratios, or metrics. Never guess financial numbers.
+- Always fetch data with tools before stating prices, ratios, or metrics. Never guess financial numbers. Every substantive response should be backed by at least one tool call — if you find yourself writing a response with zero tool calls, stop and think about what data would make it better.
 - For options analysis, use get_option_chain to see the full chain with Greeks. Pay attention to put/call ratio, unusual volume, and IV levels.
 - Present numerical data in tables when comparing multiple securities.
 - Include data timestamps so users know how fresh the information is.
@@ -39,6 +40,48 @@ When analyzing a stock, follow these steps in order:
 - For portfolio-construction and options-screening requests, provide an educational draft using the workflow tools and include the disclaimer. Do not refuse solely because the user asked for an idea, allocation, or screened setup.
 - Reuse prior tool outputs when they already answer the question. Do not re-fetch the same symbol and parameters unless you need a missing field or fresher timestamp.
 - If one provider is missing data, continue with the remaining tools and clearly label unavailable metrics instead of aborting the entire response.
+
+## When to Ask for Clarification
+Use the ask_user tool BEFORE proceeding when:
+- The request is broad or vague (e.g., "analyze the market" without specifying which asset or sector)
+- Required information is missing: a ticker symbol for asset analysis, a budget for portfolio construction, or a time horizon for recommendations
+- Multiple valid analysis approaches exist and the user has not indicated a preference (e.g., fundamental vs. technical, short-term vs. long-term)
+- Risk tolerance is unclear for portfolio or options recommendations
+
+Do NOT ask clarifying questions when:
+- The request is clear and specific (e.g., "get AAPL quote", "analyze BTC")
+- You can reasonably infer the intent from context or prior conversation
+- A reasonable default exists and can be disclosed in the Assumptions block instead
+- The user explicitly asks you to use your judgment
+
+Keep questions concise and offer specific options when possible. Prefer select-type questions over open-ended text input to minimize user effort.
+
+## After Clarification: Fetch Data Immediately
+CRITICAL: After ask_user answers come back, your NEXT action MUST be tool calls — not a text response. You are a data agent, not a chatbot. Never respond with generic investment categories or tell the user to come back with tickers. YOU pick the relevant assets and indicators based on what you learned, then fetch the data.
+
+Playbooks by scenario (use these as starting points, adapt as needed):
+
+**"Where should I put $X" / general investment advice:**
+1. Fetch get_fear_greed — is the market fearful or greedy right now?
+2. Fetch get_economic_data for key macro indicators (Fed funds rate, CPI, unemployment)
+3. Fetch get_stock_quote for benchmark ETFs relevant to their goal (e.g., SPY, QQQ, VTI for growth; BND, SCHD for income; GLD, BTC for alternatives)
+4. Fetch get_technical_indicators on those ETFs to assess current momentum and overbought/oversold conditions
+5. Synthesize: "Given current market conditions [data], here's how I'd think about allocating $X across [specific assets] and why"
+
+**"Build me a portfolio" / allocation request:**
+1. Pick 5-8 candidate assets matching their stated goal and risk level
+2. Fetch get_stock_quote and get_company_overview for each
+3. Fetch analyze_correlation to check diversification
+4. Present a concrete allocation with percentages, backed by the data you fetched
+
+**"What's happening in the market" / market outlook:**
+1. Fetch get_stock_quote for SPY, QQQ, IWM, DIA (major indices)
+2. Fetch get_fear_greed
+3. Fetch get_economic_data for 2-3 key FRED series
+4. Fetch get_reddit_sentiment for current retail mood
+5. Synthesize a market snapshot with data points
+
+If you are about to write a response that contains zero tool call results, STOP. Go fetch data first.
 
 ## Assumption Disclosure
 Workflow prompts include a pre-rendered "Assumptions" block with correct source attribution (user-specified, saved preference, or default). Start your response with that block exactly as written. Do NOT independently relabel any value's source anywhere in your response. The assumptions block is the single authoritative provenance representation.

--- a/src/tools/interaction/ask-user.ts
+++ b/src/tools/interaction/ask-user.ts
@@ -1,0 +1,112 @@
+import { Type } from "@sinclair/typebox";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+interface AskUserDetails {
+  question: string;
+  questionType: string;
+  answer: string | null;
+  cancelled: boolean;
+}
+
+const AskUserParams = Type.Object({
+  question: Type.String({ description: "The question to ask the user" }),
+  question_type: Type.Union(
+    [Type.Literal("select"), Type.Literal("text"), Type.Literal("confirm")],
+    { description: "Type of answer expected: select (pick from options), text (free input), or confirm (yes/no)" },
+  ),
+  options: Type.Optional(
+    Type.Array(Type.String(), { description: "Choices for select-type questions" }),
+  ),
+  placeholder: Type.Optional(
+    Type.String({ description: "Hint text for text input" }),
+  ),
+  reason: Type.Optional(
+    Type.String({ description: "Brief context for why this clarification is needed" }),
+  ),
+});
+
+function cancelledResult(question: string, questionType: string): {
+  content: { type: "text"; text: string }[];
+  details: AskUserDetails;
+} {
+  return {
+    content: [{ type: "text", text: "User cancelled the selection. Proceed with your best judgment and disclose your assumption." }],
+    details: { question, questionType, answer: null, cancelled: true },
+  };
+}
+
+function answerResult(question: string, questionType: string, answer: string): {
+  content: { type: "text"; text: string }[];
+  details: AskUserDetails;
+} {
+  return {
+    content: [{ type: "text", text: `User answered: ${answer}` }],
+    details: { question, questionType, answer, cancelled: false },
+  };
+}
+
+function noUiResult(question: string, questionType: string): {
+  content: { type: "text"; text: string }[];
+  details: AskUserDetails;
+} {
+  return {
+    content: [{ type: "text", text: "UI not available (non-interactive mode). Proceed with your best judgment and clearly disclose your assumption." }],
+    details: { question, questionType, answer: null, cancelled: true },
+  };
+}
+
+export function registerAskUserTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "ask_user",
+    label: "Ask User",
+    description:
+      "Ask the user a clarification question when their request is ambiguous or missing key details. Use select for multiple-choice, text for free input, or confirm for yes/no.",
+    promptSnippet:
+      "ask_user: Ask the user a clarification question when their request is ambiguous or missing key details",
+    parameters: AskUserParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const { question, question_type: questionType } = params;
+
+      if (!ctx?.hasUI) {
+        return noUiResult(question, questionType);
+      }
+
+      switch (questionType) {
+        case "select": {
+          const options = params.options ?? [];
+          if (options.length === 0) {
+            return {
+              content: [{ type: "text", text: "Error: No options provided for select question. Provide options or use text type instead." }],
+              details: { question, questionType, answer: null, cancelled: true } as AskUserDetails,
+            };
+          }
+          const choice = await ctx.ui.select(question, options);
+          if (choice === undefined) {
+            return cancelledResult(question, questionType);
+          }
+          return answerResult(question, questionType, choice);
+        }
+
+        case "text": {
+          const input = await ctx.ui.input(question, params.placeholder ?? "");
+          if (input === undefined || input.trim() === "") {
+            return cancelledResult(question, questionType);
+          }
+          return answerResult(question, questionType, input.trim());
+        }
+
+        case "confirm": {
+          const confirmed = await ctx.ui.confirm(question, params.reason ?? "");
+          return answerResult(question, questionType, confirmed ? "Yes" : "No");
+        }
+
+        default:
+          return {
+            content: [{ type: "text", text: `Unknown question type: ${questionType}. Use select, text, or confirm.` }],
+            details: { question, questionType, answer: null, cancelled: true } as AskUserDetails,
+          };
+      }
+    },
+  });
+}

--- a/tests/unit/pi/opencandle-extension.test.ts
+++ b/tests/unit/pi/opencandle-extension.test.ts
@@ -84,7 +84,7 @@ describe("opencandle extension", () => {
     const fake = createFakeApi();
     openCandleExtension(fake.api);
 
-    expect(fake.tools).toHaveLength(23);
+    expect(fake.tools).toHaveLength(24);
     expect(fake.commands.has("analyze")).toBe(true);
     expect(fake.commands.has("setup")).toBe(true);
   });

--- a/tests/unit/pi/session.test.ts
+++ b/tests/unit/pi/session.test.ts
@@ -33,7 +33,7 @@ describe("createOpenCandleSession", () => {
     expect(result.session.getActiveToolNames()).not.toContain("bash");
     expect(result.session.getActiveToolNames()).toContain("get_stock_quote");
     expect(result.session.getActiveToolNames()).toContain("manage_watchlist");
-    expect(result.session.getActiveToolNames()).toHaveLength(23);
+    expect(result.session.getActiveToolNames()).toHaveLength(24);
     expect(result.session.getAllTools().some((tool) => tool.name === "read")).toBe(true);
     if (result.modelFallbackMessage) {
       expect(result.modelFallbackMessage).toContain("No models available");

--- a/tests/unit/tools/ask-user.test.ts
+++ b/tests/unit/tools/ask-user.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerAskUserTool } from "../../../src/tools/interaction/ask-user.js";
+
+function createMockCtx(hasUI: boolean) {
+  return {
+    hasUI,
+    ui: {
+      select: vi.fn(),
+      input: vi.fn(),
+      confirm: vi.fn(),
+      notify: vi.fn(),
+    },
+  };
+}
+
+function captureRegisteredTool() {
+  let captured: any = null;
+  const mockPi = {
+    registerTool: (tool: any) => { captured = tool; },
+  } as unknown as ExtensionAPI;
+  registerAskUserTool(mockPi);
+  return captured;
+}
+
+describe("ask_user tool", () => {
+  const tool = captureRegisteredTool();
+
+  it("has correct tool metadata", () => {
+    expect(tool.name).toBe("ask_user");
+    expect(tool.label).toBe("Ask User");
+    expect(tool.description).toBeTruthy();
+    expect(tool.promptSnippet).toContain("ask_user");
+  });
+
+  it("returns no-UI fallback when ctx.hasUI is false", async () => {
+    const ctx = createMockCtx(false);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Which ticker?", question_type: "select", options: ["AAPL", "MSFT"] },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.details.answer).toBeNull();
+    expect(result.content[0].text).toContain("UI not available");
+  });
+
+  it("returns no-UI fallback when ctx is undefined", async () => {
+    const result = await tool.execute(
+      "call-1",
+      { question: "Which ticker?", question_type: "text" },
+      undefined, undefined, undefined,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.content[0].text).toContain("UI not available");
+  });
+
+  it("select — returns chosen option", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.select.mockResolvedValue("Technology");
+    const result = await tool.execute(
+      "call-1",
+      { question: "Which sector?", question_type: "select", options: ["Technology", "Healthcare", "Energy"] },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("Technology");
+    expect(result.content[0].text).toContain("Technology");
+    expect(ctx.ui.select).toHaveBeenCalledWith("Which sector?", ["Technology", "Healthcare", "Energy"]);
+  });
+
+  it("select — returns cancelled when user dismisses", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.select.mockResolvedValue(undefined);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Which sector?", question_type: "select", options: ["Tech", "Health"] },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.details.answer).toBeNull();
+    expect(result.content[0].text).toContain("cancelled");
+  });
+
+  it("select — errors when options array is empty", async () => {
+    const ctx = createMockCtx(true);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Pick one", question_type: "select", options: [] },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.content[0].text).toContain("No options provided");
+  });
+
+  it("text — returns user input", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.input.mockResolvedValue("AAPL");
+    const result = await tool.execute(
+      "call-1",
+      { question: "Enter a ticker symbol", question_type: "text", placeholder: "e.g. AAPL" },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("AAPL");
+    expect(ctx.ui.input).toHaveBeenCalledWith("Enter a ticker symbol", "e.g. AAPL");
+  });
+
+  it("text — returns cancelled when user dismisses", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.input.mockResolvedValue(undefined);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Enter a ticker", question_type: "text" },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.details.answer).toBeNull();
+  });
+
+  it("text — returns cancelled when user submits empty string", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.input.mockResolvedValue("   ");
+    const result = await tool.execute(
+      "call-1",
+      { question: "Enter a ticker", question_type: "text" },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(true);
+    expect(result.details.answer).toBeNull();
+  });
+
+  it("confirm — returns Yes", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.confirm.mockResolvedValue(true);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Include options analysis?", question_type: "confirm", reason: "Options data adds depth" },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("Yes");
+    expect(ctx.ui.confirm).toHaveBeenCalledWith("Include options analysis?", "Options data adds depth");
+  });
+
+  it("confirm — returns No", async () => {
+    const ctx = createMockCtx(true);
+    ctx.ui.confirm.mockResolvedValue(false);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Proceed?", question_type: "confirm" },
+      undefined, undefined, ctx,
+    );
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("No");
+  });
+});


### PR DESCRIPTION
## Summary

The OpenCandle agent previously made assumptions when user requests were vague (e.g., "where should I put 10k today"), often responding with generic investment advice without fetching any live market data. This PR adds a clarification tool and data-first response playbooks so the agent asks targeted questions and then grounds every response in real data.

### Changes

- **New `ask_user` tool** (`src/tools/interaction/ask-user.ts`): Registered directly with Pi (not through the adapter) to access `ExtensionContext.ui` dialogs. Supports three question types:
  - `select` — multiple choice via `ctx.ui.select()`
  - `text` — free input via `ctx.ui.input()`
  - `confirm` — yes/no via `ctx.ui.confirm()`
  - Graceful fallback when UI is unavailable (non-interactive mode)

- **System prompt updates** (`src/system-prompt.ts`):
  - Added `ask_user` to Available Tools
  - New "When to Ask for Clarification" section with explicit do/don't guidance
  - New "After Clarification: Fetch Data Immediately" section with concrete playbooks for common scenarios (investment advice, portfolio building, market outlook)
  - Strengthened core guideline: every substantive response must be backed by tool calls

- **Extension registration** (`src/pi/opencandle-extension.ts`): Single-line addition to register the tool alongside existing OpenCandle tools

- **11 unit tests** (`tests/unit/tools/ask-user.test.ts`): Full coverage of all question types, cancellation, empty options, and no-UI fallback

- **Test count updates**: Bumped tool count assertions in extension and session tests from 23 to 24

### Design decisions

- Tool is registered directly via `pi.registerTool()` (like Pi's own `question.ts` example) rather than through the adapter, since it needs `ExtensionContext` for UI access
- Single tool with `question_type` discriminator rather than separate tools, matching the pattern used by Claude Code, Codex, and Gemini CLI
- Uses Pi's simple `ctx.ui.*` primitives rather than a custom TUI component — sufficient for financial clarification and easy to upgrade later

## Test plan

- [x] All 465 unit tests pass (`npm test`)
- [ ] Manual: run `npm start`, ask "where should I put 10k today" — agent should ask 1-2 clarification questions then fetch market data (fear & greed, macro indicators, ETF quotes) before responding
- [ ] Manual: ask "get AAPL quote" — agent should NOT ask clarification, should fetch data directly
- [ ] Manual: verify non-interactive fallback by checking test coverage of `ctx.hasUI = false` path
