### PR TITLE
WP5 coordinator spec closeout

### DIFF
--- a/openspec/changes/transparent-local-session-coordinator/design.md
+++ b/openspec/changes/transparent-local-session-coordinator/design.md
@@ -74,7 +74,7 @@ Alternative considered: keep one process-wide role and hide it with copy changes
 
 TUI participation is not just a UI copy change. If a TUI owns a session and a GUI wants to write to that session, the TUI process must expose a local coordinator listener or Pi-native IPC endpoint that can accept authenticated forwarded session actions. If the TUI is a non-owner surface, it must subscribe to, poll, or otherwise tail the same session transcript so writes accepted by the GUI owner become visible in the TUI.
 
-The initial implementation uses authenticated loopback HTTP for GUI-owned coordinator forwarding: writer lock metadata publishes the owner endpoint and a local coordinator capability, non-owner GUI servers forward supported session actions to that endpoint, and the owner rejects calls that do not include the capability. The transport still must support both GUI-owned and TUI-owned topologies before the TUI+GUI verification task can pass. If the implementation cannot provide live TUI transcript updates in the first slice, the proposal must narrow the TUI verification to the concrete topology that is actually supported.
+The initial implementation uses authenticated loopback HTTP for GUI-owned and TUI-owned coordinator forwarding: writer lock metadata publishes the owner endpoint and a local coordinator capability, non-owner surfaces forward supported session actions to that endpoint, and the owner rejects calls that do not include the capability. TUI-owned sessions expose a loopback `/api/local-coordinator/chat-run` endpoint. GUI-owned sessions can be joined by an interactive TUI only when the writer lock includes coordinator metadata and stdin is a TTY; that follower proxy forwards prompts through the owner and polls the persisted session file for transcript updates. Non-interactive non-owner TUI runs fail closed with neutral syncing language. The full TUI+GUI verification task remains open until WP7 validates this concrete topology.
 
 Alternative considered: verify only GUI-to-GUI coordination and leave TUI to manual use. Rejected because the user-facing problem includes local TUI/GUI overlap.
 
@@ -156,5 +156,9 @@ Rollback is straightforward while the existing lock remains intact: disable prox
 
 ## Open Questions
 
-- What heartbeat interval, stale grace, and action dedupe retention values fit OpenCandle's longest local runs while still recovering crashed owners quickly?
 - Does Pi expose any enforceable stream-write/run-continuation hook that could support stronger fencing in a future change?
+
+## Resolution of Open Questions
+
+- **Heartbeat, stale grace, and action dedupe retention:** resolved as implemented. Writer lock stale grace is `DEFAULT_STALE_GRACE_MS = 15_000` in `src/pi/session-writer-lock.ts`. GUI and TUI writer-lock heartbeats refresh every 5,000 ms during active ownership and transient acquired locks. Coordinator accepted-action dedupe retention is 10 minutes (`DEFAULT_DEDUPE_RETENTION_MS = 10 * 60 * 1000` in `gui/server/local-session-coordinator.ts`, mirrored by the TUI coordinator). The invariant is that dedupe retention must be greater than or equal to the retry/recovery horizon. Because automatic retry across owner recovery remains disabled in v1, the current 10-minute retention is sufficient for in-owner reconnect/proxy retries and same-owner duplicate suppression.
+- **Future fencing hook:** unresolved for a future change. No stronger Pi stream-write fencing is claimed by this change.

--- a/openspec/changes/transparent-local-session-coordinator/specs/local-session-coordination/spec.md
+++ b/openspec/changes/transparent-local-session-coordinator/specs/local-session-coordination/spec.md
@@ -34,7 +34,7 @@ OpenCandle SHALL evaluate local ownership per target session and SHALL NOT recov
 #### Scenario: Owner process is gone
 - **WHEN** the recorded owner process identity is no longer alive or the owner is otherwise definitively abandoned
 - **THEN** OpenCandle may recover ownership for that target session
-- **AND** retries the pending session action once under the recovered owner
+- **AND** the original surface receives a retryable syncing or reconnecting result instead of automatically replaying an action whose acceptance status is unknown
 
 #### Scenario: Owner PID is reused or abandonment is ambiguous
 - **WHEN** OpenCandle cannot prove the recorded owner process identity is the original live owner or a definitively abandoned owner
@@ -103,10 +103,11 @@ OpenCandle SHALL attach stable action identifiers to supported session mutating 
 - **THEN** the coordinator applies it at most once for that session
 - **AND** returns or broadcasts the accepted result for that action
 
