### PR TITLE
docs: rewrite forget command openspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrote the OpenSpec `/forget` proposal to define deterministic matcher semantics, durable forget-list storage, non-destructive AI-context suppression surfaces, confirmation/listing behavior, undo, and verification requirements.
+
 ### Fixed
 
 - Autoreview now skips the React Doctor changed-scope gate for commit/range reviews whose reviewed head is not the checked-out `HEAD`, preventing unrelated later GUI changes from failing historical reviews.

--- a/openspec/changes/forget-command/proposal.md
+++ b/openspec/changes/forget-command/proposal.md
@@ -1,16 +1,26 @@
 ## Why
 
-Router prior-turn context now includes recent user and assistant text. That improves follow-up routing, but it also makes conversational text a separate privacy surface from structured memory. Users need a local `/forget` control that removes matching conversational context and matching structured memory before the LLM router sees future turns.
+Router prior-turn context, structured memory, saved market-state prompt context, and Pi compaction summaries are all AI-visible history surfaces. Users need a deterministic local `/forget` control that suppresses matching historical context from future model prompts without deleting their saved market data or rewriting visible transcripts.
 
 ## What Changes
 
-- Add a `/forget` command that accepts a topic, ticker, or free-text phrase.
-- Scrub matching structured memory rows and prevent matching prior-turn text from being included in future router context.
-- Emit a session-visible confirmation describing what was forgotten without echoing sensitive text.
-- Keep deletion local to OpenCandle/Pi state; no provider-side deletion is implied.
+- Define `/forget <topic>` where `topic` is a ticker, phrase, or free text, with deterministic ticker and phrase matching.
+- Persist forget entries in the OpenCandle memory SQLite database so suppression applies across sessions and processes.
+- Filter four AI-visible history surfaces at read time: `priorTurns`, structured memory/prompt-context rows, saved market-state summaries, and compaction or branch summaries used for prior-turn derivation.
+- Keep suppression non-destructive: saved watchlist, portfolio, alert, report, transcript, and memory rows stay on disk and in the GUI/TUI unless a separate user action deletes them.
+- Define confirmation, listing, and undo behavior for `/forget`, `/forget` with no argument, and `/forget --remove <topic>`.
 
-## Impact
+## Scope
 
-- **Code:** `src/pi/`, `src/runtime/session-coordinator.ts`, `src/memory/`
-- **Tests:** command behavior, prior-turn scrub, structured-memory scrub, non-matching context retained
-- **Dependencies:** none expected
+The implementation is expected to touch `src/pi/`, `src/runtime/session-coordinator.ts`, `src/memory/`, and prompt-context assembly, but this change is specification-only. No implementation is delivered by this proposal.
+
+## Memory Schema Ask
+
+This proposal requests the memory SQLite schema change required by `AGENTS.md`: add an additive v8 to v9 migration for a durable `forget_entries` table, for example `forget_entries(id, kind TEXT CHECK(kind IN ('ticker','phrase')), pattern TEXT, created_at)`. The implementation PR must link this proposal as the ask-first authorization, include a migration test upgrading a real v8 fixture database, and prove no data loss.
+
+## Non-Goals and Limitations
+
+- No deletion of watchlist, portfolio, alert, daily-report, transcript, or provider data is implied.
+- No transcript redaction: GUI and TUI continue to display historical turns containing the topic. Transcript redaction is a possible follow-up change.
+- No provider-side or model-side deletion is implied.
+- Forgetting does not prevent the user from re-introducing the topic; a new mention in a future turn is fresh context. The forget list filters history, not the live user turn.

--- a/openspec/changes/forget-command/specs/intent-routing/spec.md
+++ b/openspec/changes/forget-command/specs/intent-routing/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Prior-Turn Privacy and Forget Integration
 
