### PR TITLE
auto-rebuild native binding on startup

### DIFF
--- a/scripts/check-node-version-lib.mjs
+++ b/scripts/check-node-version-lib.mjs
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+
+const supportedNodeRange = "20.19+, 22.12+, or 24.x-26.x";
+
+export function isSupportedNodeVersion(version) {
+  const [majorRaw, minorRaw] = version.split(".");
+  const major = Number(majorRaw);
+  const minor = Number(minorRaw);
+
+  if (major === 20) return minor >= 19;
+  if (major === 22) return minor >= 12;
+  return major >= 24 && major < 27;
+}
+
+export function getUnsupportedNodeVersionMessage(version = process.versions.node) {
+  if (isSupportedNodeVersion(version)) return null;
+
+  return `OpenCandle supports Node ${supportedNodeRange}. Current Node is ${version}.\n` +
+    "Use a supported Node version; the repo default is Node 22.22.0 via `nvm use`.\n" +
+    "After switching Node versions, reinstall dependencies under the active Node with `npm install` or rebuild native modules with `npm rebuild better-sqlite3`.";
+}
+
+export function getNativeDependencyErrorMessage(error, dependencyName, nodeVersion = process.versions.node) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    !message.includes("NODE_MODULE_VERSION") &&
+    !message.includes("was compiled against a different Node.js version")
+  ) {
+    return null;
+  }
+
+  return `${dependencyName} native binding was built for a different Node ABI than the active Node ${nodeVersion}.\n` +
+    `Run \`npm rebuild ${dependencyName}\` or reinstall dependencies under the active Node with \`npm install\`.`;
+}
+
+export async function rebuildNativeDependency(dependencyName) {
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(npmCommand, ["rebuild", dependencyName], {
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`npm rebuild ${dependencyName} failed with exit code ${code}.`));
+    });
+  });
+}
+
+export async function ensureNativeDependency({ dependencyName, load, rebuild = rebuildNativeDependency, log = console.error }) {
+  try {
+    await load();
+    return;
+  } catch (error) {
+    const message = getNativeDependencyErrorMessage(error, dependencyName);
+    if (!message) throw error;
+
+    log(`${message}\nAttempting \`npm rebuild ${dependencyName}\` before continuing...`);
+  }
+
+  await rebuild(dependencyName);
+
+  try {
+    await load();
+  } catch (error) {
+    const message = getNativeDependencyErrorMessage(error, dependencyName);
+    if (!message) throw error;
+
+    throw new Error(
+      `${message}\nAutomatic rebuild did not repair the native binding. Run \`npm install\` under Node ${process.versions.node} and retry.`,
+    );
+  }
+}

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,47 +1,23 @@
-const currentNodeVersion = process.versions.node;
-const supportedNodeRange = "20.19+, 22.12+, or 24.x-26.x";
+import { ensureNativeDependency, getUnsupportedNodeVersionMessage } from "./check-node-version-lib.mjs";
 
-function isSupportedNodeVersion(version) {
-  const [majorRaw, minorRaw] = version.split(".");
-  const major = Number(majorRaw);
-  const minor = Number(minorRaw);
-
-  if (major === 20) return minor >= 19;
-  if (major === 22) return minor >= 12;
-  return major >= 24 && major < 27;
-}
-
-if (!isSupportedNodeVersion(currentNodeVersion)) {
-  console.error(
-    `OpenCandle supports Node ${supportedNodeRange}. Current Node is ${currentNodeVersion}.\n` +
-      "Use a supported Node version; the repo default is Node 22.22.0 via `nvm use`.\n" +
-      "After switching Node versions, reinstall dependencies under the active Node with `npm install` or rebuild native modules with `npm rebuild better-sqlite3`.",
-  );
+const nodeVersionMessage = getUnsupportedNodeVersionMessage();
+if (nodeVersionMessage) {
+  console.error(nodeVersionMessage);
   process.exit(1);
 }
 
-function getNativeDependencyErrorMessage(error, dependencyName) {
-  const message = error instanceof Error ? error.message : String(error);
-  if (
-    !message.includes("NODE_MODULE_VERSION") &&
-    !message.includes("was compiled against a different Node.js version")
-  ) {
-    return null;
-  }
-
-  return `${dependencyName} native binding was built for a different Node ABI than the active Node ${process.versions.node}.\n` +
-    `Run \`npm rebuild ${dependencyName}\` or reinstall dependencies under the active Node with \`npm install\`.`;
-}
-
-try {
+async function loadBetterSqlite3() {
   const { default: Database } = await import("better-sqlite3");
   const db = new Database(":memory:");
   db.close();
+}
+
+try {
+  await ensureNativeDependency({
+    dependencyName: "better-sqlite3",
+    load: loadBetterSqlite3,
+  });
 } catch (error) {
-  const message = getNativeDependencyErrorMessage(error, "better-sqlite3");
-  if (message) {
-    console.error(message);
-    process.exit(1);
-  }
-  throw error;
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
 }

--- a/tests/unit/scripts/check-node-version-lib.test.ts
+++ b/tests/unit/scripts/check-node-version-lib.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureNativeDependency } from "../../../scripts/check-node-version-lib.mjs";
+
+describe("check-node-version native dependency repair", () => {
+  it("rebuilds once and retries when a native binding has a stale Node ABI", async () => {
+    const load = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(
+        new Error(
+          "was compiled against a different Node.js version using NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 141.",
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    const rebuild = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    await ensureNativeDependency({
+      dependencyName: "better-sqlite3",
+      load,
+      rebuild,
+      log: vi.fn(),
+    });
+
+    expect(rebuild).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Issue

`npm run start` currently stops before launching OpenCandle when `better-sqlite3` was installed or built under a different Node ABI than the active Node runtime. The guard reports the right manual command, but the user still has to run `npm rebuild better-sqlite3` and then retry startup.

## Cause and user impact

OpenCandle uses `better-sqlite3`, which ships a native binding tied to the Node ABI it was built against. Switching Node versions can leave the local binding stale even when the selected Node version is supported by the project. Because `prestart` only checked and failed, a routine `npm run start` could break after a Node change instead of repairing the local dependency automatically.

## Fix

This change extracts the startup guard into a testable helper and teaches it to handle the known stale-native-binding case. When loading `better-sqlite3` fails with a Node ABI mismatch, the guard runs `npm rebuild better-sqlite3` once, then retries the in-memory SQLite load. Unsupported Node versions still fail fast, and non-ABI errors are still surfaced unchanged.

## Validation

- `npx vitest run tests/unit/scripts/check-node-version-lib.test.ts`
- `npm run check:node`
- `npm test` (131 files, 1419 tests)
- `npm run start -- list`
- `npm run build`
- `git diff --check`