-#### Scenario: Accepted action may be retried after owner recovery
+#### Scenario: Accepted action is not automatically retried after owner recovery
 - **WHEN** a dead-owner recovery may retry an action whose prior acceptance status is unknown
-- **THEN** OpenCandle uses transcript metadata, durable per-session action records, or an equivalent tested mechanism to avoid duplicating an already accepted action
-- **AND** it does not automatically retry the action if duplicate prevention cannot be guaranteed
+- **THEN** OpenCandle surfaces a retryable error to the non-owner surface
+- **AND** it does not automatically retry the action across owner recovery in v1
+- **AND** durable action-id persistence remains deferred until automatic retry across owner recovery is intentionally enabled
 
 #### Scenario: User intentionally repeats an action
 - **WHEN** the user deliberately submits the same prompt text again as a new action
@@ -139,10 +140,12 @@ OpenCandle SHALL describe coordination failures and recovery using user-facing c
 ### Requirement: Cross-Surface Verification Contract
 OpenCandle SHALL verify transparent local coordination with real GUI and TUI surfaces, including Browser-driven GUI checks and multiple clients submitting messages.
 
-#### Scenario: GUI and TUI stay synchronized
-- **WHEN** a TUI session and GUI browser view are open for the same local session
-- **THEN** messages submitted from either surface appear in the other surface after synchronization
-- **AND** neither surface exposes writer/follower terminology during the successful flow
+#### Scenario: GUI and TUI use the supported v1 topology
+- **WHEN** a TUI-owned session and GUI browser view target the same local session
+- **THEN** the GUI can forward supported session actions through the TUI owner endpoint and observe the accepted transcript update after synchronization
+- **AND** when a GUI-owned persisted session is joined from an interactive TUI with coordinator metadata, the TUI can forward prompts through the GUI owner and poll the session file for transcript updates
+- **AND** a non-interactive non-owner TUI reports neutral syncing language instead of silently tailing or writing directly
+- **AND** neither surface exposes writer/follower terminology during the supported successful flow
 
 #### Scenario: TUI owns the session coordinator
 - **WHEN** a TUI owns the target session and a GUI Browser client submits a supported session action
@@ -150,9 +153,10 @@ OpenCandle SHALL verify transparent local coordination with real GUI and TUI sur
 - **AND** the GUI observes the accepted transcript update after synchronization
 
 #### Scenario: GUI owns the session coordinator
-- **WHEN** the GUI owns the target session and the TUI is also viewing that session
-- **THEN** the TUI receives, tails, polls, or otherwise renders transcript updates accepted by the GUI owner
-- **AND** the TUI does not require a separate competing writer to stay in sync
+- **WHEN** the GUI owns the target persisted session and an interactive TUI opens the same session while coordinator metadata is available
+- **THEN** the TUI forwards prompts to the GUI owner rather than acquiring a competing writer lock
+- **AND** the TUI polls the persisted session file for new transcript entries
+- **AND** broader live TUI tailing outside this interactive follower proxy remains deferred
 
 #### Scenario: Multiple agents submit through GUI clients
 - **WHEN** two automated agents or browser clients submit messages through local GUI clients for the same session

--- a/openspec/changes/transparent-local-session-coordinator/tasks.md
+++ b/openspec/changes/transparent-local-session-coordinator/tasks.md
@@ -24,7 +24,6 @@
 - [x] 3.1 Define a session action envelope with `sessionId`, `actionId`, action type, payload, and source surface.
 - [x] 3.2 Add action-id dedupe tests for session prompts, direct tool invocation, run controls, and `ask_user` answers/cancels.
 - [x] 3.3 Implement coordinator-side dedupe for accepted session action IDs with retention at least as long as the retry/recovery horizon selected in implementation.
-- [ ] 3.4 Persist action IDs in transcript metadata, a durable per-session action store, or an equivalent tested mechanism before enabling automatic retry across owner recovery.
 - [x] 3.5 Update GUI write call sites to reuse action IDs only for retries of the same user action and mint fresh IDs for intentional repeats.
 - [x] 3.6 Update TUI chat write call sites to use the same action envelope after GUI proxying is stable.
 - [x] 3.7 Return a neutral busy/retry state for a second prompt submitted while a session run is active, rather than silently queueing or starting a competing run.