-The system SHALL provide a local `/forget` command that suppresses matching historical context before future router and agent prompts are assembled. Conversational text in `priorTurns` is not governed by the structured-memory `NEVER_TRUST_FROM_MEMORY` guard, so `/forget` SHALL apply the same deterministic matcher to prior-turn derivation, structured memory reads, saved market-state prompt-context summaries, and compaction or branch summaries that can become router-visible history. Suppression SHALL be read-time filtering, not destructive deletion, unless the user explicitly invokes `/forget --remove <topic>` to remove a forget-list entry.
+The system SHALL provide a local `/forget` command that suppresses matching historical context before future router and agent prompts are assembled. Conversational text in `priorTurns` is not governed by the structured-memory `NEVER_TRUST_FROM_MEMORY` guard, so `/forget` SHALL apply the same deterministic matcher to prior-turn derivation, structured memory reads, saved market-state prompt-context summaries, and compaction or branch summaries that can become router-visible history. Suppression SHALL be read-time filtering, not destructive deletion; no suppressed content is ever deleted. (`/forget --remove <topic>` deletes only the forget-list entry itself, restoring visibility of previously suppressed content.)
 
 #### Scenario: Forgotten prior turn is excluded whole
 
@@ -31,7 +31,7 @@ The system SHALL provide a local `/forget` command that suppresses matching hist
 
 OpenCandle SHALL support `/forget <topic>` where `topic` is a ticker, phrase, or free text. The topic SHALL be normalized by trimming whitespace, casefolding, and stripping one leading `$` before mode selection. If the normalized topic matches `^[A-Za-z]{1,5}$`, the entry kind SHALL be `ticker`; otherwise the entry kind SHALL be `phrase`.
 
-Ticker entries SHALL match word-boundary occurrences, case-insensitively, of either the bare symbol or the `$SYMBOL` cashtag. Ticker matching SHALL NOT match inside longer words. Ticker matching SHALL NOT match company-name aliases in v1; for example, forgetting `ASTS` does not match the phrase "AST SpaceMobile" unless the symbol token is also present. Acronym collisions are the user's responsibility.
+Ticker entries SHALL match word-boundary occurrences, case-insensitively, of either the bare symbol or the `$SYMBOL` cashtag. Ticker matching SHALL NOT match inside longer words. Ticker matching SHALL NOT match company-name aliases in v1; for example, forgetting `ASTS` does not match the phrase "AST SpaceMobile" unless the symbol token is also present. Acronym collisions are the user's responsibility. Both ticker and phrase matching SHALL operate on the raw stored text, including markdown syntax characters such as backticks; markdown is not stripped or rendered before matching, so a phrase that spans a markdown boundary (for example, text containing backticks between its words) does not match unless the stored characters match.
 
 Phrase entries SHALL match by case-insensitive substring search on the normalized phrase and target text.
 
@@ -120,7 +120,7 @@ On successful `/forget <topic>`, the session SHALL show a confirmation that stat
 
 - **WHEN** the user runs `/forget` with no argument
 - **THEN** the session SHALL list active forget entries with their stored patterns, kinds, and suppression counts
-- **AND** this listing MAY show patterns because the user requested the active forget list
+- **AND** this listing SHALL show patterns because the user requested the active forget list
 
 ### Requirement: Forget Undo
 

