### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.9.0] - 2026-06-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.9.0] - 2026-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Financial trading & investing agent",
   "license": "MIT",
   "homepage": "https://opencandle.app",


### PR DESCRIPTION
## Summary

- Release OpenCandle v0.9.0.
- Move the accumulated [Unreleased] changelog entries into the v0.9.0 section.
- Add a fresh [Unreleased] section for the next cycle.

## Validation

- `npm run release:minor` completed the full release preflight before branch protection blocked direct protected-branch push:
  - `npx tsc --noEmit`
  - `npx biome ci .`
  - full Vitest: 213 files, 2205 tests passed
  - docs site build
  - package contents check
  - packed install/import/doctor smoke
  - public docs link check

Note: the local `v0.9.0` tag has been created but not pushed. It will be pushed after this PR merges so the publish workflow runs on the merged release commit.