### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.8.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.0] - 2026-06-22
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Financial trading & investing agent",
   "license": "MIT",
   "homepage": "https://opencandle.app",


### PR DESCRIPTION
## Summary
- Release OpenCandle v0.8.0
- Reset CHANGELOG.md with a fresh [Unreleased] section

## Validation
- npm run release:check passed before version bump
- release script reran npm run release:check and passed before creating release commits
- packed install smoke imported public package entrypoints and ran `opencandle doctor` from the packed tarball