--- a/openspec/changes/forget-command/specs/intent-routing/spec.md
+++ b/openspec/changes/forget-command/specs/intent-routing/spec.md
@@ -1,25 +1,150 @@
+## MODIFIED Requirements
+
+### Requirement: Prior-Turn Privacy and Forget Integration
+
+The system SHALL provide a local `/forget` command that suppresses matching historical context before future router and agent prompts are assembled. Conversational text in `priorTurns` is not governed by the structured-memory `NEVER_TRUST_FROM_MEMORY` guard, so `/forget` SHALL apply the same deterministic matcher to prior-turn derivation, structured memory reads, saved market-state prompt-context summaries, and compaction or branch summaries that can become router-visible history. Suppression SHALL be read-time filtering, not destructive deletion, unless the user explicitly invokes `/forget --remove <topic>` to remove a forget-list entry.
+
+#### Scenario: Forgotten prior turn is excluded whole
+
+- **WHEN** a session contains a prior user or assistant turn mentioning "ASTS"
+- **AND** the user runs `/forget ASTS`
+- **THEN** `buildPriorTurns` in `src/runtime/session-coordinator.ts` SHALL exclude the entire matching turn from subsequent router input
+- **AND** the turn SHALL NOT be masked, truncated around the match, or rewritten
+- **AND** unrelated prior turns remain eligible for `priorTurns`
+
+#### Scenario: Live turn is not filtered
+
+- **WHEN** the user previously ran `/forget ASTS`
+- **AND** the next live user turn says "look at ASTS again"
+- **THEN** the current turn SHALL remain available to the router as fresh user-provided context
+- **AND** only historical context matching the active forget entry SHALL be filtered
+
+#### Scenario: Compaction summary is excluded like a normal turn
+
+- **WHEN** a Pi compaction or branch summary entry contains text matching an active forget entry
+- **THEN** that summary SHALL be excluded from prior-turn derivation before the router prompt is rendered
+- **AND** the implementation SHALL NOT delete or regenerate existing compaction summaries as part of v1
+
 ## ADDED Requirements
 
-### Requirement: Forget Command Scrubs Router Prior-Turn Context
+### Requirement: Forget Command Topic Matching
 
-OpenCandle SHALL provide a local `/forget <topic>` command that prevents future router invocations from receiving prior user or assistant turns matching the forgotten topic.
+OpenCandle SHALL support `/forget <topic>` where `topic` is a ticker, phrase, or free text. The topic SHALL be normalized by trimming whitespace, casefolding, and stripping one leading `$` before mode selection. If the normalized topic matches `^[A-Za-z]{1,5}$`, the entry kind SHALL be `ticker`; otherwise the entry kind SHALL be `phrase`.
 
-#### Scenario: Forgotten text is excluded from priorTurns
+Ticker entries SHALL match word-boundary occurrences, case-insensitively, of either the bare symbol or the `$SYMBOL` cashtag. Ticker matching SHALL NOT match inside longer words. Ticker matching SHALL NOT match company-name aliases in v1; for example, forgetting `ASTS` does not match the phrase "AST SpaceMobile" unless the symbol token is also present. Acronym collisions are the user's responsibility.
 
-- **WHEN** a session contains a prior user turn mentioning "ASTS"
-- **AND** the user runs `/forget ASTS`
-- **THEN** subsequent router input SHALL NOT include matching prior-turn text in `priorTurns`
+Phrase entries SHALL match by case-insensitive substring search on the normalized phrase and target text.
 
-#### Scenario: Unrelated prior turns remain available
+#### Scenario: Ticker does not match inside longer word
 
 - **WHEN** the user runs `/forget ASTS`
-- **THEN** prior turns that do not match ASTS SHALL remain eligible for router context
+- **AND** a prior turn contains "blasts off"
+- **THEN** the prior turn SHALL NOT match the forget entry
 
-### Requirement: Forget Command Scrubs Matching Structured Memory
+#### Scenario: Ticker matches a parenthesized acronym token
 
-The `/forget` command SHALL also remove or mask matching OpenCandle structured memory rows so future prompt context and router context do not reintroduce the forgotten topic.
+- **WHEN** the user runs `/forget $IV`
+- **AND** a prior turn contains "implied volatility (IV)"
+- **THEN** the prior turn SHALL match the forget entry because `IV` appears as a word-boundary token
+- **AND** the implementation SHALL treat this acronym collision as the user's responsibility
 
-#### Scenario: Matching preference removed
+#### Scenario: Phrase with punctuation matches by substring
 
