### PR TITLE
Release v0.11.0

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,14 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     steps:
       - id: deployment
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+      - name: Wait before deployment retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+      - id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub Pages deployment now retries once after a transient `deploy-pages` failure before failing the workflow.
+
 ## [0.11.0] - 2026-07-03
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.11.0] - 2026-07-03
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.11.0] - 2026-07-03
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - GitHub Pages deployment now retries once after a transient `deploy-pages` failure before failing the workflow.
+- Session-entry wait tests now use deterministic timers for async workflow settlement, removing a Node 24 CI timing flake.
 
 ## [0.11.0] - 2026-07-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Financial trading & investing agent",
   "license": "MIT",
   "homepage": "https://opencandle.app",

--- a/tests/unit/gui-server/session-entry-wait.test.ts
+++ b/tests/unit/gui-server/session-entry-wait.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   findUnresolvedToolCalls,
   waitForEntryCount,
   waitForNewEntryId,
   waitForSessionTurnSettlement,
 } from "../../../gui/server/session-entry-wait.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("waitForEntryCount", () => {
   it("waits until the entry count advances past the previous count", async () => {
@@ -47,7 +51,11 @@ describe("waitForEntryCount", () => {
 
 describe("waitForSessionTurnSettlement", () => {
   it("waits through an async workflow-dispatched turn before returning", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
     let isStreaming = false;
+    let resolvedAt: number | undefined;
     setTimeout(() => {
       isStreaming = true;
     }, 5);
@@ -55,14 +63,21 @@ describe("waitForSessionTurnSettlement", () => {
       isStreaming = false;
     }, 20);
 
-    const started = Date.now();
-    await waitForSessionTurnSettlement(() => ({ isStreaming, pendingMessageCount: 0 }), {
+    const settled = waitForSessionTurnSettlement(() => ({ isStreaming, pendingMessageCount: 0 }), {
       timeoutMs: 100,
       intervalMs: 1,
       idleGraceMs: 10,
+    }).then(() => {
+      resolvedAt = Date.now();
     });
 
-    expect(Date.now() - started).toBeGreaterThanOrEqual(28);
+    await vi.advanceTimersByTimeAsync(29);
+    expect(resolvedAt).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await settled;
+
+    expect(resolvedAt).toBe(30);
   });
 
   it("waits until queued follow-ups clear and the session remains idle", async () => {


### PR DESCRIPTION
## Summary
- release v0.11.0
- reset changelog with a fresh [Unreleased] section

## Validation
- npm run release:check passed locally during release preparation
- packed install smoke passed
- docs link check passed

## Notes
Direct push to protected main was rejected because required status checks must run first, so this PR carries the release commits through branch protection.