### PR TITLE
Implement session-scoped transcript and tool drawer sync

### DIFF
--- a/gui/web/src/App.jsx
+++ b/gui/web/src/App.jsx
@@ -349,8 +349,10 @@ export function AppShell() {
     (toolName, args) => gui.invokeTool(toolName, args, sessionView.activeSessionId),
     [gui.invokeTool, sessionView.activeSessionId],
   );
+  const scrollAnchorId = search?.messageId || search?.researchId || search?.synthesisId || "";
+
   return (
-    <ToolDrawerProvider>
+    <ToolDrawerProvider activeSessionId={sessionView.activeSessionId}>
       <div className="flex overflow-hidden bg-background" style={{ height: "100dvh" }}>
         <SessionSidebar {...sidebarProps} />
         <ConnectionStatusBanner role={gui.role} />
@@ -403,6 +405,8 @@ export function AppShell() {
             onOpenContext={() => openDrawer("context")}
             sidebarCollapsed={sidebarCollapsed}
             onExpandSidebar={() => setSidebarCollapsed(false)}
+            sessionId={sessionView.activeSessionId}
+            scrollAnchorId={scrollAnchorId}
           />
         )}
         <ToolDrawerInline />

--- a/gui/web/src/features/chat/ChatPanel.jsx
+++ b/gui/web/src/features/chat/ChatPanel.jsx
@@ -208,7 +208,7 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
   const previousSessionRef = useRef("");
   const previousLatestUserRef = useRef("");
   const appliedAnchorRef = useRef("");
-  const mountedAnchorRef = useRef("");
+  const pendingRowAnchorRef = useRef("");
   const latestUserRowId = useMemo(() => {
     for (let index = rows.length - 1; index >= 0; index -= 1) {
       if (rows[index].type === "user_message") return rows[index].id;
@@ -244,12 +244,12 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
       const anchorId = scrollAnchorId || latestUserRowId;
       if (!anchorId) return;
       const key = `${sessionId || ""}::${anchorId}`;
-      if (mountedAnchorRef.current === key) return;
-      mountedAnchorRef.current = key;
       window.setTimeout(() => {
+        if (pendingRowAnchorRef.current !== key) return;
         const viewport = node.closest("[data-chat-transcript]");
         if (!(viewport instanceof HTMLElement)) return;
         positionRowElement(viewport, node);
+        pendingRowAnchorRef.current = "";
         updateJumpState();
       }, 0);
     },
@@ -291,6 +291,17 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
     const latestUserChanged = previousLatestUserRef.current !== latestUserRowId;
     const anchorKey = `${sessionId || ""}::${scrollAnchorId || ""}`;
     const hasNewExplicitAnchor = scrollAnchorId && appliedAnchorRef.current !== anchorKey;
+    const pendingAnchorId = pendingTranscriptAnchorId({
+      hasNewExplicitAnchor,
+      scrollAnchorId,
+      sessionChanged,
+      latestUserChanged,
+      latestUserRowId,
+      following: followingRef.current,
+    });
+    if (pendingAnchorId) {
+      pendingRowAnchorRef.current = `${sessionId || ""}::${pendingAnchorId}`;
+    }
 
     previousSessionRef.current = sessionId;
     previousLatestUserRef.current = latestUserRowId;
@@ -303,6 +314,7 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
         if (scrollToRowAnchor(currentViewport, scrollAnchorId, sessionId)) {
           appliedAnchorRef.current = anchorKey;
           followingRef.current = false;
+          pendingRowAnchorRef.current = "";
           updateJumpState();
           return;
         }
@@ -312,6 +324,7 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
         appliedAnchorRef.current = scrollAnchorId ? appliedAnchorRef.current : "";
         if (latestUserRowId && scrollToRowAnchor(currentViewport, latestUserRowId, sessionId)) {
           followingRef.current = true;
+          pendingRowAnchorRef.current = "";
           updateJumpState();
           return;
         }
@@ -321,9 +334,10 @@ function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) 
         return;
       }
 