-- **WHEN** a saved preference or memory row matches the forgotten topic
-- **THEN** future prompt context SHALL NOT include that row
+- **WHEN** the user runs `/forget rates: higher-for-longer`
+- **AND** historical text contains "Rates: higher-for-longer remains my base case"
+- **THEN** the text SHALL match the phrase entry case-insensitively
+
+#### Scenario: Phrase spans a markdown code span
+
+- **WHEN** the user runs `/forget cash flow`
+- **AND** historical markdown text contains "review `cash flow` assumptions"
+- **THEN** the text SHALL match the phrase entry even though the words appear inside a markdown code span
+
+#### Scenario: Cashtag and bare ticker tokens match
+
+- **WHEN** the user runs `/forget ASTS`
+- **THEN** historical text containing "ASTS", "$asts", or "asts calls" SHALL match
+- **AND** historical text containing "AST SpaceMobile" without an `ASTS` token SHALL NOT match in v1
+
+### Requirement: Durable Forget List Storage
+
+OpenCandle SHALL persist forget entries in the memory SQLite database so active entries apply across sessions and processes. The implementation SHALL add an additive v8 to v9 schema migration that creates a durable table such as `forget_entries(id, kind TEXT CHECK(kind IN ('ticker','phrase')), pattern TEXT, created_at)`. The migration SHALL preserve all existing data and SHALL NOT reset the database on version mismatch.
+
+#### Scenario: Forget entry persists across sessions and processes
+
+- **WHEN** the user runs `/forget ASTS` in one OpenCandle session
+- **AND** OpenCandle starts a later session or another process using the same memory database
+- **THEN** the later router and prompt-context assembly paths SHALL apply the active `ASTS` forget entry
+
+#### Scenario: v8 database migrates to v9 without data loss
+
+- **WHEN** OpenCandle opens a real v8 fixture database containing existing workflow, preference, and market-state data
+- **THEN** the database SHALL migrate additively to v9
+- **AND** `forget_entries` SHALL exist
+- **AND** all pre-existing rows SHALL remain present
+
+### Requirement: Structured Memory Suppression
+
+Structured memory and preference rows matching an active forget entry SHALL be excluded from router-visible and analyst-visible prompt-context assembly and memory retrieval. Matching rows SHALL NOT be deleted by `/forget`; they SHALL be filtered at read time by the same matcher used for prior turns.
+
+#### Scenario: Saved preference no longer appears in prompt context
+
+- **WHEN** a saved preference mentions "ASTS"
+- **AND** the user runs `/forget ASTS`
+- **THEN** future rendered prompt context SHALL NOT include that saved preference
+- **AND** the underlying preference row SHALL remain stored unless deleted through a separate user action
+
+### Requirement: Saved Market-State Summary Suppression
+
+Saved market-state prompt-context builders SHALL exclude AI-visible watchlist, portfolio, alert, and report summary entries that match an active forget entry. `/forget` SHALL NOT delete watchlist, portfolio, alert, or report rows from SQLite and SHALL NOT hide them from the GUI or TUI management surfaces.
+
+#### Scenario: Forgotten ticker is omitted from serialized saved-state context
+
+- **WHEN** `ASTS` is present in the user's watchlist
+- **AND** the user runs `/forget ASTS`
+- **THEN** the serialized prompt context for future model calls SHALL contain no "ASTS" from saved market-state summaries
+- **AND** the `ASTS` watchlist row SHALL remain visible and manageable in the GUI
+
+### Requirement: Forget Confirmation and Listing Contract
+
+On successful `/forget <topic>`, the session SHALL show a confirmation that states the kind and count of active patterns added or already present, plus counts of suppressed item categories. The confirmation SHALL NOT echo the matched text or the topic itself beyond the user's own typed command. `/forget` with no argument SHALL list active forget entries, including patterns and the count of items each suppresses, because the user explicitly requested the list.
+
+#### Scenario: Success confirmation does not echo topic text
+
+- **WHEN** the user runs `/forget ASTS`
+- **THEN** the session MAY show a confirmation such as "Forgotten: 1 ticker pattern. 3 prior turns and 1 saved preference will no longer be shared with the model."
+- **AND** the confirmation SHALL state the pattern kind and suppressed-item counts
+- **AND** the confirmation SHALL NOT repeat "ASTS" or any matched historical text outside the user's typed command
+
+#### Scenario: Empty forget command lists active entries
+
+- **WHEN** the user runs `/forget` with no argument
+- **THEN** the session SHALL list active forget entries with their stored patterns, kinds, and suppression counts
+- **AND** this listing MAY show patterns because the user requested the active forget list
+
+### Requirement: Forget Undo
+
+OpenCandle SHALL support `/forget --remove <topic>` to delete the matching forget entry from the durable forget list. The command surface SHALL NOT add a separate `/remember` command for v1.
+
+#### Scenario: Removing a forget entry restores future history eligibility
+
+- **WHEN** the user has an active forget entry for `ASTS`
+- **AND** the user runs `/forget --remove ASTS`
+- **THEN** the durable forget entry for `ASTS` SHALL be deleted
+- **AND** future router and prompt-context assembly SHALL stop filtering historical context solely because of that removed entry
+
+### Requirement: Forget Limitations Are Explicit
+
+The `/forget` command SHALL document the v1 limitations: no deletion of watchlist, portfolio, alert, or report rows; no provider-side or model-side deletion; no transcript redaction; and no prevention of future user re-introduction of the topic.
+
+#### Scenario: Historical transcripts remain visible
+
+- **WHEN** a prior GUI or TUI transcript turn contains a forgotten topic
+- **AND** the user runs `/forget <topic>`
+- **THEN** GUI and TUI continue to display historical turns containing the topic
+- **AND** transcript redaction SHALL be documented as a possible follow-up change
+
+#### Scenario: Providers and models are not deletion targets
+
+- **WHEN** the user runs `/forget <topic>`
+- **THEN** OpenCandle SHALL NOT imply provider-side deletion or model-side deletion