@@ -43,7 +42,7 @@
 
 - [x] 5.1 Add GUI browser regression coverage for two browser tabs submitting through one coordinator without exposing writer/follower wording.
 - [x] 5.2 Add TUI coordinator listener or chosen IPC support so a GUI Browser client can forward supported session actions to a TUI-owned session.
-- [ ] 5.3 Add TUI transcript subscription, polling, or tailing so a non-owner TUI can render session updates accepted by a GUI owner.
+- [ ] 5.3 Add full TUI transcript subscription, polling, or tailing so a non-owner TUI can render session updates accepted by a GUI owner outside the v1 interactive follower proxy. Note 2026-07-03: v1 supports an interactive TTY follower proxy that forwards prompts to a GUI owner and polls the persisted session file; broader live-following remains deferred.
 - [ ] 5.4 Add a scripted TUI plus GUI smoke that opens the same session in TUI and in the GUI Browser, sends a message from each supported topology, and verifies both surfaces converge on the same transcript.
 - [x] 5.5 Add a multi-agent/client smoke where two automated GUI clients submit messages and the coordinator serializes admitted actions into one canonical transcript while returning busy/retry for non-admissible concurrent prompts.
 - [x] 5.6 Add stale-owner recovery verification where one owner process exits, another recovers, and the old dead-owner lock does not block the new surface.
@@ -56,11 +55,11 @@
 - [x] 6.1 Run `npm test`.
 - [x] 6.2 Run `npx tsc --noEmit`.
 - [x] 6.3 Run targeted GUI browser tests with the Browser-visible GUI session.
-- [ ] 6.4 Run the TUI plus GUI Browser smoke from task 5.4 before marking implementation complete.
+- [ ] 6.4 Run the TUI plus GUI Browser smoke from task 5.4 before marking implementation complete. Verification owned by WP7 of docs/internal/openspec-backlog-cleanup-plan.md; this change must not be archived until WP7 lands.
 - [x] 6.5 Update `CHANGELOG.md` under `[Unreleased]`.
 - [x] 6.6 Run `graphify update .` after implementation changes.
 
 ## Deferred Follow-Up
 
-- [ ] Persist accepted action IDs across coordinator owner recovery before enabling automatic replay of actions with unknown acceptance status.
+- [ ] 3.4 decision, recorded 2026-07-03: automatic retry across owner recovery stays disabled in v1. Persist accepted action IDs across coordinator owner recovery only if automatic replay of actions with unknown acceptance status is intentionally enabled later.
 - [ ] Add full non-owner TUI transcript tailing for GUI-owned sessions; this implementation verifies TUI-owned forwarding and harness execution, but the TUI still needs a dedicated read-only/live-following mode.


### PR DESCRIPTION
## Summary
- Edited `transparent-local-session-coordinator` only; no archive was performed.
- Resolved the timing constants in `design.md`: stale grace 15s, heartbeat 5s, dedupe retention 10 minutes, plus the dedupe >= retry/recovery horizon invariant with owner-recovery auto-retry disabled in v1.
- Updated the local-session-coordination spec to state that accepted actions are not automatically retried after owner recovery; users receive a retryable syncing/reconnecting result.
- Narrowed the GUI/TUI topology to the supported v1 behavior and left broader TUI live-following plus WP7 verification deferred.
- Left tasks 1.8, 5.4, and 6.4 unchecked; added the required WP7 pointer on 6.4.

## Validation
```text
$ openspec validate --strict transparent-local-session-coordinator
Change 'transparent-local-session-coordinator' is valid
```

## Required Checks
```text
$ npm test

> opencandle@0.11.0 pretest
> npm run check:node

> opencandle@0.11.0 check:node
> node scripts/check-node-version.mjs

> opencandle@0.11.0 test
> vitest run

RUN  v4.1.9 /Users/kahtaf/Documents/workspace/opencandle-wp5

Test Files  218 passed (218)
Tests  2296 passed (2296)
Duration  17.04s
```
Note: first `npm test` attempt failed before tests because local dependencies were missing (`better-sqlite3` import from `scripts/check-node-version.mjs`). Ran `npm install`, reverted npm lockfile metadata churn from the working diff, then reran `npm test` successfully as shown above.
```text
$ npx tsc --noEmit
# no output; exit 0
```
```text
$ npx biome ci .
Checked 593 files in 258ms. No fixes applied.
Found 494 warnings.
Found 38 infos.
# exit 0
```