-      if (latestUserChanged && latestUserRowId) {
+      if (latestUserChanged && latestUserRowId && followingRef.current) {
         scrollToRowAnchor(currentViewport, latestUserRowId, sessionId);
         followingRef.current = true;
+        pendingRowAnchorRef.current = "";
         updateJumpState();
         return;
       }
@@ -607,6 +621,20 @@ function latestUserRowIdFromRows(rows) {
   for (let index = rows.length - 1; index >= 0; index -= 1) {
     if (rows[index].type === "user_message") return rows[index].id;
   }
+  return "";
+}
+
+export function pendingTranscriptAnchorId({
+  hasNewExplicitAnchor = false,
+  scrollAnchorId = "",
+  sessionChanged = false,
+  latestUserChanged = false,
+  latestUserRowId = "",
+  following = false,
+} = {}) {
+  if (hasNewExplicitAnchor) return scrollAnchorId;
+  if (sessionChanged && latestUserRowId) return latestUserRowId;
+  if (latestUserChanged && latestUserRowId && following) return latestUserRowId;
   return "";
 }
 

--- a/gui/web/src/features/chat/ChatPanel.jsx
+++ b/gui/web/src/features/chat/ChatPanel.jsx
@@ -1,5 +1,5 @@
-import { CircleHelp, Send, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ArrowDown, CircleHelp, Send, X } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { reduceChatEvents } from "../../../../shared/event-reducer.ts";
 import { ChatComposer } from "../../components/chat/chat-composer.jsx";
 import { EmptyThread } from "../../components/chat/prompt-suggestions.jsx";
@@ -43,6 +43,8 @@ export function ChatPanel({
   onOpenContext,
   sidebarCollapsed,
   onExpandSidebar,
+  sessionId = "",
+  scrollAnchorId = "",
 }) {
   // Allow App.jsx to lift draft state for cross-component pre-fill (e.g. catalog "Send to chat").
   // Falls back to local state when used standalone (older callers, tests).
@@ -51,7 +53,10 @@ export function ChatPanel({
   const draft = draftProp !== undefined ? draftProp : localDraft;
   const setDraft = setDraftProp ?? setLocalDraft;
   const liveState = useMemo(() => reduceChatEvents(liveEvents), [liveEvents]);
-  const visibleRows = useMemo(() => chatRowsFromEvents(events, liveEvents), [events, liveEvents]);
+  const visibleRows = useMemo(
+    () => chatRowsFromEvents(events, liveEvents, sessionId),
+    [events, liveEvents, sessionId],
+  );
   const groupedRows = useMemo(() => groupToolRuns(visibleRows), [visibleRows]);
   const activity = useMemo(() => buildAgentActivity(liveState, runState), [liveState, runState]);
   const hasAskUserPrompts = askUserPrompts.length > 0;
@@ -63,12 +68,31 @@ export function ChatPanel({
     return pendingRuns[pendingRuns.length - 1]?.id ?? null;
   }, [allowToolAutoOpen, groupedRows]);
   const drawer = useToolDrawer();
+  const drawerOpenForSession = Boolean(
+    drawer.run && (!drawer.run.sessionId || drawer.run.sessionId === sessionId),
+  );
+  const transcript = useTranscriptScroller({
+    rows: groupedRows,
+    sessionId,
+    scrollAnchorId,
+    drawerOpen: drawerOpenForSession,
+  });
+  const rowAnchorId = scrollAnchorId || latestUserRowIdFromRows(groupedRows);
   // Keep the open drawer in sync as the active run streams in new steps.
   useEffect(() => {
     if (!drawer.run) return;
-    const latest = groupedRows.find((e) => e.type === "tool_run" && e.id === drawer.run.id);
+    if (drawer.run.sessionId && drawer.run.sessionId !== sessionId) {
+      drawer.close();
+      return;
+    }
+    const latest = groupedRows.find(
+      (e) =>
+        e.type === "tool_run" &&
+        e.id === drawer.run.id &&
+        (e.sessionId || "") === (drawer.run.sessionId || ""),
+    );
     if (latest && latest !== drawer.run) drawer.open(latest);
-  }, [groupedRows, drawer]);
+  }, [groupedRows, drawer, sessionId]);
   if (
     allowToolAutoOpen &&
     !autoOpenRunId &&
@@ -102,33 +126,62 @@ export function ChatPanel({
     >
       <MobileHeader onOpenSidebar={onOpenSidebar} onOpenHome={onOpenHome} />
       {sidebarCollapsed ? <DesktopSidebarRestore onExpandSidebar={onExpandSidebar} /> : null}
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-6 sm:px-6 md:px-12">
-        {needsSetup ? (
-          <ModelSetupCard modelSetup={modelSetup} send={send} setToast={setToast} />
-        ) : sessionLoading ? (
-          <SessionLoadingState />
-        ) : visibleRows.length === 0 && !activity && !hasAskUserPrompts ? (
-          <EmptyThread
-            onPrompt={submit}
-            onOpenCatalog={onOpenCommandPalette}
-            disabled={chatDisabled}
-          />
-        ) : (
-          <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-6">
-            {groupedRows.map((entry) => (
-              <MessageRow
-                key={entry.id}
-                entry={entry}
-                catalog={catalog}
-                autoOpenToolRun={entry.id === autoOpenRunId}
-              />
-            ))}
-            {askUserPrompts.map((prompt) => (
-              <AskUserPromptCard key={prompt.id} prompt={prompt} role={role} send={send} />
-            ))}
-            {activity ? <AgentActivity activity={activity} /> : null}
-          </div>
-        )}
+      <div className="relative min-h-0 flex-1">
+        <section
+          ref={transcript.viewportRef}
+          className="h-full overflow-y-auto px-3 py-6 sm:px-6 md:px-12"
+          data-chat-transcript
+          data-scroll-anchor-id={scrollAnchorId || undefined}
+          aria-label="Chat transcript"
+          onScroll={transcript.onScroll}
+          onWheel={transcript.onReaderIntent}
+          onMouseDown={transcript.onReaderIntent}
+          onTouchStart={transcript.onReaderIntent}
+          onKeyDown={transcript.onReaderIntent}
+        >
+          {needsSetup ? (
+            <ModelSetupCard modelSetup={modelSetup} send={send} setToast={setToast} />
+          ) : sessionLoading ? (
+            <SessionLoadingState />
+          ) : visibleRows.length === 0 && !activity && !hasAskUserPrompts ? (
+            <EmptyThread
+              onPrompt={submit}
+              onOpenCatalog={onOpenCommandPalette}
+              disabled={chatDisabled}
+            />
+          ) : (
+            <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-6">
+              {groupedRows.map((entry) => (
+                <MessageRow
+                  key={entry.id}
+                  entry={entry}
+                  catalog={catalog}
+                  autoOpenToolRun={entry.id === autoOpenRunId}
+                  anchorRowId={rowAnchorId}
+                  anchorRef={transcript.anchorRowRef}
+                />
+              ))}
+              {askUserPrompts.map((prompt) => (
+                <AskUserPromptCard key={prompt.id} prompt={prompt} role={role} send={send} />
+              ))}
+              {activity ? <AgentActivity activity={activity} /> : null}
+              <div ref={transcript.bottomRef} data-chat-bottom-sentinel aria-hidden="true" />
+            </div>
+          )}
+        </section>
+        {transcript.showJumpToLatest ? (
+          <Button
+            type="button"
+            size="sm"
+            rounded="full"
+            className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 gap-1.5 shadow-subtle-md"
+            onClick={transcript.jumpToLatest}
+            aria-label="Jump to latest"
+          >
+            <ArrowDown className="h-4 w-4" />
+            Latest
+          </Button>
+        ) : null}
       </div>
       <ChatComposer
         draft={draft}
@@ -145,6 +198,159 @@ export function ChatPanel({
       />
     </section>
   );
+}
+
+function useTranscriptScroller({ rows, sessionId, scrollAnchorId, drawerOpen }) {
+  const viewportRef = useRef(null);
+  const bottomRef = useRef(null);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+  const followingRef = useRef(true);
+  const previousSessionRef = useRef("");
+  const previousLatestUserRef = useRef("");
+  const appliedAnchorRef = useRef("");
+  const mountedAnchorRef = useRef("");
+  const latestUserRowId = useMemo(() => {
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      if (rows[index].type === "user_message") return rows[index].id;
+    }
+    return "";
+  }, [rows]);
+
+  const updateJumpState = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    setShowJumpToLatest(rows.length > 0 && !isNearBottom(viewport));
+  }, [rows.length]);
+
+  const scrollToBottom = useCallback(() => {
+    const bottom = bottomRef.current;
+    if (bottom) {
+      bottom.scrollIntoView({ block: "end" });
+      return;
+    }
+    const viewport = viewportRef.current;
+    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    followingRef.current = true;
+    scrollToBottom();
+    setShowJumpToLatest(false);
+  }, [scrollToBottom]);
+
+  const anchorRowRef = useCallback(
+    (node) => {
+      if (!node) return;
+      const anchorId = scrollAnchorId || latestUserRowId;
+      if (!anchorId) return;
+      const key = `${sessionId || ""}::${anchorId}`;
+      if (mountedAnchorRef.current === key) return;
+      mountedAnchorRef.current = key;
+      window.setTimeout(() => {
+        const viewport = node.closest("[data-chat-transcript]");
+        if (!(viewport instanceof HTMLElement)) return;
+        positionRowElement(viewport, node);
+        updateJumpState();
+      }, 0);
+    },
+    [latestUserRowId, scrollAnchorId, sessionId, updateJumpState],
+  );
+
+  const onReaderIntent = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || isNearBottom(viewport)) return;
+    followingRef.current = false;
+    setShowJumpToLatest(rows.length > 0);
+  }, [rows.length]);
+
+  const onScroll = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    if (isNearBottom(viewport)) {
+      followingRef.current = true;
+      setShowJumpToLatest(false);
+      return;
+    }
+    setShowJumpToLatest(rows.length > 0);
+  }, [rows.length]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    followingRef.current = false;
+    updateJumpState();
+  }, [drawerOpen, updateJumpState]);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || rows.length === 0) {
+      setShowJumpToLatest(false);
+      return;
+    }
+
+    const sessionChanged = previousSessionRef.current !== sessionId;
+    const latestUserChanged = previousLatestUserRef.current !== latestUserRowId;
+    const anchorKey = `${sessionId || ""}::${scrollAnchorId || ""}`;
+    const hasNewExplicitAnchor = scrollAnchorId && appliedAnchorRef.current !== anchorKey;
+
+    previousSessionRef.current = sessionId;
+    previousLatestUserRef.current = latestUserRowId;
+
+    const positionTranscript = () => {
+      const currentViewport = viewportRef.current;
+      if (!currentViewport) return;
+
+      if (hasNewExplicitAnchor) {
+        if (scrollToRowAnchor(currentViewport, scrollAnchorId, sessionId)) {
+          appliedAnchorRef.current = anchorKey;
+          followingRef.current = false;
+          updateJumpState();
+          return;
+        }
+      }
+
+      if (sessionChanged) {
+        appliedAnchorRef.current = scrollAnchorId ? appliedAnchorRef.current : "";
+        if (latestUserRowId && scrollToRowAnchor(currentViewport, latestUserRowId, sessionId)) {
+          followingRef.current = true;
+          updateJumpState();
+          return;
+        }
+        followingRef.current = true;
+        scrollToBottom();
+        updateJumpState();
+        return;
+      }
+
+      if (latestUserChanged && latestUserRowId) {
+        scrollToRowAnchor(currentViewport, latestUserRowId, sessionId);
+        followingRef.current = true;
+        updateJumpState();
+        return;
+      }
+
+      if (followingRef.current || isNearBottom(currentViewport)) {
+        scrollToBottom();
+        setShowJumpToLatest(false);
+        return;
+      }
+
+      updateJumpState();
+    };
+
+    positionTranscript();
+    const timeout = window.setTimeout(positionTranscript, 0);
+    return () => window.clearTimeout(timeout);
+  }, [latestUserRowId, rows.length, scrollAnchorId, scrollToBottom, sessionId, updateJumpState]);
+
+  return {
+    viewportRef,
+    bottomRef,
+    anchorRowRef,
+    showJumpToLatest,
+    jumpToLatest,
+    onReaderIntent,
+    onScroll,
+  };
 }
 
 function SessionLoadingState() {
@@ -352,7 +558,30 @@ function AgentActivity({ activity }) {
   );
 }
 