--- a/openspec/changes/forget-command/tasks.md
+++ b/openspec/changes/forget-command/tasks.md
@@ -1,16 +1,39 @@
-## 1. Command Contract
+## 1. Command and Matcher
 
-- [ ] 1.1 Define `/forget <topic>` parsing, empty-input behavior, and confirmation text.
-- [ ] 1.2 Define matching rules for tickers, phrases, and saved preference keys.
+- [ ] 1.1 Implement `/forget <topic>`, `/forget`, and `/forget --remove <topic>` parsing without adding a separate `/remember` command.
+- [ ] 1.2 Implement topic normalization: trim, casefold, and strip one leading `$`.
+- [ ] 1.3 Implement ticker mode for normalized topics matching `^[A-Za-z]{1,5}$`, with case-insensitive word-boundary matching for bare symbols and `$SYMBOL` cashtags.
+- [ ] 1.4 Implement phrase mode for all other topics, with case-insensitive substring matching.
+- [ ] 1.5 Add unit tests for the matcher decision table: `ASTS` vs "blasts off" no-match, `$IV` vs "implied volatility (IV)" match, phrase with punctuation, phrase spanning a markdown code span, cashtag match, and company-name alias no-match.
 
-## 2. State Scrub
+## 2. Durable Forget List
 
-- [ ] 2.1 Remove or mask matching structured memory/preferences from SQLite-backed OpenCandle memory.
-- [ ] 2.2 Ensure future `priorTurns` derivation excludes matching user/assistant text.
-- [ ] 2.3 Preserve unrelated session and memory rows.
+- [ ] 2.1 Add the `forget_entries` memory SQLite table with `kind` constrained to `ticker` or `phrase`, stored normalized `pattern`, and `created_at`.
+- [ ] 2.2 Bump the memory database schema from v8 to v9 through an additive migration.
+- [ ] 2.3 Add a migration test upgrading a real v8 fixture database to v9 and asserting no data loss.
+- [ ] 2.4 Ensure forget entries persist across sessions and processes that share the same memory database.
 
