### PR TITLE
feat: add agent test harness with injectable ask_user handler

### DIFF
--- a/.pi/prompts/opsx-apply.md
+++ b/.pi/prompts/opsx-apply.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.pi/prompts/opsx-archive.md
+++ b/.pi/prompts/opsx-archive.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.pi/prompts/opsx-explore.md
+++ b/.pi/prompts/opsx-explore.md
@@ -1,0 +1,170 @@
+---
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.pi/prompts/opsx-propose.md
+++ b/.pi/prompts/opsx-propose.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.pi/skills/openspec-apply-change/SKILL.md
+++ b/.pi/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.pi/skills/openspec-archive-change/SKILL.md
+++ b/.pi/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.pi/skills/openspec-explore/SKILL.md
+++ b/.pi/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.pi/skills/openspec-propose/SKILL.md
+++ b/.pi/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ export const cache = new Cache();
 - Make live API calls in unit tests
 - Draw conclusions until all relevant data is gathered
 
+## TESTING OPENCANDLE AS AN AGENT
+
+Run `npx tsx tests/harness/manual-run.ts <ipc-dir> "<prompt>"` in background. Poll `<ipc-dir>/status` (`running`/`waiting`/`done`). When `waiting`, read `question.json`, write `{"value":"..."}` to `answer.json`, repeat until `done`. Final output in `trace.json`.
+
 ## RUNTIME STATE
 - Pi config: `.pi/` and `~/.pi/agent/` — do not move into OpenCandle storage.
 - OpenCandle user state: `~/.opencandle/` — CLI must not depend on repo-local `.pi/extensions/`.