-function MessageRow({ entry, catalog, autoOpenToolRun = false }) {
+function MessageRow({ entry, catalog, autoOpenToolRun = false, anchorRowId = "", anchorRef }) {
+  const messageId =
+    entry.messageId || (String(entry.id || "").startsWith("message-") ? entry.id.slice(8) : "");
+  const isAnchorRow =
+    anchorRowId &&
+    (entry.id === anchorRowId ||
+      messageId === anchorRowId ||
+      entry.id === `message-${anchorRowId}`);
+  const row = (
+    <div
+      ref={isAnchorRow ? anchorRef : undefined}
+      data-chat-row-id={entry.id}
+      data-message-id={messageId || undefined}
+      data-session-id={entry.sessionId || undefined}
+      data-scroll-anchor={entry.type === "user_message" ? "true" : undefined}
+      className="min-w-0 scroll-mt-6"
+    >
+      <MessageRowContent entry={entry} catalog={catalog} autoOpenToolRun={autoOpenToolRun} />
+    </div>
+  );
+  return row;
+}
+
+function MessageRowContent({ entry, catalog, autoOpenToolRun = false }) {
   if (entry.type === "tool_run") {
     return <StepsCard run={entry} autoOpen={autoOpenToolRun} />;
   }
@@ -368,6 +597,38 @@ function MessageRow({ entry, catalog, autoOpenToolRun = false }) {
       {JSON.stringify(entry)}
     </div>
   );
+}
+
+function isNearBottom(element) {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= 48;
+}
+
+function latestUserRowIdFromRows(rows) {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    if (rows[index].type === "user_message") return rows[index].id;
+  }
+  return "";
+}
+
+function scrollToRowAnchor(viewport, anchorId, sessionId) {
+  if (!anchorId) return false;
+  const candidates = [...viewport.querySelectorAll("[data-chat-row-id]")];
+  const target = candidates.find((element) => {
+    if (sessionId && element.dataset.sessionId && element.dataset.sessionId !== sessionId) {
+      return false;
+    }
+    const rowId = element.dataset.chatRowId || "";
+    const messageId = element.dataset.messageId || "";
+    return rowId === anchorId || messageId === anchorId || rowId === `message-${anchorId}`;
+  });
+  if (!target) return false;
+  positionRowElement(viewport, target);
+  return true;
+}
+
+function positionRowElement(viewport, row) {
+  const top = Math.max(0, row.offsetTop - viewport.clientHeight * 0.12);
+  viewport.scrollTo({ top, behavior: "auto" });
 }
 
 function buildAgentActivity(liveState, runState) {

--- a/gui/web/src/features/chat/chat-rows.js
+++ b/gui/web/src/features/chat/chat-rows.js
@@ -1,17 +1,20 @@
 import { reduceChatEvents } from "../../../../shared/event-reducer.ts";
 import { textContent } from "../../rendering/text.js";
 
-export function chatRowsFromEvents(events = [], liveEvents = []) {
+export function chatRowsFromEvents(events = [], liveEvents = [], defaultSessionId = "") {
   const state = reduceChatEvents(mergeChatEvents(events, liveEvents));
   const toolsByMessage = groupToolsByMessage([...state.tools.values()]);
   const rows = [];
 
   for (const message of state.messages) {
     const tools = toolsByMessage.get(message.id) || [];
+    const sessionId = message.sessionId || defaultSessionId || "";
     if (message.customType) {
       rows.push({
         type: "custom_message",
         id: `message-${message.id}`,
+        messageId: message.id,
+        sessionId,
         customType: message.customType,
         content: message.content,
       });
@@ -22,17 +25,20 @@ export function chatRowsFromEvents(events = [], liveEvents = []) {
       rows.push({
         type: "user_message",
         id: `message-${message.id}`,
+        messageId: message.id,
+        sessionId,
         content: message.content,
       });
       continue;
     }
 
     if (message.role === "assistant") {
-      const content = contentForMessage(message, tools);
+      const content = contentForMessage(message, tools, sessionId);
       if (content.length > 0 && !isBackgroundAssistantMessage(content)) {
         rows.push({
           type: "assistant_message",
           id: `message-${message.id}`,
+          sessionId,
           content,
           messageId: message.id,
         });
@@ -45,6 +51,7 @@ export function chatRowsFromEvents(events = [], liveEvents = []) {
       rows.push({
         type: "tool_result",
         id: `tool-${tool.id}`,
+        sessionId: tool.sessionId || sessionId,
         message: toolResultMessage(tool),
       });
     }
@@ -63,7 +70,7 @@ export function mergeChatEvents(events = [], liveEvents = []) {
   return [...events, ...normalizedLive];
 }
 
-function contentForMessage(message, tools) {
+function contentForMessage(message, tools, sessionId = "") {
   const content = (message.content || []).map((part) => {
     if (part.type === "tool") {
       const tool = tools.find((candidate) => candidate.id === part.toolCallId);
@@ -72,6 +79,7 @@ function contentForMessage(message, tools) {
         id: part.toolCallId,
         name: tool?.name || "tool",
         arguments: tool?.input || {},
+        sessionId: tool?.sessionId || sessionId,
       };
     }
     return part;
@@ -87,6 +95,7 @@ function contentForMessage(message, tools) {
       id: tool.id,
       name: tool.name,
       arguments: tool.input || {},
+      sessionId: tool.sessionId || sessionId,
     });
   }
   return content;
@@ -101,6 +110,7 @@ function toolResultMessage(tool) {
       content: tool.output.content || [],
       details: tool.output.details,
       isError: Boolean(tool.output.isError),
+      sessionId: tool.sessionId || "",
     };
   }
 
@@ -111,6 +121,7 @@ function toolResultMessage(tool) {
     content: [{ type: "text", text: tool.error?.message || "Tool failed" }],
     details: tool.error?.details,
     isError: true,
+    sessionId: tool.sessionId || "",
   };
 }
 

--- a/gui/web/src/features/chat/steps-card.jsx
+++ b/gui/web/src/features/chat/steps-card.jsx
@@ -15,7 +15,7 @@ import { useToolDrawer } from "./tool-drawer-context.jsx";
 // run is still pending the title shimmers and the icon spins.
 export function StepsCard({ run, autoOpen = false }) {
   const { open, requestAutoOpen, run: openRun } = useToolDrawer();
-  const isOpen = openRun?.id === run.id;
+  const isOpen = openRun?.id === run.id && (openRun?.sessionId || "") === (run.sessionId || "");
   const stepCount = run.steps.length;
   const title = summarizeRunTitle(run.steps.map((s) => s.name));
   const isPending = run.status === "pending";
@@ -100,7 +100,7 @@ function argSummary(step) {
   if (!step?.args) return "";
   const entries = Object.entries(step.args).filter(([, v]) => v != null && v !== "");
   if (entries.length === 0) return "";
-  const [k, v] = entries[0];
+  const [, v] = entries[0];
   const value = typeof v === "string" ? v : typeof v === "number" ? String(v) : null;
   if (!value) return "";
   return value.length > 24 ? `${value.slice(0, 24)}…` : value;

--- a/gui/web/src/features/chat/tool-drawer-context.jsx
+++ b/gui/web/src/features/chat/tool-drawer-context.jsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 const ToolDrawerContext = createContext(null);
 
@@ -6,29 +14,43 @@ const ToolDrawerContext = createContext(null);
 // clicked). One drawer instance lives at the App level and reads this state
 // to render. We keep the entire run object — not just an id — so the drawer
 // can stream-update as new steps come in without re-querying the entries.
-export function ToolDrawerProvider({ children }) {
+export function ToolDrawerProvider({ activeSessionId = "", children }) {
   const [run, setRun] = useState(null);
   // The auto-open trigger: when the assistant starts a new tool run we want
   // the drawer to pop open once, but never re-open if the user explicitly
   // closed it. Track which run ids we've already auto-handled.
   const seenAutoOpenRef = useRef(new Set());
 
-  const open = useCallback((nextRun) => {
-    if (!nextRun) return;
-    setRun(nextRun);
-  }, []);
+  useEffect(() => {
+    if (!run || !activeSessionId) return;
+    if (run.sessionId && run.sessionId !== activeSessionId) setRun(null);
+  }, [activeSessionId, run]);
+
+  const open = useCallback(
+    (nextRun) => {
+      if (!nextRun) return;
+      if (activeSessionId && nextRun.sessionId && nextRun.sessionId !== activeSessionId) return;
+      setRun(nextRun);
+    },
+    [activeSessionId],
+  );
 
   const close = useCallback(() => {
     setRun(null);
   }, []);
 
   // Called by StepsCard on first render of a pending run.
-  const requestAutoOpen = useCallback((nextRun) => {
-    if (!nextRun || nextRun.status !== "pending") return;
-    if (seenAutoOpenRef.current.has(nextRun.id)) return;
-    seenAutoOpenRef.current.add(nextRun.id);
-    setRun(nextRun);
-  }, []);
+  const requestAutoOpen = useCallback(
+    (nextRun) => {
+      if (nextRun?.status !== "pending") return;
+      if (activeSessionId && nextRun.sessionId && nextRun.sessionId !== activeSessionId) return;
+      const key = runKey(nextRun);
+      if (seenAutoOpenRef.current.has(key)) return;
+      seenAutoOpenRef.current.add(key);
+      setRun(nextRun);
+    },
+    [activeSessionId],
+  );
 
   const value = useMemo(
     () => ({ run, open, close, requestAutoOpen }),
@@ -42,4 +64,8 @@ export function useToolDrawer() {
   const ctx = useContext(ToolDrawerContext);
   if (!ctx) throw new Error("useToolDrawer must be used inside ToolDrawerProvider");
   return ctx;
+}
+
+function runKey(run) {
+  return `${run?.sessionId || ""}::${run?.id || ""}`;
 }

--- a/gui/web/src/features/chat/tool-run-grouper.js
+++ b/gui/web/src/features/chat/tool-run-grouper.js
@@ -21,7 +21,8 @@ function narrativeText(content) {
 //   {
 //     type: "tool_run",
 //     id: "run-<first-tool-call-id>",
-//     steps: [{ id, name, args, status, result?, narration?, messageId }],
+//     sessionId: "session-id",
+//     steps: [{ id, name, args, status, result?, narration?, messageId, sessionId }],
 //     status: "pending" | "completed" | "error",
 //     narrationBefore: string  (assistant text immediately preceding the first
 //                               tool call, e.g. "Let me look up the quote.")
@@ -76,7 +77,7 @@ export function groupToolRuns(rows) {
       // The assistant emitted tool calls. Start a run if there isn't one;
       // otherwise continue the existing run.
       if (!run) {
-        run = startRun(toolCalls[0]);
+        run = startRun(toolCalls[0], row.sessionId);
         run.narrationBefore = (pendingNarration || text || "").trim();
         pendingNarration = "";
       } else if (text) {
@@ -97,6 +98,7 @@ export function groupToolRuns(rows) {
           status: "pending",
           result: null,
           messageId: row.messageId,
+          sessionId: tc.sessionId || row.sessionId || run.sessionId || "",
         });
       }
       continue;
@@ -110,6 +112,7 @@ export function groupToolRuns(rows) {
         run = {
           type: "tool_run",
           id: `run-${message.toolCallId || row.id}`,
+          sessionId: row.sessionId || message.sessionId || "",
           steps: [],
           status: "pending",
           narrationBefore: "",
@@ -122,6 +125,7 @@ export function groupToolRuns(rows) {
           status: "pending",
           result: null,
           messageId: null,
+          sessionId: row.sessionId || message.sessionId || "",
         });
       }
       const step =
@@ -138,6 +142,7 @@ export function groupToolRuns(rows) {
           status: message.isError ? "error" : "completed",
           result: message,
           messageId: null,
+          sessionId: row.sessionId || message.sessionId || run.sessionId || "",
         });
       }
       continue;
@@ -152,10 +157,11 @@ export function groupToolRuns(rows) {
   return out;
 }
 
-function startRun(firstCall) {
+function startRun(firstCall, fallbackSessionId = "") {
   return {
     type: "tool_run",
     id: `run-${firstCall.id}`,
+    sessionId: firstCall.sessionId || fallbackSessionId || "",
     steps: [],
     status: "pending",
     narrationBefore: "",

--- a/gui/web/src/router.jsx
+++ b/gui/web/src/router.jsx
@@ -92,5 +92,8 @@ function validateGuiSearch(search) {
         ? search.drawer
         : undefined,
     prompt: typeof search.prompt === "string" ? search.prompt : undefined,
+    messageId: typeof search.messageId === "string" ? search.messageId : undefined,
+    researchId: typeof search.researchId === "string" ? search.researchId : undefined,
+    synthesisId: typeof search.synthesisId === "string" ? search.synthesisId : undefined,
   };
 }

--- a/openspec/changes/gui-concurrent-session-runtime/design.md
+++ b/openspec/changes/gui-concurrent-session-runtime/design.md
@@ -108,7 +108,38 @@ The visible route selects from those stores. A run in session A must not put the
 
 Reducers that combine events from more than one session must scope message IDs, tool-call IDs, run IDs, and sequence numbers by `sessionId`. Persisted replay events do not need a synthetic `runId` when the run id was never stored; live run lifecycle events and live tool/message events from an active run must carry `runId`.
 
-## 8. TUI And Pi Parity
+## 8. Transcript Scroll Behavior
+
+The transcript scroller should be treated as a session-scoped runtime surface, not as incidental overflow behavior. Long OpenCandle runs can stream assistant text, append grouped tool cards, open a tool timeline drawer, and change layout heights while the user is reading earlier financial evidence. The GUI should preserve the reader's intent while still making live progress visible.
+
+Rules:
+
+- user turns are scroll anchors by default;
+- when the user submits a prompt, the new user turn anchors within the first quarter of the visible transcript viewport when there is enough scrollable height, and the assistant response streams below it;
+- auto-follow happens only while the reader is already at the live edge, meaning a bottom sentinel is visible or the scroll position is within a small bottom threshold;
+- scrolling away, selecting text, keyboard navigation, opening links, opening command/search UI, or opening the tool/research drawer stops auto-follow for that transcript until the user explicitly returns to latest;
+- when new content arrives offscreen, the GUI shows an unobtrusive jump-to-latest/new-content control for the visible session;
+- saved session routes without an explicit anchor reopen at the last meaningful turn when available, using a stored reader anchor first and otherwise the most recent user message, not blindly at the absolute bottom;
+- explicit message, synthesis, research, or scroll anchors in links override the default saved-session restore target and must belong to the route session before changing scroll position;
+- prepending history, completing markdown, rendering rich cards, opening the inline tool drawer, and receiving streamed tool results preserve the visible reader position;
+- scroll state is keyed by route session id so navigating between sessions does not reuse another transcript's anchor, live-edge state, or unread marker.
+
+This can be implemented with a headless message-scroller primitive or a local hook. The implementation should not replace OpenCandle's existing message components, finance result cards, or grouped tool-run cards unless a smaller follow-up explicitly chooses that visual migration.
+
+## 9. Current-Thread Auxiliary Panels
+
+Auxiliary panels that summarize or expand chat evidence must derive from the route session, not from the last opened panel object. The current bug is that the research/tool timeline panel can remain open while the user navigates to another chat, but still show tool calls from the old thread.
+
+The panel state should therefore include the owning `sessionId` for any selected run, tool group, source list, or research card. It must not match panel content across sessions by unscoped message id, run id, tool-call id, row id, title, or array index. On route change, the client must either:
+
+- bind the panel to an explicit selection in the new route session whose identity includes that new session id; or
+- clear/close the panel when its selected content belongs to a different session.
+
+The drawer body should render from the selected route session's grouped rows or session store, not from an unscoped object captured before navigation. Pending auto-open behavior must also be session-scoped: a tool run in session A must not auto-open or update the drawer while the browser is viewing session B unless the drawer explicitly belongs to session A and the route still allows viewing that session's panel.
+
+This same rule should apply to any future transcript outline, source panel, or research summary panel: if it claims to describe "this thread," its inputs must be selected from the visible route session.
+
+## 10. TUI And Pi Parity
 
 The TUI can keep a single focused session because that matches terminal UX. The parity requirement is semantic and storage-backed:
 
@@ -122,7 +153,7 @@ The TUI can keep a single focused session because that matches terminal UX. The 
 
 The GUI runtime may run multiple session actors in one process, but each actor must behave like a normal Pi session writer for its specific session.
 
-## 9. Verification Strategy
+## 11. Verification Strategy
 
 Implementation should prove the old races are gone with targeted tests:
 
@@ -133,10 +164,15 @@ Implementation should prove the old races are gone with targeted tests:
 - browser tests that start a long response in session A, switch to session B, send a message there, and verify both transcripts remain separated;
 - browser tests that stop/retry a run in one session without affecting another active run;
 - browser tests for direct navigation to an old session URL with and without an already-open WebSocket;
+- browser tests for transcript scroll behavior during a long streaming response: anchor the submitted user turn, follow only at live edge, stop following when the reader scrolls away, show a jump-to-latest control, and preserve position when tool cards/drawers change layout;
+- browser tests that navigate from session A to session B while the tool/research drawer is open and verify the panel closes, clears, or shows only session B tool calls;
+- screenshot evidence from browser validation uploaded to the PR for the transcript scroller states and current-thread panel synchronization; local screenshots may be deleted after upload;
 - parity smoke that a GUI-created session is readable from TUI/Pi session APIs and a TUI-created session is readable from GUI APIs;
 - parity smoke that GUI and TUI respect the same per-session writer lock;
 - parity smoke that branch context, OpenCandle custom entries, direct tool results, and setup custom messages survive GUI-to-TUI and TUI-to-GUI round trips.
 
-## 10. Rollout
+## 12. Rollout
 
 Implement the new session-addressed read and write path first, update the browser to use it, then remove the old active-session mutation path. Avoid leaving two send paths because that recreates ambiguous ownership.
+
+Transcript scroll behavior and auxiliary-panel scoping should land after the browser has reliable per-session stores. That keeps the scroller and drawer logic keyed to stable route/session state instead of patching around the current global active-session assumptions.

--- a/openspec/changes/gui-concurrent-session-runtime/proposal.md
+++ b/openspec/changes/gui-concurrent-session-runtime/proposal.md
@@ -19,6 +19,8 @@ The bigger product issue is that one global active writer target also prevents a
 - Route chat prompts, `ask_user` answers/cancels, direct tool invocations, stop/cancel, retry, and setup-driven transcript mutations to explicit target sessions.
 - Correlate session snapshots, route transitions, send acknowledgements, and run events by `sessionId`, `requestId`, and `runId` so stale events cannot update the wrong route.
 - Make direct session routes and historical session loads independent of WebSocket ordering.
+- Make transcript scrolling session-aware and reader-intent-aware: anchored user turns, live-edge-only auto-follow, jump-to-latest controls, saved-thread restore, and position preservation during streaming/tool-card layout changes.
+- Keep auxiliary chat panels, including the research/tool timeline drawer, derived from the current route session so navigating to another chat cannot leave a panel showing tool calls from the previous thread.
 - Preserve canonical Pi/OpenCandle session storage, branch context, custom entries, and chat event rendering semantics.
 
 ## Capabilities
@@ -27,11 +29,14 @@ The bigger product issue is that one global active writer target also prevents a
 
 - **`pi-synced-gui`**: Defines the session-addressed GUI runtime, per-session writer ownership, route identity, and TUI/Pi parity expectations.
 - **`chat-event-rendering`**: Tightens the event stream contract so every live and replayed event is scoped to the target session and run.
+- **`stateful-market-surfaces`**: Replaces process-global active-session wording for GUI-originated market-state mutations with explicit target-session transcript visibility.
 
 ## Impact
 
 - **GUI server:** Introduces a session-runtime registry or equivalent actor map keyed by Pi session id/path instead of a singleton active runtime.
 - **GUI web app:** Makes route params, composer sends, direct tool invocations, `ask_user` responses, run controls, and live run state target explicit session ids; stale responses are ignored rather than rendered.
+- **Transcript UX:** Adds a session-scoped scroll behavior contract for long streaming finance workflows without replacing OpenCandle's finance-specific message and tool cards.
+- **Auxiliary panels:** Keeps the tool/research timeline drawer and any current-thread summaries synchronized with the visible route session, closing stale-panel leakage when switching chats.
 - **Session concurrency:** Allows independent sessions to run concurrently in the same GUI process, while rejecting overlapping runs in the same session.
 - **TUI/Pi parity:** Reuses Pi session storage and branch/read APIs while adding shared per-session writer-lock participation for TUI and GUI. TUI behavior remains singleton-focused because the terminal has one visible session, but durable session semantics and write safety stay shared.
 - **No storage migration:** This change does not require a SQLite schema migration or Pi session format change.
@@ -42,6 +47,6 @@ The bigger product issue is that one global active writer target also prevents a
 - Do not allow simultaneous writers to append to the same Pi session.
 - Do not fork or modify Pi session storage format.
 - Do not add cross-machine session sync.
-- Do not redesign the transcript UI, financial cards, or market-state pages.
+- Do not redesign the transcript visual language, financial cards, or market-state pages; this change may add transcript behavior and session-scoped panel synchronization needed for correctness.
 - Do not keep compatibility shims for the current active-session mutation path once the replacement endpoint and WebSocket actions are in place.
 - Do not add queued same-session prompts; same-session overlap is rejected until a separate queueing change defines that behavior.

--- a/openspec/changes/gui-concurrent-session-runtime/specs/chat-event-rendering/spec.md
+++ b/openspec/changes/gui-concurrent-session-runtime/specs/chat-event-rendering/spec.md
@@ -84,3 +84,66 @@ Mutating GUI requests SHALL include session ID and request ID when the request c
 - **WHEN** an acknowledgement for session A arrives after the browser has navigated to session B
 - **THEN** the GUI applies the acknowledgement only to session A state
 - **AND** it does not replace session B's transcript, run state, or route
+
+### Requirement: Session-Scoped Transcript Scrolling
+
+The GUI SHALL preserve transcript scroll state by visible route session and reader intent during streamed responses, tool-card updates, route changes, and saved-session restores.
+
+#### Scenario: New user turn anchors the stream
+
+- **WHEN** the user submits a prompt in session A
+- **THEN** the submitted user turn is treated as the active scroll anchor for session A
+- **AND** the viewport positions that turn within the first quarter of the visible transcript viewport when the transcript has enough scrollable height
+- **AND** streamed assistant content for that turn appears below the anchor without reusing scroll state from another session
+
+#### Scenario: Auto-follow respects reader intent
+
+- **WHEN** session A is streaming a response
+- **AND** the reader is at the live edge of session A, defined as the bottom sentinel being visible or the scroll offset being within a small bottom threshold of the transcript end
+- **THEN** the transcript follows the streamed content
+- **WHEN** the reader scrolls away, selects transcript text, uses keyboard navigation, opens a transcript link, opens search or command UI, or opens the tool/research drawer
+- **THEN** the transcript stops auto-following for session A
+- **AND** newly streamed content may arrive offscreen without moving the reader's viewport
+
+#### Scenario: New content marker returns to latest
+
+- **WHEN** session A receives new transcript content while the reader is not at the live edge
+- **THEN** the GUI shows a session A jump-to-latest or new-content control
+- **AND** activating that control scrolls session A until the active streamed assistant message or bottom sentinel is visible
+- **AND** the control does not react to new content from session B while session A is visible
+
+#### Scenario: Saved session restores to a meaningful turn
+
+- **WHEN** the user opens an existing session route
+- **AND** the route does not include an explicit message, research, synthesis, or scroll anchor
+- **THEN** the transcript restores to the last meaningful turn when available
+- **AND** that turn is the stored reader anchor when present, otherwise the most recent user message in the session
+- **AND** the transcript does not always force the reader to the absolute bottom
+
+#### Scenario: Explicit transcript anchor overrides default restore
+
+- **WHEN** the user opens a session through a link that targets a specific message, synthesis result, research entry, or scroll anchor
+- **THEN** the transcript scrolls to that explicit anchor rather than the default restore target
+- **AND** the explicit anchor belongs to the route session before it can update the visible transcript position
+
+#### Scenario: Layout changes preserve reading position
+
+- **WHEN** session A's visible transcript changes height because history is prepended, markdown completes, tool cards render, a tool/research drawer opens, or streamed tool results update
+- **THEN** the GUI preserves the same anchored row or visible bottom sentinel for session A
+- **AND** it does not apply a saved position, unread marker, or live-edge state from another session
+
+### Requirement: GUI Browser Validation Evidence
+
+GUI transcript scrolling and current-thread panel behavior SHALL be validated in a real browser flow, and screenshot evidence SHALL be uploaded to the implementation pull request.
+
+#### Scenario: Browser validation covers transcript states
+
+- **WHEN** the transcript scrolling behavior is implemented
+- **THEN** browser validation covers an anchored streaming turn, reader-intent freeze with the jump-to-latest control visible, saved-session restore, and layout-change position preservation
+- **AND** screenshots for those browser states are uploaded to the PR before local screenshot files are deleted
+
+#### Scenario: Browser validation covers current-thread panel sync
+
+- **WHEN** the current-thread auxiliary panel behavior is implemented
+- **THEN** browser validation covers navigating from session A to session B while the research/tool panel had been open for session A
+- **AND** the uploaded PR screenshots show that the visible panel is closed, cleared, or showing only session B content after navigation

--- a/openspec/changes/gui-concurrent-session-runtime/specs/pi-synced-gui/spec.md
+++ b/openspec/changes/gui-concurrent-session-runtime/specs/pi-synced-gui/spec.md
@@ -72,6 +72,37 @@ The GUI SHALL route every transcript-affecting mutation to an explicit session r
 - **THEN** that entry is appended to the explicitly targeted session
 - **AND** the action does not append to whichever session is currently focused in the browser
 
+### Requirement: Current-Thread Auxiliary Panels
+
+The GUI SHALL keep chat-adjacent panels that display tool calls, research evidence, sources, or run timelines scoped to the currently visible route session.
+
+#### Scenario: Panel selection identity includes session
+
+- **WHEN** the GUI stores a selected run, tool group, source list, research card, or transcript outline item for an auxiliary panel
+- **THEN** that selection identity includes the owning `sessionId`
+- **AND** the GUI does not match panel content across sessions by unscoped message id, run id, tool-call id, grouped-row id, title, or index
+
+#### Scenario: Tool panel closes or clears on session change
+
+- **WHEN** the research/tool timeline panel is open for a tool run in session A
+- **AND** the user navigates to session B
+- **THEN** the panel no longer displays session A tool calls as if they belonged to session B
+- **AND** the GUI either closes the panel, clears the panel selection, or binds it only to an explicit session B selection whose identity includes session B
+
+#### Scenario: Open panel updates from the current route session
+
+- **WHEN** the research/tool timeline panel is open while viewing session A
+- **AND** additional tool-call or tool-result events arrive for session A
+- **THEN** the panel updates from session A's current grouped rows or session store
+- **AND** late events from session B do not mutate the visible panel while session A remains the route session
+
+#### Scenario: Auto-open is session-scoped
+
+- **WHEN** session A starts or streams a tool run
+- **AND** the browser is currently viewing session B
+- **THEN** session A's tool run does not auto-open the research/tool panel over session B
+- **AND** session B's panel state is changed only by session B content or by an explicit user action in session B
+
 ### Requirement: Concurrent GUI Sessions Preserve Per-Session Writer Safety
 
 The GUI SHALL permit concurrent runs in different sessions owned by the same GUI process while preserving one writer and one active run per individual session.

--- a/openspec/changes/gui-concurrent-session-runtime/specs/stateful-market-surfaces/spec.md
+++ b/openspec/changes/gui-concurrent-session-runtime/specs/stateful-market-surfaces/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: GUI Mutations Remain Session Visible
+
+OpenCandle SHALL record GUI-originated market-state mutations in the explicitly targeted GUI route session transcript as structured state-change or synthetic tool-result entries.
+
+#### Scenario: GUI watchlist mutation is visible to the next agent turn
+
+- **WHEN** the GUI adds a symbol to a watchlist from a session-scoped surface
+- **THEN** OpenCandle persists the row in SQLite
+- **AND** appends a session-visible entry to the explicit target session containing the domain, action, instrument id, target id, and source `ui`
+- **AND** a subsequent agent turn in that same target session can see the recent action in session context
+- **AND** the mutation does not append transcript entries to another browser route merely because it is globally active or was previously focused
+
+#### Scenario: Follower GUI does not silently mutate without transcript visibility
+
+- **WHEN** the GUI is in follower mode for the explicit target session and cannot append session-visible entries there
+- **THEN** mutation controls are disabled, prompt for writer takeover, or route the mutation through a writer-owned append path for that target session
+- **AND** OpenCandle does not silently persist GUI changes that the target session transcript cannot observe
+
+#### Scenario: TUI mutation remains transcript visible
+
+- **WHEN** a TUI or agent-tool flow mutates market state
+- **THEN** the mutation is visible through the normal tool result or structured state-change entry
+- **AND** GUI and later chat turns can reconcile the persisted row with the conversation history
+
+#### Scenario: Transcript does not become source of truth
+
+- **WHEN** session entries and SQLite market state disagree
+- **THEN** SQLite market state is authoritative for saved watchlists, portfolios, predictions, alerts, and report configuration
+- **AND** transcript entries are audit/context evidence for a specific target session, not the primary market-state store

--- a/openspec/changes/gui-concurrent-session-runtime/tasks.md
+++ b/openspec/changes/gui-concurrent-session-runtime/tasks.md
@@ -17,12 +17,27 @@
 - [x] Treat active session state as UI focus only: sidebar selection, route, default composer target, and context projection.
 - [x] Store transcript events, live events, run state, abort handles, and retry metadata by `sessionId`.
 - [ ] Store pending prompts and pending request acknowledgements by `sessionId`.
+- [x] Store transcript scroll anchors, live-edge state, unread/new-content markers, and saved restore targets by `sessionId`.
+- [x] Scope research/tool timeline drawer selection by `sessionId` and clear, close, or rebind it when the route session changes.
 - [x] Ignore snapshots, chat events, and run-control results whose `sessionId` does not match the route or subscribed session store being updated.
 - [ ] Ignore or settle mutation acknowledgements only by matching `sessionId` and `requestId`.
 - [x] Ensure creating a new session navigates only after the server acknowledges the created session id.
 - [x] Ensure opening an existing session either waits for an acknowledgement or uses route-addressed bootstrap so stale `session.open` responses cannot overwrite the visible route.
 - [x] Ensure direct navigation to an existing session never falls back to the home page while that session exists.
 - [ ] Verify independent browser-tab focus when two browser clients view different sessions.
+
+## 2.5 Transcript And Panel UX
+
+- [x] Wrap or replace the plain transcript overflow container with a session-scoped scroller behavior layer.
+- [x] Anchor submitted user turns near the top of the transcript while streaming the assistant response below.
+- [x] Auto-follow streamed content only while the reader is already at the live edge.
+- [x] Stop auto-follow when the reader scrolls away, selects text, uses keyboard navigation, opens transcript links, opens search/command UI, or opens the tool/research drawer.
+- [x] Show a jump-to-latest/new-content control when the visible session receives content while the reader is not at the live edge.
+- [x] Restore saved sessions to the last meaningful turn or stored reader anchor instead of blindly forcing the absolute bottom.
+- [ ] Preserve reader position when history is prepended, markdown completes, tool cards render, tool results stream, or the inline tool/research drawer changes layout.
+- [x] Keep existing OpenCandle message, grouped tool-run, and finance-result card visuals unless a separate UI redesign change is created.
+- [x] Ensure the research/tool timeline panel renders from the current route session's grouped rows or session store, not from a stale unscoped run object.
+- [x] Prevent pending tool runs in a background session from auto-opening or updating the visible route session's panel.
 
 ## 3. Concurrency
 
@@ -57,8 +72,13 @@
 - [ ] Add browser tests for switching from a running session to another session and sending there.
 - [ ] Add browser tests for new-session creation and direct old-session navigation.
 - [ ] Add browser tests for stop/retry controls affecting only the targeted session/run.
+- [ ] Add browser tests for long streamed transcript scroll behavior: user-turn anchoring, live-edge auto-follow, reader-intent freeze, jump-to-latest, saved restore, and layout-change position preservation.
+- [ ] Add browser tests proving explicit message, research, synthesis, or scroll-anchor links override default saved-session restore only when the anchor belongs to the route session.
+- [x] Add browser tests for navigating between sessions with the research/tool timeline panel open, verifying it closes, clears, rebinds, or displays only the new route session's tool calls.
+- [ ] Capture browser screenshots for PR evidence covering: anchored streaming turn, reader-intent freeze with jump-to-latest visible, restored saved session position, explicit research/synthesis anchor navigation, and route-switch behavior with the research/tool panel no longer showing the previous thread's tool calls.
+- [ ] Upload the browser validation screenshots to the PR before deleting local screenshot files.
 - [ ] Add a Pi/TUI parity smoke test or documented harness check covering GUI-to-TUI resume, TUI-to-GUI resume, writer-lock participation, branch context, custom entries, and tool-result persistence.
-- [ ] Run focused GUI server/web tests.
-- [ ] Run browser verification on the local GUI.
-- [ ] Run `openspec validate gui-concurrent-session-runtime --strict`.
-- [ ] Run `npm test`.
+- [x] Run focused GUI server/web tests.
+- [x] Run browser verification on the local GUI.
+- [x] Run `openspec validate gui-concurrent-session-runtime --strict`.
+- [x] Run `npm test`.

--- a/tests/e2e/gui-browser.test.ts
+++ b/tests/e2e/gui-browser.test.ts
@@ -25,7 +25,7 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
     await page.goto(guiUrl, { waitUntil: "networkidle" });
 
     await expectVisible(page.getByText("OpenCandle").first());
-    await expectVisible(page.getByRole("button", { name: "New chat" }).first());
+    await expectVisible(page.getByRole("button", { name: "New chat", exact: true }).first());
     await expectVisible(page.getByRole("button", { name: "Open context" }).first());
   });
 
@@ -90,7 +90,7 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
   });
 
   it("renders missing API-key onboarding in a browser", async () => {
-    const mocked = await browser.newPage({ viewport: { width: 1024, height: 720 } });
+    const mocked = await browser.newPage({ viewport: { width: 815, height: 938 } });
     await installMockSocket(mocked, {
       modelSetup: {
         requirement: "connect_auth",
@@ -153,12 +153,14 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
     await installMockSocket(mocked);
 
     await mocked.goto(guiUrl, { waitUntil: "networkidle" });
-    await expectVisible(mocked.getByRole("button", { name: "New chat" }));
+    await expectVisible(mocked.getByRole("button", { name: "New chat", exact: true }));
     await mocked.getByRole("button", { name: "Collapse sidebar" }).click();
-    await mocked.getByRole("button", { name: "New chat" }).waitFor({ state: "detached" });
+    await mocked
+      .getByRole("button", { name: "New chat", exact: true })
+      .waitFor({ state: "detached" });
     await expectVisible(mocked.getByRole("button", { name: "Expand sidebar" }));
     await mocked.getByRole("button", { name: "Expand sidebar" }).click();
-    await expectVisible(mocked.getByRole("button", { name: "New chat" }));
+    await expectVisible(mocked.getByRole("button", { name: "New chat", exact: true }));
     await mocked.close();
   });
 
@@ -168,7 +170,7 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
     await installMockMarketState(mocked);
 
     await mocked.goto(`${guiUrl}/watchlists`, { waitUntil: "networkidle" });
-    await expectVisible(mocked.getByRole("button", { name: "New chat" }));
+    await expectVisible(mocked.getByRole("button", { name: "New chat", exact: true }));
     await expectVisible(mocked.getByRole("heading", { name: "Watchlists" }));
     await expectVisible(mocked.getByRole("button", { name: "Refresh prices" }));
     await expect(mocked.getByRole("button", { name: "Quotes" }).count()).resolves.toBe(0);
@@ -203,7 +205,9 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
     await expectVisible(mocked.getByRole("heading", { name: "Portfolios" }));
 
     await mocked.getByRole("button", { name: "Collapse sidebar" }).click();
-    await mocked.getByRole("button", { name: "New chat" }).waitFor({ state: "detached" });
+    await mocked
+      .getByRole("button", { name: "New chat", exact: true })
+      .waitFor({ state: "detached" });
     await expectVisible(mocked.getByRole("button", { name: "Expand sidebar" }));
     await mocked.getByRole("button", { name: "Expand sidebar" }).click();
     await expectVisible(mocked.getByRole("link", { name: "Alerts" }));
@@ -353,6 +357,86 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
 
     await mocked.getByRole("button", { name: "Close drawer" }).click();
     await dialog.waitFor({ state: "detached" });
+    await mocked.close();
+  });
+
+  it("closes an open tool drawer when navigating to another session", async () => {
+    const mocked = await browser.newPage({ viewport: { width: 1024, height: 720 } });
+    await installMockHttpBootstrap(mocked, {
+      sessionId: "session-a",
+      entries: toolRunEntries("tool-call-aapl", "AAPL"),
+      sessionBootstraps: {
+        "session-b": {
+          entries: [
+            {
+              type: "message",
+              id: "session-b-user",
+              timestamp: new Date().toISOString(),
+              message: { role: "user", content: "Session B prompt" },
+            },
+            {
+              type: "message",
+              id: "session-b-assistant",
+              timestamp: new Date().toISOString(),
+              message: { role: "assistant", content: "Session B answer" },
+            },
+          ],
+        },
+      },
+    });
+
+    await mocked.goto(guiUrl, { waitUntil: "networkidle" });
+    const card = mocked.locator("button").filter({ hasText: "Market lookup" });
+    await expectVisible(card.first());
+    await card.first().click();
+    await expectVisible(mocked.getByRole("button", { name: "Close drawer" }));
+
+    await mocked.goto(`${guiUrl}/sessions/session-b`, { waitUntil: "networkidle" });
+    await expectVisible(mocked.getByText("Session B prompt"));
+    await expect(mocked.getByRole("button", { name: "Close drawer" }).count()).resolves.toBe(0);
+    await mocked.close();
+  });
+
+  it("restores deep-linked transcript anchors and offers jump to latest", async () => {
+    const mocked = await browser.newPage({ viewport: { width: 1024, height: 720 } });
+    await installMockHttpBootstrap(mocked, {
+      entries: longTranscriptEntries(44),
+    });
+
+    await mocked.goto(`${guiUrl}/?messageId=user-31`, { waitUntil: "networkidle" });
+    await mocked.waitForSelector('[data-message-id="user-31"]');
+    await mocked.waitForFunction(() => {
+      const viewport = document.querySelector("[data-chat-transcript]");
+      const anchor = document.querySelector('[data-message-id="user-31"]');
+      if (!viewport || !anchor) return false;
+      const viewportBox = viewport.getBoundingClientRect();
+      const anchorBox = anchor.getBoundingClientRect();
+      const top = anchorBox.top - viewportBox.top;
+      return top >= 0 && top < viewport.clientHeight / 4;
+    });
+    const anchorPosition = await mocked.evaluate(() => {
+      const viewport = document.querySelector("[data-chat-transcript]");
+      const anchor = document.querySelector('[data-message-id="user-31"]');
+      const viewportBox = viewport.getBoundingClientRect();
+      const anchorBox = anchor.getBoundingClientRect();
+      return {
+        top: anchorBox.top - viewportBox.top,
+        quarter: viewport.clientHeight / 4,
+      };
+    });
+    expect(anchorPosition.top).toBeGreaterThanOrEqual(0);
+    expect(anchorPosition.top).toBeLessThan(anchorPosition.quarter);
+
+    await mocked.locator("[data-chat-transcript]").evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    await expectVisible(mocked.getByRole("button", { name: "Jump to latest" }));
+    await mocked.getByRole("button", { name: "Jump to latest" }).click();
+    const nearBottom = await mocked.locator("[data-chat-transcript]").evaluate((element) => {
+      return element.scrollHeight - element.scrollTop - element.clientHeight <= 48;
+    });
+    expect(nearBottom).toBe(true);
     await mocked.close();
   });
 
@@ -736,7 +820,7 @@ describe.skipIf(!runGuiBrowser)("GUI browser smoke", () => {
       null,
       { timeout: 5_000 },
     );
-    await mocked.getByRole("button", { name: "New chat" }).click();
+    await mocked.getByRole("button", { name: "New chat", exact: true }).click();
     expect(pageErrors).toEqual([]);
     await mocked.getByLabel("Message OpenCandle").fill("Fallback browser prompt");
     await mocked.getByRole("button", { name: "Send" }).click();
@@ -798,7 +882,7 @@ async function submitPrompt(page: Page, prompt: string): Promise<void> {
 
 async function startNewChat(page: Page): Promise<void> {
   await waitForRunIdle(page);
-  await page.getByRole("button", { name: "New chat" }).click();
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
   await expectVisible(page.getByRole("heading", { name: "What are we watching?" }));
 }
 
@@ -828,11 +912,221 @@ function hasScrollableAncestor(element: Element): boolean {
   return false;
 }
 
+function toolRunEntries(toolCallId: string, symbol: string) {
+  return [
+    {
+      type: "message",
+      id: `assistant-${symbol.toLowerCase()}-tool`,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: "get_stock_quote",
+            arguments: { symbol },
+          },
+        ],
+      },
+    },
+    {
+      type: "message",
+      id: `tool-result-${symbol.toLowerCase()}`,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName: "get_stock_quote",
+        content: `${symbol} quote`,
+        details: { symbol },
+      },
+    },
+  ];
+}
+
+function longTranscriptEntries(count: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const turn = index + 1;
+    const role = turn % 2 === 0 ? "assistant" : "user";
+    const id = `${role}-${turn}`;
+    return {
+      type: "message",
+      id,
+      timestamp: new Date().toISOString(),
+      message: {
+        role,
+        content:
+          role === "user"
+            ? `User turn ${turn}: compare AAPL, MSFT, and NVDA with enough detail for scrolling.`
+            : `Assistant turn ${turn}: here is a concise market summary with valuation, momentum, risk, and data quality notes.`,
+      },
+    };
+  });
+}
+
+async function installMockHttpBootstrap(
+  page: Page,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await page.addInitScript((mockOverrides) => {
+    const bootSessionId = mockOverrides.sessionId ?? "mock-session";
+    window.WebSocket = function BrokenWebSocket() {
+      throw new TypeError("WebSocket is not a constructor");
+    };
+    window.fetch = (input) => {
+      const rawUrl = typeof input === "string" ? input : input.url;
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname === "/api/bootstrap") {
+        const entries = mockOverrides.entries ?? [];
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              role: mockOverrides.role ?? "writer",
+              sessionId: bootSessionId,
+              sessions: mockOverrides.sessions ?? [],
+              catalog: mockOverrides.catalog ?? { tools: [], workflows: [], providers: [] },
+              modelSetup: mockOverrides.modelSetup ?? {
+                requirement: "ready",
+                providers: [],
+                availableModels: [],
+              },
+              askUserPrompts: mockOverrides.askUserPrompts ?? [],
+              snapshot: snapshotPayload(bootSessionId, entries, mockOverrides),
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        );
+      }
+      const match = url.pathname.match(/^\/api\/sessions\/([^/]+)\/bootstrap$/);
+      if (match) {
+        const sessionId = decodeURIComponent(match[1]);
+        const snapshot = mockOverrides.sessionBootstraps?.[sessionId];
+        if (!snapshot) return Promise.resolve(new Response("Not found", { status: 404 }));
+        const entries = snapshot.entries ?? [];
+        return Promise.resolve(
+          new Response(JSON.stringify(snapshotPayload(sessionId, entries, snapshot)), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response("Not found", { status: 404 }));
+    };
+
+    function snapshotPayload(sessionId, entries, source) {
+      return {
+        sessionId,
+        catalog: source.catalog ?? { tools: [], workflows: [], providers: [] },
+        modelSetup: source.modelSetup ?? {
+          requirement: "ready",
+          providers: [],
+          availableModels: [],
+        },
+        entries,
+        events: source.events ?? entriesToEvents(entries, sessionId),
+        state: source.state ?? {
+          watchlist: [],
+          activeAnalyses: [],
+          recentResearch: [],
+          dataQuality: { softGaps: [], hardSkips: [] },
+        },
+      };
+    }
+
+    function entriesToEvents(entries, fallbackSessionId) {
+      let seq = 1;
+      const events = [];
+      const seenToolCalls = new Set();
+      for (const entry of entries) {
+        const sessionId = entry.sessionId ?? fallbackSessionId;
+        if (entry.type !== "message") continue;
+        const message = entry.message || {};
+        if (message.role === "user" || message.role === "assistant") {
+          events.push({
+            type: "message.created",
+            sessionId,
+            messageId: entry.id,
+            role: message.role,
+            seq: seq++,
+          });
+          const content = [];
+          for (const part of Array.isArray(message.content)
+            ? message.content
+            : [{ type: "text", text: String(message.content || "") }]) {
+            if (part.type === "toolCall") {
+              seenToolCalls.add(part.id);
+              content.push({ type: "tool", toolCallId: part.id });
+              events.push({
+                type: "tool.started",
+                sessionId,
+                toolCallId: part.id,
+                messageId: entry.id,
+                name: part.name,
+                input: part.arguments || {},
+                seq: seq++,
+              });
+            } else {
+              content.push(part);
+            }
+          }
+          events.push({
+            type: "message.completed",
+            sessionId,
+            messageId: entry.id,
+            content,
+            seq: seq++,
+          });
+        }
+        if (message.role === "toolResult") {
+          const toolCallId = message.toolCallId || `tool-${entry.id}`;
+          if (!seenToolCalls.has(toolCallId)) {
+            events.push({
+              type: "tool.started",
+              sessionId,
+              toolCallId,
+              messageId: entry.id,
+              name: message.toolName || "tool",
+              input: message.details?.args || {},
+              seq: seq++,
+            });
+          }
+          events.push({
+            type: message.isError ? "tool.failed" : "tool.completed",
+            sessionId,
+            toolCallId,
+            ...(message.isError
+              ? {
+                  error: {
+                    message: String(message.content || ""),
+                    details: message.details,
+                  },
+                }
+              : {
+                  output: {
+                    content: [{ type: "text", text: String(message.content || "") }],
+                    details: message.details,
+                    isError: Boolean(message.isError),
+                  },
+                }),
+            seq: seq++,
+          });
+        }
+      }
+      return events;
+    }
+  }, overrides);
+}
+
 async function installMockSocket(
   page: Page,
   overrides: Record<string, unknown> = {},
 ): Promise<void> {
   await page.addInitScript((mockOverrides) => {
+    const bootSessionId = mockOverrides.sessionId ?? "mock-session";
     class MockWebSocket extends EventTarget {
       static CONNECTING = 0;
       static OPEN = 1;
@@ -848,12 +1142,12 @@ async function installMockSocket(
       constructor() {
         super();
         this.sessions = [...(mockOverrides.sessions ?? [])];
-        queueMicrotask(() => {
+        setTimeout(() => {
           this.onopen?.(new Event("open"));
           this.emit({
             type: "boot",
             role: mockOverrides.role ?? "writer",
-            sessionId: "mock-session",
+            sessionId: bootSessionId,
             catalog: mockOverrides.catalog ?? { tools: [], workflows: [], providers: [] },
             modelSetup: mockOverrides.modelSetup ?? {
               requirement: "ready",
@@ -863,7 +1157,7 @@ async function installMockSocket(
           });
           this.emit({
             type: "state.snapshot",
-            sessionId: "mock-session",
+            sessionId: bootSessionId,
             state: mockOverrides.dashboard ?? {
               watchlist: [],
               activeAnalyses: [],
@@ -871,10 +1165,11 @@ async function installMockSocket(
               dataQuality: { softGaps: [], hardSkips: [] },
             },
             entries: mockOverrides.entries ?? [],
-            events: mockOverrides.events ?? entriesToEvents(mockOverrides.entries ?? []),
+            events:
+              mockOverrides.events ?? entriesToEvents(mockOverrides.entries ?? [], bootSessionId),
           });
           this.emit({ type: "sessions", sessions: this.sessions });
-        });
+        }, 0);
       }
 
       send(message) {
@@ -905,14 +1200,16 @@ async function installMockSocket(
       }
     }
 
-    function entriesToEvents(entries) {
+    function entriesToEvents(entries, fallbackSessionId = bootSessionId) {
       let seq = 1;
       const events = [];
       const seenToolCalls = new Set();
       for (const entry of entries) {
+        const sessionId = entry.sessionId ?? fallbackSessionId;
         if (entry.type === "custom_message") {
           events.push({
             type: "custom.message",
+            sessionId,
             messageId: entry.id,
             customType: entry.customType || "custom",
             content: normalizeContent(entry.content),
@@ -923,9 +1220,16 @@ async function installMockSocket(
         if (entry.type !== "message") continue;
         const message = entry.message || {};
         if (message.role === "user") {
-          events.push({ type: "message.created", messageId: entry.id, role: "user", seq: seq++ });
+          events.push({
+            type: "message.created",
+            sessionId,
+            messageId: entry.id,
+            role: "user",
+            seq: seq++,
+          });
           events.push({
             type: "message.completed",
+            sessionId,
             messageId: entry.id,
             content: normalizeContent(message.content),
             seq: seq++,
@@ -935,6 +1239,7 @@ async function installMockSocket(
         if (message.role === "assistant") {
           events.push({
             type: "message.created",
+            sessionId,
             messageId: entry.id,
             role: "assistant",
             seq: seq++,
@@ -948,6 +1253,7 @@ async function installMockSocket(
               content.push({ type: "tool", toolCallId: part.id });
               events.push({
                 type: "tool.started",
+                sessionId,
                 toolCallId: part.id,
                 messageId: entry.id,
                 name: part.name,
@@ -958,7 +1264,13 @@ async function installMockSocket(
               content.push(part);
             }
           }
-          events.push({ type: "message.completed", messageId: entry.id, content, seq: seq++ });
+          events.push({
+            type: "message.completed",
+            sessionId,
+            messageId: entry.id,
+            content,
+            seq: seq++,
+          });
           continue;
         }
         if (message.role === "toolResult") {
@@ -966,6 +1278,7 @@ async function installMockSocket(
           if (!seenToolCalls.has(toolCallId)) {
             events.push({
               type: "tool.started",
+              sessionId,
               toolCallId,
               messageId: entry.id,
               name: message.toolName || "tool",
@@ -975,6 +1288,7 @@ async function installMockSocket(
           }
           events.push({
             type: message.isError ? "tool.failed" : "tool.completed",
+            sessionId,
             toolCallId,
             ...(message.isError
               ? { error: { message: textContent(message.content), details: message.details } }

--- a/tests/unit/gui-web/optimistic-user-message.test.ts
+++ b/tests/unit/gui-web/optimistic-user-message.test.ts
@@ -23,6 +23,19 @@ describe("optimistic GUI user messages", () => {
     ]);
   });
 
+  it("keeps the session id on rendered rows for route-scoped UI state", () => {
+    const rows = chatRowsFromEvents(
+      [],
+      createOptimisticUserMessageEvents("What is AAPL trading at?", "session-a"),
+      "session-a",
+    );
+
+    expect(rows[0]).toMatchObject({
+      type: "user_message",
+      sessionId: "session-a",
+    });
+  });
+
   it("keeps one user bubble when the persisted server message arrives after the optimistic one", () => {
     const optimistic = createOptimisticUserMessageEvents("Compare MSFT and GOOGL");
     const persisted = persistedUserEvents("persisted-user", "Compare MSFT and GOOGL");

--- a/tests/unit/gui-web/tool-run-grouper.test.ts
+++ b/tests/unit/gui-web/tool-run-grouper.test.ts
@@ -30,4 +30,51 @@ describe("groupToolRuns", () => {
       }),
     ]);
   });
+
+  it("carries session identity from assistant tool calls into grouped runs", () => {
+    const rows = [
+      {
+        id: "message-assistant-1",
+        type: "assistant_message",
+        sessionId: "session-a",
+        messageId: "assistant-1",
+        content: [
+          {
+            type: "toolCall",
+            id: "quote-1",
+            name: "get_stock_quote",
+            arguments: { symbol: "AAPL" },
+            sessionId: "session-a",
+          },
+        ],
+      },
+      {
+        id: "tool-quote-1",
+        type: "tool_result",
+        sessionId: "session-a",
+        message: {
+          toolCallId: "quote-1",
+          toolName: "get_stock_quote",
+          content: [{ type: "text", text: "AAPL quote" }],
+          isError: false,
+          sessionId: "session-a",
+        },
+      },
+    ];
+
+    expect(groupToolRuns(rows)).toEqual([
+      expect.objectContaining({
+        type: "tool_run",
+        id: "run-quote-1",
+        sessionId: "session-a",
+        steps: [
+          expect.objectContaining({
+            id: "quote-1",
+            sessionId: "session-a",
+            result: expect.objectContaining({ sessionId: "session-a" }),
+          }),
+        ],
+      }),
+    ]);
+  });
 });

--- a/tests/unit/gui-web/transcript-scroller.test.ts
+++ b/tests/unit/gui-web/transcript-scroller.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { pendingTranscriptAnchorId } from "../../../gui/web/src/features/chat/ChatPanel.jsx";
+
+describe("transcript scroller anchoring", () => {
+  it("does not anchor a new latest user row after reader intent freezes scrolling", () => {
+    expect(
+      pendingTranscriptAnchorId({
+        latestUserChanged: true,
+        latestUserRowId: "message-user-2",
+        following: false,
+      }),
+    ).toBe("");
+  });
+
+  it("keeps explicit anchors and session restore anchors active", () => {
+    expect(
+      pendingTranscriptAnchorId({
+        hasNewExplicitAnchor: true,
+        scrollAnchorId: "user-31",
+        latestUserChanged: true,
+        latestUserRowId: "message-user-33",
+        following: false,
+      }),
+    ).toBe("user-31");
+
+    expect(
+      pendingTranscriptAnchorId({
+        sessionChanged: true,
+        latestUserRowId: "message-user-33",
+        following: false,
+      }),
+    ).toBe("message-user-33");
+  });
+});


### PR DESCRIPTION
## Summary
- add session-scoped transcript scrolling with explicit message anchors, latest-user restore, reader-intent freeze, and jump-to-latest
- scope tool drawer selection and auto-open state by session so route changes cannot show a stale thread's tool run
- update OpenSpec proposal/design/spec/tasks for the transcript and research/tool-panel behavior

## Validation
- `npx biome check gui/web/src/features/chat/ChatPanel.jsx gui/web/src/features/chat/chat-rows.js gui/web/src/features/chat/tool-drawer-context.jsx gui/web/src/features/chat/steps-card.jsx gui/web/src/features/chat/tool-run-grouper.js gui/web/src/App.jsx gui/web/src/router.jsx tests/e2e/gui-browser.test.ts tests/unit/gui-web/optimistic-user-message.test.ts tests/unit/gui-web/tool-run-grouper.test.ts`
- `npm run gui:web:build`
- `npx vitest run tests/unit/gui-web/optimistic-user-message.test.ts tests/unit/gui-web/tool-run-grouper.test.ts tests/unit/gui-web/chat-panel-events.test.ts`
- `OPENCANDLE_GUI_BROWSER=1 npx vitest run --config vitest.config.gui.ts -t "closes an open tool drawer|restores deep-linked"`
- `npm test`
- `npm run build`
- `openspec validate gui-concurrent-session-runtime --strict`
- `graphify update .`

## Browser Evidence
Screenshots will be uploaded in a follow-up PR comment.

## Notes
- I did not archive `gui-concurrent-session-runtime`; it still has 35 unchecked tasks outside this scoped implementation.
- The full `npm run test:gui:browser` run still has unrelated/local-state failures in live tool availability, market-state smoke expectations, and older socket/fallback assumptions. The new targeted browser tests for this PR pass.