-## 3. Verification
+## 3. Suppression Surfaces
 
-- [ ] 3.1 Add unit tests for memory deletion/masking.
-- [ ] 3.2 Add extension tests proving router context no longer contains forgotten text.
-- [ ] 3.3 Run `npm test`.
+- [ ] 3.1 Filter `buildPriorTurns` in `src/runtime/session-coordinator.ts` by excluding whole matching turns, not masking or rewriting them.
+- [ ] 3.2 Filter Pi compaction and branch summary entries from prior-turn derivation when their text matches an active forget entry.
+- [ ] 3.3 Filter matching structured memory and preference rows at read time for prompt-context assembly and memory retrieval without deleting the rows.
+- [ ] 3.4 Filter saved watchlist, portfolio, alert, and report summaries from AI-visible prompt context without deleting rows or hiding them from GUI/TUI management surfaces.
+- [ ] 3.5 Ensure the forget list filters history only and never suppresses the live user turn that re-introduces a topic.
+
+## 4. User Feedback and Limitations
+
+- [ ] 4.1 Show success confirmations that state pattern kind and suppression counts without echoing the topic or matched historical text.
+- [ ] 4.2 Implement `/forget` with no argument as an active-entry listing that includes patterns, kinds, and per-entry suppression counts.
+- [ ] 4.3 Implement `/forget --remove <topic>` to delete the matching durable forget entry.
+- [ ] 4.4 Document v1 limitations: no watchlist/portfolio/alert/report deletion, no transcript redaction, no provider-side or model-side deletion, and no prevention of future user re-introduction.
+
+## 5. Verification
+
+- [ ] 5.1 Add an extension-level test proving that after `/forget`, the serialized router prompt for the next turn contains no forgotten match; assert on the actual prompt string, not intermediate structures.
+- [ ] 5.2 Add a structured-memory prompt-context test where a saved preference mentioning the forgotten ticker no longer appears in rendered prompt context.
+- [ ] 5.3 Add a saved market-state prompt-context test where a forgotten ticker remains in SQLite/GUI state but is absent from the serialized AI-visible summary.
+- [ ] 5.4 Add a harness e2e using the multi-prompt harness from `docs/internal/high-leverage-improvements-plan.md` item I1: turn 1 mentions the topic, turn 2 runs `/forget`, turn 3 asks an unrelated question, and `trace.json` router input is clean.
+- [ ] 5.5 Add the privacy eval case from `docs/internal/high-leverage-improvements-plan.md` item I5/E4: turn 1 "I hold 4,000 shares of XYZ at $12", turn 2 `/forget XYZ`, turn 3 "what should I buy this month?", with assertions that the trace does not expose the forgotten holding.
+- [ ] 5.6 Run `npm test`, `npx tsc --noEmit`, `npx biome ci .`, and `openspec validate forget-command --strict`.
+- [ ] 5.7 Before archiving the implemented change, run `openspec validate forget-command --strict` and archive through the OpenSpec CLI.


### PR DESCRIPTION
## Summary

Rewrites the active `forget-command` OpenSpec change. This PR edits `proposal.md`, the `intent-routing` spec delta, and `tasks.md`, plus the required `[Unreleased]` changelog entry.

No code or tests are changed, and no OpenSpec change is archived in WP6.

## Why

The previous `/forget` proposal left core behavior unspecified: matching rules, persistence, destructive versus read-time filtering, saved market-state summaries, compaction summaries, confirmation behavior, and undo. WP6 replaces it with the decided privacy contract so the later implementation can be built and verified against deterministic semantics.