--- a/docs/eval-framework-plan.md
+++ b/docs/eval-framework-plan.md
@@ -1,0 +1,246 @@
+# OpenCandle Eval Framework Plan
+
+> Context preserved from exploration session (2026-04-03). This document captures the full research and design thinking for the eval framework, to be implemented after the test harness is built.
+
+## Purpose
+
+Deterministic-as-possible regression detection: does a new feature or change make OpenCandle worse as a financial agent? The eval framework consumes structured traces produced by the test harness and scores them against baseline measurements.
+
+---
+
+## Research Summary
+
+### How peer projects handle evals
+
+| Project | Eval Approach | Key Insight |
+|---------|--------------|-------------|
+| **Gemini CLI** | Two-tier: `ALWAYS_PASSES` (every CI) + `USUALLY_PASSES` (nightly, 6 models x 3 attempts) | Acknowledges non-determinism. Graduate evals from USUALLY to ALWAYS as they stabilize. |
+| **Codex CLI** | No evals in open-source repo. Deterministic unit/integration tests with wiremock SSE mocks + VT100 snapshot testing. | Separates "does the code work" (deterministic) from "does the agent behave well" (presumably internal). |
+| **OpenCode** | Almost no tests at all (4 test files, CI doesn't run them). | Not a model to follow. |
+| **Pi Framework** | Fake ExtensionAPI pattern for unit tests, SessionManager.inMemory() for integration. No eval framework. | Good test infrastructure but no quality measurement. |
+
+### Frameworks evaluated
+
+| Framework | Language | Fit for OpenCandle | Notes |
+|-----------|----------|-------------------|-------|
+| **vitest-evals** (Sentry) | TypeScript | Best fit | Adds `describeEval` + `ToolCallScorer` to Vitest. Zero new infrastructure. |
+| **Promptfoo** | TypeScript | Good for LLM-judge | YAML-driven, `llm-rubric` assertions, GitHub Action. Acquired by OpenAI March 2026. |
+| **Evalite** (Matt Pocock) | TypeScript | Possible | Built on Vitest, local web UI. v1 beta. |
+| **Braintrust** | TS + Python | Overkill for now | Platform-oriented. Valuable at scale with production traffic. |
+| **DeepEval** | Python | Poor fit | Python-primary. Wrong language for this project. |
+| **Inspect AI** (UK AISI) | Python | Poor fit | Same — Python-only. |
+| **LangSmith** | TS + Python | Overkill for now | Platform-oriented. Framework-agnostic despite LangChain name. |
+| **RAGAS** | Python | Not applicable | RAG-focused. Faithfulness metric concept is useful but can be custom-built. |
+
+### Making evals deterministic
+
+From Anthropic's engineering guidance and academic research:
+
+1. **Deterministic (code-based) graders first** — exact string match, JSON schema validation, regex, numeric range checks. Fully reproducible.
+2. **LLM judges where necessary** — for open-ended quality assessment.
+   - Low temperature (0.1) for near-deterministic scoring
+   - Categorical integer scales (1-5), not continuous floats
+   - Atomized evaluation — one quality dimension per judge call
+   - Chain-of-thought before scoring
+   - Few-shot examples (2-3 per category) improve accuracy 25-30%
+3. **Average across 3+ runs** to absorb non-deterministic variance.
+4. **Track rolling pass rates** — flag drops > 10% below baseline.
+
+---
+
+## Eval Architecture
+
+### Layer model
+
+```
+Layer 1: Intent Classification (deterministic, every CI)
+  "AAPL stock price" → market intent
+  "What's the P/E ratio of MSFT" → fundamentals intent
+  "Should I buy calls on TSLA" → options intent
+  Scoring: exact match against expected intent categories
+
+Layer 2: Tool Selection Correctness (deterministic, every CI)
+  Given prompt, did the agent call the right tools?
+  Scoring: trajectory matching
+    required_tools ⊆ actual_tools (recall)
+    actual_tools ⊆ allowed_tools (precision)
+    penalize unnecessary tool calls (efficiency)
+
+Layer 3: Tool Argument Correctness (deterministic, every CI)
+  Did the right arguments get passed?
+  "Compare AAPL and MSFT" → symbol args include both
+  Scoring: exact match on key arguments
+
+Layer 4: Data Faithfulness (deterministic, every CI)
+  Every number in the response appears in tool output.
+  No hallucinated metrics, prices, ratios.
+  Scoring:
+    1. Extract all numbers from final text
+    2. Check each against union of all tool results in trace
+    3. Flag any number not grounded in tool output
+  This catches the most dangerous financial agent failure mode.
+
+Layer 5: Risk Disclosure (deterministic, every CI)
+  Response contains disclaimer text (regex)
+  No "guaranteed", "risk-free", "can't lose"
+  For any BUY signal, at least one risk factor mentioned
+  Scoring: regex + keyword search
+
+Layer 6: Analysis Quality (LLM-judge, nightly)
+  Rubric items (each scored binary):
+    a. Data Collection Completeness — references data from multiple tool categories?
+    b. Quantitative Screen Present — explicit PASS/FAIL on screening criteria?
+    c. Risk Check Present — mentions volatility, drawdown, or VaR?
+    d. Reasoning Chain Explicit — "Because [data] + [data], I conclude [thesis]"?
+    e. Actionable Conclusion — clear directional view with conviction level?
+  Scoring: LLM-as-judge, atomized per rubric item, temperature 0.1, few-shot
+
+Layer 7: E2E Workflow (LLM-judge + trajectory, nightly)
+  Full conversation flows including multi-turn interactions
+  Multi-analyst orchestration completeness
+  Scoring: trajectory matching + LLM quality assessment
+```
+
+### Eval case format
+
+```typescript
+interface EvalCase {
+  name: string;
+  tier: "always" | "usually";  // Gemini CLI's model
+  prompt: string;
+  answers?: Record<string, string>;  // scripted answers for ask_user questions
+  assertions: {
+    // Deterministic (Layer 1-5)
+    expectedIntent?: string;
+    requiredTools?: string[];
+    forbiddenTools?: string[];
+    requiredArgs?: Record<string, Record<string, unknown>>;
+    responseContains?: (string | RegExp)[];
+    responseNotContains?: (string | RegExp)[];
+    dataFaithfulness?: boolean;  // enable numeric grounding check
+
+    // LLM-judge (Layer 6-7)
+    rubric?: string[];
+  };
+}
+```
+
+### Scoring and regression detection
+
+```typescript
+interface EvalReport {
+  cases: Array<{
+    name: string;
+    tier: "always" | "usually";
+    score: number;            // 0.0 - 1.0
+    details: Record<string, { passed: boolean; message?: string }>;
+  }>;
+  aggregate: number;           // weighted average
+  baseline: number | null;     // from baseline.json, null if first run
+  delta: number | null;
+  regression: boolean;         // true if delta < -0.05
+  improved: string[];          // cases that got better
+  regressed: string[];         // cases that got worse
+  unchanged: string[];         // cases within noise threshold
+}
+```
+
+### Baseline management
+
+- Stored in `tests/evals/baseline.json`, checked into git
+- Contains per-case scores from last accepted run
+- Updated manually: `npx oc-eval --update-baseline`
+- Before merging a feature branch: run evals, compare against baseline on main
+
+### Recommended starter eval cases (20-25)
+
+Drawing from existing e2e tests + uncovered domains:
+
+**Routing (Layer 1-2):**
+1. Stock quote — "What's AAPL trading at?"
+2. Technical analysis — "Run technicals on SPY"
+3. Backtest — "Backtest SMA crossover on SPY 2 years"
+4. SEC filings — "Show recent SEC filings for Apple"
+5. Correlation — "Correlation between AAPL, MSFT, GOOGL"
+6. Options chain — "Show options chain for TSLA"
+7. Fear & Greed — "What's the Fear and Greed index?"
+8. Macro data — "What's the current GDP growth rate?"
+9. Reddit sentiment — "What's Reddit saying about NVDA?"
+10. DCF valuation — "Run a DCF on AAPL"
+
+**Multi-turn workflows (Layer 2-3, need ask_user harness):**
+11. Portfolio builder (conservative) — "Build me a portfolio with $50k"
+12. Portfolio builder (aggressive) — same prompt, different answers
+13. Options screener — "Find covered call candidates"
+14. Compare assets — "Compare AAPL and MSFT"
+15. Comprehensive analysis — "analyze NVDA"
+
+**Data faithfulness (Layer 4):**
+16. Quote accuracy — verify reported price matches tool output
+17. Ratio accuracy — verify P/E, market cap match fundamentals tool
+18. Backtest metrics — verify return %, drawdown match tool output
+
+**Risk disclosure (Layer 5):**
+19. Bullish recommendation — must include risk factors
+20. High-conviction signal — must include disclaimer
+21. No "guaranteed" language — across various prompts
+
+**Quality (Layer 6, LLM-judge):**
+22. Analysis depth — comprehensive analysis produces multi-dimensional view
+23. Reasoning chain — conclusions cite specific data points
+24. Balanced perspective — both bull and bear cases presented
+
+---
+
+## Implementation plan
+
+### Phase 1: Deterministic evals on existing test infrastructure
+- Install `vitest-evals`
+- Convert existing e2e test cases to eval format
+- Add tool argument and data faithfulness checks
+- Run as part of `npm test` for `always` tier
+
+### Phase 2: Harness-dependent evals
+- After test harness is built, add multi-turn workflow evals
+- Portfolio builder, options screener, compare assets paths
+- These require the ask_user IPC mechanism
+
+### Phase 3: LLM-judge evals
+- Add Promptfoo or custom LLM-judge scorer
+- Define rubrics for analysis quality
+- Run nightly or on-demand, not in CI
+- Track pass rates over time
+
+### Phase 4: Regression workflow
+- Baseline management tooling
+- CI integration for `always` tier
+- PR comment bot showing regression/improvement summary
+- Graduate `usually` evals to `always` as they stabilize
+
+---
+
+## Key design decisions (from exploration)
+
+1. **Live LLM for all evals** — mocked responses only test routing, not synthesis quality. Use live LLM with 3x averaging for the `usually` tier.
+
+2. **vitest-evals as the base** — it's TypeScript-native, Vitest-native (which OpenCandle already uses), and adds eval semantics without new infrastructure.
+
+3. **Promptfoo for LLM-judge** — YAML-driven, supports `llm-rubric`, has GitHub Action. Use for Layer 6-7 only.
+
+4. **Gemini CLI's two-tier model** — `always` (deterministic, every CI) vs `usually` (LLM-dependent, nightly/on-demand). This is the right mental framework for a non-deterministic system.
+
+5. **Data faithfulness is the most valuable deterministic check** — extracting numbers from responses and verifying against tool output catches the most dangerous financial agent failure mode (hallucinated metrics).
+
+6. **Baseline stored in git** — simple, version-controlled, no external dependencies. Updated explicitly, not automatically.
+
+---
+
+## References
+
+- [vitest-evals (Sentry)](https://github.com/getsentry/vitest-evals) — Vitest extension with `describeEval`, `ToolCallScorer`
+- [Promptfoo](https://www.promptfoo.dev/) — YAML-driven eval with `llm-rubric` assertions
+- [Anthropic: Demystifying Evals for AI Agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+- [Gemini CLI evals](https://github.com/google-gemini/gemini-cli/tree/main/evals) — Two-tier eval model with ALWAYS_PASSES/USUALLY_PASSES
+- [FinGAIA Benchmark](https://arxiv.org/html/2507.17186v1) — Financial agent evaluation (407 tasks, 7 sub-domains)
+- [Rulers: Rubric-Anchored Scoring](https://arxiv.org/html/2601.08654) — Making rubric-based evaluation deterministic
+- [ECLIPSE: Hallucination Detection in Finance](https://arxiv.org/abs/2512.03107) — Semantic entropy for financial QA

--- a/openspec/changes/agent-test-harness/design.md
+++ b/openspec/changes/agent-test-harness/design.md
@@ -1,0 +1,261 @@
+# Agent Test Harness — Design
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  CODING AGENT (Claude Code / Codex / Gemini CLI / script)           │
+│                                                                     │
+│  1. bash("npx oc-harness run --prompt '...' --ipc /tmp/t1")         │
+│     └── starts harness in background                                │
+│                                                                     │
+│  2. bash("npx oc-harness wait --ipc /tmp/t1")                       │
+│     └── blocks until question or done                               │
+│     └── exit 100 + question JSON, or exit 0 + trace summary        │
+│                                                                     │
+│  3. bash("npx oc-harness answer --ipc /tmp/t1 --value 'Moderate'")  │
+│     └── sends answer to pending question                            │
+│                                                                     │
+│  4. repeat 2-3 until done                                           │
+│                                                                     │
+│  5. bash("cat /tmp/t1/trace.json")                                  │
+│     └── read complete structured trace                              │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│  OC-HARNESS (long-running Node.js process)                          │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────┐              │
+│  │ createOpenCandleSession({                          │              │
+│  │   sessionManager: SessionManager.inMemory(),       │              │
+│  │   askUserHandler: fileBasedIpcHandler(ipcDir),     │   ← new     │
+│  │ })                                                 │              │
+│  │                                                    │              │
+│  │ session.subscribe() → trace-collector.ts            │              │
+│  │ session.prompt(userPrompt)                          │              │
+│  └───────────────────────────────────────────────────┘              │
+│                                                                     │
+│  IPC directory:                                                     │
+│  /tmp/t1/                                                           │
+│  ├── status        "running" | "waiting" | "done" | "error"        │
+│  ├── question.json  pending question (when status=waiting)          │
+│  ├── answer.json    agent's answer (agent writes, harness reads)    │
+│  ├── events.jsonl   streaming event log (append-only)               │
+│  ├── trace.json     final structured trace (when status=done)       │
+│  └── error.txt      error message (when status=error)               │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Design
+
+### 1. `askUserHandler` injection into `createOpenCandleSession`
+
+Add an optional `askUserHandler` to the session options. When provided, `registerAskUserTool` uses this handler instead of `ctx.ui.*` calls.
+
+```typescript
+// In src/types or wherever session options live
+export type AskUserHandler = (params: {
+  question: string;
+  questionType: "select" | "text" | "confirm";
+  options?: string[];
+  placeholder?: string;
+  reason?: string;
+}) => Promise<{ answer: string | null; cancelled: boolean }>;
+
+// In createOpenCandleSession options
+interface OpenCandleSessionOptions {
+  // ... existing options ...
+  askUserHandler?: AskUserHandler;
+}
+```
+
+The `ask-user.ts` tool checks for the handler:
+
+```typescript
+async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+  const { question, question_type: questionType } = params;
+
+  // Priority: injected handler > UI > no-UI fallback
+  if (askUserHandler) {
+    const result = await askUserHandler({ question, questionType, ...params });
+    if (result.cancelled) return cancelledResult(question, questionType);
+    return answerResult(question, questionType, result.answer!);
+  }
+
+  if (!ctx?.hasUI) {
+    return noUiResult(question, questionType);
+  }
+
+  // ... existing ctx.ui.* logic ...
+}
+```
+
+The handler must be accessible to the tool. Two options:
+- **Closure**: pass it through the extension factory
+- **Module-level setter**: `setAskUserHandler(handler)` called before session starts
+
+Closure via extension factory is cleaner — the handler is passed through `createOpenCandleSession` → `openCandleExtension` → `registerAskUserTool`.
+
+### 2. Trace collector
+
+Subscribes to `session.subscribe()` and builds an `AgentTrace`:
+
+```typescript
+export function createTraceCollector(session: AgentSession): {
+  getTrace(): AgentTrace;
+  appendToFile(path: string): void;  // for events.jsonl
+} {
+  const trace: AgentTrace = { prompt: "", turns: [], interactions: [], ... };
+  let currentTurn: TurnTrace = { toolCalls: [], text: "" };
+
+  session.subscribe((event) => {
+    switch (event.type) {
+      case "tool_execution_start":
+        // Start tracking a tool call: name, args, timestamp
+        break;
+      case "tool_execution_end":
+        // Complete tool call: result, isError, duration
+        break;
+      case "message_update":
+        // Accumulate text deltas
+        break;
+      case "turn_end":
+        // Push currentTurn, start new one
+        break;
+      case "agent_end":
+        // Finalize trace
+        break;
+    }
+  });
+
+  return { getTrace, appendToFile };
+}
+```
+
+### 3. File-based IPC
+
+```typescript
+export class IpcChannel {
+  constructor(private dir: string) {}
+
+  // Harness side
+  async writeQuestion(q: Question): Promise<void>;      // write question.json + set status=waiting
+  async pollForAnswer(timeoutMs?: number): Promise<Answer>; // watch/poll answer.json
+  async writeTrace(trace: AgentTrace): Promise<void>;    // write trace.json + set status=done
+  async writeError(message: string): Promise<void>;      // write error.txt + set status=error
+  setStatus(status: string): void;                       // write status file
+
+  // CLI side (static helpers)
+  static readStatus(dir: string): string;
+  static readQuestion(dir: string): Question | null;
+  static writeAnswer(dir: string, value: string): void;
+  static readTrace(dir: string): AgentTrace | null;
+}
+```
+
+`pollForAnswer` uses `fs.watch()` with a fallback to 100ms polling (fs.watch is unreliable on some systems). Deletes both `question.json` and `answer.json` after reading the answer.
+
+### 4. CLI commands
+
+Single entry point: `tests/harness/cli.ts`
+
+```
+oc-harness run --prompt <text> --ipc <dir> [--model <id>] [--timeout <ms>]
+  Creates IPC dir, starts session, sends prompt, runs until completion.
+  Writes events.jsonl continuously, trace.json at end.
+  When ask_user fires, pauses and writes question.json.
+
+oc-harness wait --ipc <dir> [--timeout <ms>]
+  Watches the IPC dir. Blocks until:
+    status=waiting → print question JSON to stdout, exit 100
+    status=done    → print trace summary to stdout, exit 0
+    status=error   → print error to stderr, exit 1
+    timeout        → exit 2
+
+oc-harness answer --ipc <dir> --value <text>
+  Writes answer.json. Exits immediately.
+
+oc-harness trace --ipc <dir>
+  Reads and prints trace.json to stdout.
+```
+
+### 5. Harness extension factory
+
+```typescript
+export function createHarnessExtension(
+  ipcDir: string,
+  traceCollector: TraceCollector,
+): (pi: ExtensionAPI) => void {
+  return (pi) => {
+    // No additional tool registration needed — ask_user handler
+    // is injected via createOpenCandleSession's askUserHandler option.
+    // The extension just wires up trace collection.
+  };
+}
+```
+
+Actually, the harness doesn't need its own extension. The `askUserHandler` injection and `session.subscribe()` trace collector are both set up outside the extension system. The harness is just:
+
+1. `createOpenCandleSession({ askUserHandler: ipcHandler })`
+2. `createTraceCollector(session)`
+3. `session.prompt(userPrompt)`
+
+## Data Flow
+
+```
+Agent                    Harness                   OpenCandle Session
+  │                        │                              │
+  ├─ run --prompt "..."    │                              │
+  │                        ├─ createSession()              │
+  │                        ├─ subscribe(traceCollector)    │
+  │                        ├─ session.prompt()             │
+  │                        │                              ├─ classifyIntent()
+  │                        │                              ├─ route to workflow
+  │                        │                              ├─ LLM decides to call tools
+  │                        │                              │
+  │                        │    tool_execution_start ◄────┤ get_stock_quote({symbol:"AAPL"})
+  │                        │    → append events.jsonl      │
+  │                        │    tool_execution_end   ◄────┤ {price: 248.5, ...}
+  │                        │    → append events.jsonl      │
+  │                        │                              │
+  │                        │                              ├─ LLM decides to call ask_user
+  │                        │    askUserHandler fires  ◄───┤ ask_user({question: "Risk?"})
+  │                        ├─ write question.json          │
+  │                        ├─ set status=waiting           │
+  │                        │    (handler blocks here)      │
+  │                        │                              │
+  ├─ wait ─────────────────┤                              │
+  │  ◄─ exit 100 + question│                              │
+  │                        │                              │
+  ├─ answer --value "Mod"  │                              │
+  │                        ├─ read answer.json             │
+  │                        │    handler returns ──────────►│ "User answered: Moderate"
+  │                        │                              ├─ LLM continues...
+  │                        │                              │
+  │                        │    agent_end          ◄──────┤
+  │                        ├─ write trace.json             │
+  │                        ├─ set status=done              │
+  │                        │                              │
+  ├─ wait ─────────────────┤                              │
+  │  ◄─ exit 0 + summary   │                              │
+  │                        │                              │
+  ├─ cat trace.json        │                              │
+  │  ◄─ full trace          │                              │
+  │                        │                              │
+```
+
+## Error Handling
+
+- **Harness crashes**: `status` file remains at `running` or `waiting`. The `wait` command detects this by checking if the harness process is still alive (PID file in IPC dir). If dead, it reads any partial trace from events.jsonl and exits with code 1.
+- **LLM errors**: Caught by Pi's retry mechanism. If all retries fail, the harness writes `error.txt` and sets `status=error`.
+- **Timeout on answer**: The `pollForAnswer` has a configurable timeout (default 5 minutes). If no answer arrives, the handler returns `cancelled: true` and the agent proceeds with best judgment (existing behavior).
+- **IPC dir doesn't exist**: `wait` and `answer` commands exit with helpful error.
+
+## Testing the Harness Itself
+
+- Unit test the trace collector with mock session events
+- Unit test IPC read/write/poll
+- Integration test: start harness, wait, answer, verify trace
+- The harness should work with existing e2e test prompts (no ask_user needed for simple queries)

--- a/openspec/changes/agent-test-harness/proposal.md
+++ b/openspec/changes/agent-test-harness/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+No coding agent (Claude Code, Codex, Gemini CLI) can currently test OpenCandle end-to-end as a real user would. The existing e2e tests (`cli.test.ts`, `audit-fixes.test.ts`) capture tool names and text, but miss tool arguments, tool results, and — critically — cannot participate in multi-turn interactions when OpenCandle asks follow-up questions via `ask_user`. This means:
+
+- Agents can't test workflows that require clarification (portfolio builder, options screener)
+- Agents can't verify that tool arguments are correct (e.g., did it pass "AAPL" not "Apple"?)
+- Agents can't check data faithfulness (did the response numbers match what tools returned?)
+- No structured trace artifact exists for programmatic analysis or regression comparison
+
+## What Changes
+
+Build a **test harness** that any coding agent can drive via CLI commands, producing structured traces of every tool call, tool result, LLM response, and user interaction.
+
+### Core: File-based IPC harness
+
+A long-running Node process that creates an OpenCandle session (SDK mode, in-memory), sends a prompt, and communicates with the driving agent through files in an IPC directory:
+
+- **`question.json`** — written by harness when `ask_user` fires, contains the question, options, and context
+- **`answer.json`** — written by the driving agent with the selected answer
+- **`events.jsonl`** — append-only log of all session events (tool calls, results, text deltas)
+- **`trace.json`** — final structured trace written on completion
+- **`status`** — current state: `running`, `waiting`, `done`, `error`
+
+### CLI interface
+
+```
+oc-harness run    --prompt "..." --ipc /tmp/dir    # Start a test run (background)
+oc-harness wait   --ipc /tmp/dir                   # Block until question or done
+oc-harness answer --ipc /tmp/dir --value "..."      # Send answer to pending question
+oc-harness trace  --ipc /tmp/dir                   # Read final trace
+```
+
+### ask_user injection
+
+Add an optional `askUserHandler` to `createOpenCandleSession()`. When provided, the `ask_user` tool calls this handler instead of `ctx.ui.*` methods. The harness provides a handler that writes `question.json` and polls for `answer.json`.
+
+### Structured trace
+
+```typescript
+interface AgentTrace {
+  prompt: string;
+  turns: Array<{
+    toolCalls: Array<{
+      name: string;
+      args: Record<string, unknown>;
+      result: unknown;
+      isError: boolean;
+      durationMs: number;
+    }>;
+    text: string;
+  }>;
+  interactions: Array<{
+    question: string;
+    method: "select" | "text" | "confirm";
+    options?: string[];
+    answer: string | null;
+  }>;
+  finalText: string;
+  toolSequence: string[];
+  workflowType?: string;
+  durationMs: number;
+}
+```
+
+## Capabilities
+
+### New Capabilities
+- `test-harness`: File-based IPC harness enabling any coding agent to drive OpenCandle as a simulated user, with structured trace output
+
+### Modified Capabilities
+- `ask-user` tool gains an injectable handler for non-UI contexts, replacing the current `ctx.hasUI` / `noUiResult` binary
+
+## Non-goals
+
+- TUI rendering tests (not needed — agents don't evaluate visual output)
+- Eval framework (separate change, planned — see `docs/eval-framework-plan.md`)
+- Pre-scripted answer mode (can be built on top of the IPC mechanism later)
+- RPC-mode harness (SDK in-process approach is simpler and sufficient)

--- a/openspec/changes/agent-test-harness/tasks.md
+++ b/openspec/changes/agent-test-harness/tasks.md
@@ -1,0 +1,59 @@
+## Tasks
+
+### 1. Add `askUserHandler` injection to session and ask-user tool
+- [x] Add `AskUserHandler` type to `src/types/` or alongside ask-user tool
+- [x] Add `askUserHandler` option to `createOpenCandleSession()` in `src/index.ts`
+- [x] Thread handler through extension factory → `registerAskUserTool`
+- [x] Modify `ask-user.ts` execute: check for injected handler before `ctx.hasUI`
+- [x] Unit test: handler receives correct params, return value flows back to tool result
+- [x] Verify existing tests still pass (handler is optional, no behavior change when absent)
+
+### 2. Build trace collector
+- [ ] Define `AgentTrace`, `TurnTrace`, `ToolCallTrace`, `InteractionTrace` types in `tests/harness/types.ts`
+- [ ] Implement `createTraceCollector(session)` in `tests/harness/trace-collector.ts`
+- [ ] Handle events: `tool_execution_start` (capture name, args, timestamp), `tool_execution_end` (capture result, isError, duration), `message_update` (text deltas), `turn_end` (finalize turn), `agent_end` (finalize trace)
+- [ ] Add `appendToJsonl(filePath)` for streaming event log
+- [ ] Build `toolSequence` flat array from turns
+- [ ] Unit test with synthetic session events
+
+### 3. Build file-based IPC
+- [ ] Implement `IpcChannel` class in `tests/harness/ipc.ts`
+- [ ] `writeQuestion()` — atomic write of question.json + status=waiting
+- [ ] `pollForAnswer()` — fs.watch with fallback polling, configurable timeout, cleans up files after read
+- [ ] `writeTrace()` — write trace.json + status=done
+- [ ] `writeError()` — write error.txt + status=error
+- [ ] `setStatus()` — atomic status file write
+- [ ] Static read helpers: `readStatus`, `readQuestion`, `writeAnswer`, `readTrace`
+- [ ] Write PID file on start for liveness detection
+- [ ] Unit test the full cycle: write question → write answer → read answer
+
+### 4. Build `askUserHandler` for IPC
+- [ ] Implement file-based handler: receives question params → writes question.json via IPC → polls for answer.json → returns result
+- [ ] Track interactions in trace collector (question + answer pairs)
+- [ ] Handle timeout → return cancelled
+- [ ] Integration test: handler writes question, external process writes answer, handler returns it
+
+### 5. Build CLI entry point
+- [ ] Create `tests/harness/cli.ts` with subcommands: `run`, `wait`, `answer`, `trace`
+- [ ] `run`: parse args, create IPC dir, create session with askUserHandler, start trace collector, prompt session, write trace on completion
+- [ ] `wait`: watch IPC dir for status changes, print question (exit 100) or trace summary (exit 0) or error (exit 1), support --timeout
+- [ ] `answer`: write answer.json to IPC dir, exit immediately
+- [ ] `trace`: read and print trace.json
+- [ ] Add `oc-harness` bin entry to package.json (or document npx usage)
+- [ ] Handle graceful shutdown (SIGINT/SIGTERM → cancel workflow, write partial trace)
+
+### 6. Integration test the full loop
+- [ ] Test: simple prompt (no ask_user) → harness runs to completion → trace.json has tool calls and text
+- [ ] Test: prompt that triggers ask_user → harness pauses → answer provided via file → harness continues → trace includes interaction
+- [ ] Test: multi-step workflow (portfolio builder) → multiple question/answer rounds → complete trace
+- [ ] Test: timeout on answer → handler returns cancelled → agent proceeds with best judgment
+- [ ] Test: verify events.jsonl is written continuously during the run
+
+### 7. Document harness usage for coding agents
+- [ ] Add `tests/harness/README.md` with:
+  - Quick start example for Claude Code
+  - Quick start example for Codex CLI
+  - CLI reference
+  - Trace format reference
+  - Troubleshooting (stale IPC dirs, process didn't exit, etc.)
+- [ ] Add AGENTS.md entry in tests/ pointing to harness docs

--- a/src/pi/opencandle-extension.ts
+++ b/src/pi/opencandle-extension.ts
@@ -14,15 +14,20 @@ import {
 import { getOpenCandleToolDefinitions } from "./tool-adapter.js";
 import { registerAskUserTool } from "../tools/interaction/ask-user.js";
 import { SessionCoordinator } from "../runtime/session-coordinator.js";
+import type { AskUserHandler } from "../types/index.js";
 
-export default function openCandleExtension(pi: ExtensionAPI): void {
+export interface OpenCandleExtensionOptions {
+  askUserHandler?: AskUserHandler;
+}
+
+export default function openCandleExtension(pi: ExtensionAPI, options?: OpenCandleExtensionOptions): void {
   const coordinator = new SessionCoordinator();
 
   // Register tools
   for (const tool of getOpenCandleToolDefinitions()) {
     pi.registerTool(tool);
   }
-  registerAskUserTool(pi);
+  registerAskUserTool(pi, options?.askUserHandler);
 
   // /analyze command
   pi.registerCommand("analyze", {

--- a/src/pi/session.ts
+++ b/src/pi/session.ts
@@ -9,6 +9,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { loadEnv } from "../config.js";
 import openCandleExtension from "./opencandle-extension.js";
+import type { AskUserHandler } from "../types/index.js";
 
 export interface CreateOpenCandleSessionOptions {
   cwd?: string;
@@ -17,6 +18,7 @@ export interface CreateOpenCandleSessionOptions {
   settingsManager?: SettingsManager;
   sessionManager?: SessionManager;
   useInlineExtension?: boolean;
+  askUserHandler?: AskUserHandler;
 }
 
 export async function createOpenCandleSession(
@@ -30,7 +32,7 @@ export async function createOpenCandleSession(
     ? new DefaultResourceLoader({
         cwd,
         settingsManager: options.settingsManager,
-        extensionFactories: [openCandleExtension],
+        extensionFactories: [(pi) => openCandleExtension(pi, { askUserHandler: options.askUserHandler })],
       })
     : undefined;
 

--- a/src/tools/interaction/ask-user.ts
+++ b/src/tools/interaction/ask-user.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { AskUserHandler } from "../../types/index.js";
 
 interface AskUserDetails {
   question: string;
@@ -55,7 +56,7 @@ function noUiResult(question: string, questionType: string): {
   };
 }
 
-export function registerAskUserTool(pi: ExtensionAPI): void {
+export function registerAskUserTool(pi: ExtensionAPI, askUserHandler?: AskUserHandler): void {
   pi.registerTool({
     name: "ask_user",
     label: "Ask User",
@@ -67,6 +68,19 @@ export function registerAskUserTool(pi: ExtensionAPI): void {
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const { question, question_type: questionType } = params;
+
+      // Priority: injected handler > UI > no-UI fallback
+      if (askUserHandler) {
+        const result = await askUserHandler({
+          question,
+          questionType,
+          options: params.options,
+          placeholder: params.placeholder,
+          reason: params.reason,
+        });
+        if (result.cancelled) return cancelledResult(question, questionType);
+        return answerResult(question, questionType, result.answer!);
+      }
 
       if (!ctx?.hasUI) {
         return noUiResult(question, questionType);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,16 @@ export { FRED_SERIES } from "./macro.js";
 export type { Greeks, OptionContract, OptionsChain } from "./options.js";
 export type { Position, PortfolioSummary, RiskMetrics, TechnicalIndicators } from "./portfolio.js";
 export type { FearGreedData, RedditSentimentResult } from "./sentiment.js";
+
+/**
+ * Handler for `ask_user` tool invocations in non-UI contexts (e.g. test harness).
+ * When provided to `createOpenCandleSession`, the ask-user tool calls this handler
+ * instead of `ctx.ui.*` methods.
+ */
+export type AskUserHandler = (params: {
+  question: string;
+  questionType: "select" | "text" | "confirm";
+  options?: string[];
+  placeholder?: string;
+  reason?: string;
+}) => Promise<{ answer: string | null; cancelled: boolean }>;

--- a/tests/harness/manual-run.ts
+++ b/tests/harness/manual-run.ts
@@ -1,0 +1,100 @@
+/**
+ * Manual test runner — uses askUserHandler injection with file-based IPC.
+ * Writes questions to ipc/question.json, polls for ipc/answer.json.
+ * An external agent reads questions, writes answers, and drives the session.
+ */
+import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import { SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createOpenCandleSession } from "../../src/index.js";
+import { cache } from "../../src/infra/cache.js";
+import type { AskUserHandler } from "../../src/types/index.js";
+
+const ipcDir = process.argv[2] || join(tmpdir(), "oc-ipc-" + Date.now());
+const prompt = process.argv[3] || "Help me build a diversified stock portfolio for long-term growth";
+
+mkdirSync(ipcDir, { recursive: true });
+console.log(`IPC dir: ${ipcDir}`);
+console.log(`Prompt: ${prompt}`);
+
+function setStatus(status: string) {
+  writeFileSync(join(ipcDir, "status"), status, "utf-8");
+}
+
+const askUserHandler: AskUserHandler = async (params) => {
+  // Write question
+  writeFileSync(join(ipcDir, "question.json"), JSON.stringify(params, null, 2), "utf-8");
+  setStatus("waiting");
+
+  // Poll for answer
+  const answerPath = join(ipcDir, "answer.json");
+  const start = Date.now();
+  const timeout = 5 * 60 * 1000; // 5 min
+
+  while (!existsSync(answerPath)) {
+    if (Date.now() - start > timeout) {
+      setStatus("running");
+      return { answer: null, cancelled: true };
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  const raw = readFileSync(answerPath, "utf-8");
+  const { value } = JSON.parse(raw) as { value: string };
+
+  // Clean up for next round
+  rmSync(answerPath, { force: true });
+  rmSync(join(ipcDir, "question.json"), { force: true });
+  setStatus("running");
+
+  return { answer: value, cancelled: false };
+};
+
+const openCandleHome = mkdtempSync(join(tmpdir(), "oc-manual-test-"));
+process.env.OPENCANDLE_HOME = openCandleHome;
+
+const { session } = await createOpenCandleSession({
+  cwd: process.cwd(),
+  sessionManager: SessionManager.inMemory(),
+  settingsManager: SettingsManager.inMemory({
+    defaultProvider: "google",
+    defaultModel: "gemini-2.5-flash",
+  }),
+  useInlineExtension: true,
+  askUserHandler,
+});
+
+cache.clear();
+setStatus("running");
+
+let text = "";
+const toolCalls: string[] = [];
+const toolResults: Record<string, string>[] = [];
+
+await new Promise<void>((resolve) => {
+  const unsub = session.subscribe((event: AgentSessionEvent) => {
+    if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+      text += event.assistantMessageEvent.delta;
+    }
+    if (event.type === "tool_execution_start") {
+      toolCalls.push(event.toolName);
+    }
+    if (event.type === "agent_end") {
+      unsub();
+      resolve();
+    }
+  });
+  void session.prompt(prompt);
+});
+
+// Write final trace
+const trace = { prompt, toolCalls, text };
+writeFileSync(join(ipcDir, "trace.json"), JSON.stringify(trace, null, 2), "utf-8");
+setStatus("done");
+console.log("Session complete. Trace written.");
+
+rmSync(openCandleHome, { recursive: true, force: true });
+session.dispose();
+process.exit(0);

--- a/tests/unit/tools/ask-user.test.ts
+++ b/tests/unit/tools/ask-user.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerAskUserTool } from "../../../src/tools/interaction/ask-user.js";
+import type { AskUserHandler } from "../../../src/types/index.js";
 
 function createMockCtx(hasUI: boolean) {
   return {
@@ -14,12 +15,12 @@ function createMockCtx(hasUI: boolean) {
   };
 }
 
-function captureRegisteredTool() {
+function captureRegisteredTool(askUserHandler?: AskUserHandler) {
   let captured: any = null;
   const mockPi = {
     registerTool: (tool: any) => { captured = tool; },
   } as unknown as ExtensionAPI;
-  registerAskUserTool(mockPi);
+  registerAskUserTool(mockPi, askUserHandler);
   return captured;
 }
 
@@ -153,5 +154,94 @@ describe("ask_user tool", () => {
     );
     expect(result.details.cancelled).toBe(false);
     expect(result.details.answer).toBe("No");
+  });
+});
+
+describe("ask_user tool with injected handler", () => {
+  it("handler receives correct params and answer flows back", async () => {
+    const handler = vi.fn<Parameters<AskUserHandler>, ReturnType<AskUserHandler>>()
+      .mockResolvedValue({ answer: "Technology", cancelled: false });
+
+    const tool = captureRegisteredTool(handler);
+    const ctx = createMockCtx(true);
+
+    const result = await tool.execute(
+      "call-1",
+      {
+        question: "Which sector?",
+        question_type: "select",
+        options: ["Technology", "Healthcare"],
+        placeholder: "pick one",
+        reason: "need to narrow search",
+      },
+      undefined, undefined, ctx,
+    );
+
+    // Handler receives all params correctly
+    expect(handler).toHaveBeenCalledWith({
+      question: "Which sector?",
+      questionType: "select",
+      options: ["Technology", "Healthcare"],
+      placeholder: "pick one",
+      reason: "need to narrow search",
+    });
+
+    // Answer flows back to tool result
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("Technology");
+    expect(result.content[0].text).toContain("Technology");
+
+    // UI methods are NOT called — handler takes priority
+    expect(ctx.ui.select).not.toHaveBeenCalled();
+  });
+
+  it("handler cancelled result returns cancelled tool result", async () => {
+    const handler = vi.fn<Parameters<AskUserHandler>, ReturnType<AskUserHandler>>()
+      .mockResolvedValue({ answer: null, cancelled: true });
+
+    const tool = captureRegisteredTool(handler);
+    const result = await tool.execute(
+      "call-1",
+      { question: "Risk tolerance?", question_type: "text" },
+      undefined, undefined, undefined,
+    );
+
+    expect(result.details.cancelled).toBe(true);
+    expect(result.details.answer).toBeNull();
+    expect(result.content[0].text).toContain("cancelled");
+  });
+
+  it("handler takes priority over ctx.hasUI", async () => {
+    const handler = vi.fn<Parameters<AskUserHandler>, ReturnType<AskUserHandler>>()
+      .mockResolvedValue({ answer: "Yes", cancelled: false });
+
+    const tool = captureRegisteredTool(handler);
+    const ctx = createMockCtx(true); // UI available, but handler should still win
+
+    const result = await tool.execute(
+      "call-1",
+      { question: "Proceed?", question_type: "confirm" },
+      undefined, undefined, ctx,
+    );
+
+    expect(handler).toHaveBeenCalled();
+    expect(result.details.answer).toBe("Yes");
+    expect(ctx.ui.confirm).not.toHaveBeenCalled();
+  });
+
+  it("handler takes priority over no-UI fallback", async () => {
+    const handler = vi.fn<Parameters<AskUserHandler>, ReturnType<AskUserHandler>>()
+      .mockResolvedValue({ answer: "AAPL", cancelled: false });
+
+    const tool = captureRegisteredTool(handler);
+    // No ctx at all — without handler, would return no-UI fallback
+    const result = await tool.execute(
+      "call-1",
+      { question: "Enter ticker", question_type: "text" },
+      undefined, undefined, undefined,
+    );
+
+    expect(result.details.cancelled).toBe(false);
+    expect(result.details.answer).toBe("AAPL");
   });
 });


### PR DESCRIPTION
## Summary

OpenCandle lacked a way to test the full agent loop end-to-end without a live UI. This PR adds:

- **`AskUserHandler` type** — a callback interface that the `ask_user` tool invokes instead of `ctx.ui.*` when provided. This enables headless sessions where an external process (test harness, CI runner, another agent) can answer clarification questions programmatically.

- **Injectable handler plumbing** — `createOpenCandleSession` and the Pi extension now accept an optional `askUserHandler`, threaded through to the tool registration.

- **File-based IPC test harness** (`tests/harness/manual-run.ts`) — launches a real OpenCandle session, writes questions to `question.json`, polls for `answer.json`, and produces a `trace.json` with the full tool call sequence and final text. Documented in `AGENTS.md`.

- **4 new ask_user tests** — handler receives correct params, cancelled results propagate, handler takes priority over both UI and no-UI fallbacks.

- **OpenSpec artifacts** — design doc, proposal, and task tracking for the agent test harness change.

- **Eval framework plan** — initial design doc for a broader evaluation framework.

### Why

Without this, the only way to test OpenCandle's interactive flows (where it asks the user for clarification) was to manually run the Pi shell. The harness enables another agent or script to drive the full session, which is essential for regression testing and evaluating agent behavior.

### What changed

| File | Change |
|------|--------|
| `src/types/index.ts` | New `AskUserHandler` type |
| `src/tools/interaction/ask-user.ts` | Injected handler takes priority over UI/no-UI |
| `src/pi/opencandle-extension.ts` | Accepts and forwards `askUserHandler` option |
| `src/pi/session.ts` | `createOpenCandleSession` accepts `askUserHandler` |
| `tests/harness/manual-run.ts` | File-based IPC harness |
| `tests/unit/tools/ask-user.test.ts` | 4 new handler tests |
| `AGENTS.md` | Documents harness usage |

## Test plan

- [x] All 569 unit tests pass
- [x] Manual end-to-end test: launched harness with "What are the top performing tech stocks this year?", answered clarification, observed 4 `get_stock_history` tool calls and final response
- [ ] Verify harness works in CI (future: automated eval runner)