The memory SQLite schema ask required by `AGENTS.md` is recorded in `openspec/changes/forget-command/proposal.md#memory-schema-ask`.

## Validation

- [x] `npm test`
- [ ] `npm run release:check` for release-facing changes, or note why the focused check is enough
- [ ] `npm run review:pr` before merge for non-trivial changes
- [x] Docs updated if behavior or workflow changed
- [ ] Tests added or updated for behavior changes

Focused check is enough here because WP6 is OpenSpec/changelog only and does not change implementation or release packaging.

No behavior tests were added because WP6 is explicitly specification-only; the rewritten `tasks.md` now requires the future implementation PR to add matcher, migration, extension-level, prompt-context, harness e2e, and eval coverage.

Autoreview findings accepted/rejected: not run.

Runtime/eval proof for behavior changes: N/A, no implementation and no live LLM evals run.

Additional checks run:

```text
$ openspec validate forget-command --strict
Change 'forget-command' is valid
```

```text
$ openspec validate --all --strict
- Validating...
✓ spec/agent-planning-layer
✓ spec/analyst-stance
✓ spec/chat-event-rendering
✓ spec/ci-hardening
✓ spec/composable-prompts
✓ spec/conversational-provider-setup
✓ spec/deterministic-evals
✓ spec/docs-cleanup
✓ spec/doctor-health-diagnostics
✓ spec/eval-baseline
✓ change/forget-command
✓ spec/graceful-degradation
✓ change/gui-concurrent-session-runtime
✓ spec/hybrid-scorer
✓ spec/intent-routing
✓ spec/llm-judge-evals
✓ spec/local-market-automations
✓ spec/market-alerts-and-reports
✓ spec/market-state-imports
✓ spec/market-state-user-experience
✓ spec/pi-synced-gui
✓ change/production-router-and-tool-hardening
✓ spec/provider-registry
✓ spec/public-site-static-rendering
✓ spec/quant-tool-integrity
✓ spec/reddit-comments
✓ spec/route-tool-bundles
✓ spec/router-evals
✓ spec/runtime-validation
✓ spec/selective-memory
✓ spec/sentiment-pipeline
✓ spec/sentiment-summary
✓ spec/sentiment-trend
✓ spec/sentinel-store
✓ spec/stateful-market-surfaces
✓ spec/structured-analysts
✓ spec/structured-provenance
✓ spec/test-harness-observability
✓ spec/tool-authoring-docs
✓ spec/tool-extensibility
✓ spec/tradingview-screener
✓ change/transparent-local-session-coordinator
✓ spec/turn-context-resolution
✓ spec/twitter-sentiment
✓ spec/user-market-state
✓ spec/visual-identity
✓ spec/watchlist
✓ spec/web-search
✓ spec/web-sentiment
✓ spec/workflow-events
✓ spec/workflow-runner
Totals: 51 passed, 0 failed (51 items)
```

```text
$ npm test
Test Files  218 passed (218)
Tests       2296 passed (2296)
```

```text
$ npx tsc --noEmit
<no output; exit 0>
```

```text
$ npx biome ci .
Checked 593 files in 235ms. No fixes applied.
Found 494 warnings.
Found 38 infos.
exit 0
```

Note: first `npm test` attempt failed before tests because dependencies were missing in this worktree (`Cannot find package 'better-sqlite3' imported from scripts/check-node-version.mjs`). I ran `npm ci`, then reran the required checks successfully.

## Risks / Follow-ups

Requires human review before merge because WP6 rewrites user-facing spec content.

Follow-up implementation is owned by the later `/forget` implementation work. That implementation must keep the spec's non-destructive posture: filter AI-visible history at read time, do not redact transcripts, do not delete saved market-state rows, and do not filter the live user turn.

## Issue / Discussion

See `docs/internal/openspec-backlog-cleanup-plan.md` WP6 and `docs/internal/high-leverage-improvements-plan.md` I4/I5.
