### PR TITLE
feat(harness): support multi-prompt sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - `release:check` now includes a credential-free GUI release smoke that builds the browser bundle, boots the real GUI server, verifies `/health`, renders first-run model setup in Chromium, and keeps chat disabled until setup is ready.
+- Harness sessions now support sequential `prompts` with per-prompt trace boundaries while preserving single-`prompt` behavior, and the IPC harness can `send` follow-up prompts into an existing session.
 - Rewrote the OpenSpec `/forget` proposal to define deterministic matcher semantics, durable forget-list storage, non-destructive AI-context suppression surfaces, confirmation/listing behavior, undo, and verification requirements.
 
 ### Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -38,3 +38,22 @@ Branch: `feat/eval-provider-outage`
 - Different sessions can run concurrently while same-session action exclusion remains: `tests/unit/gui-server/local-session-coordinator.test.ts` and `tests/e2e/gui-browser.test.ts`.
 - GUI-created sessions remain TUI-continuable without SQLite schema or Pi session format changes: `tests/unit/gui-server/session-resume.test.ts` and `docs/internal/pr-evidence/feat-gui-session-scoped-actions/tui-resume-transcript.md`.
 - Browser runtime evidence for two concurrent sessions with a stop targeting the background session is in `docs/internal/pr-evidence/feat-gui-session-scoped-actions/browser-concurrent-stop-log.json` plus desktop/mobile screenshots.
+
+# I1 Harness Multi-Prompt Notes
+
+## Behavior-to-test mapping
+
+- `runOpenCandleSession({ prompts })` sends prompts sequentially, waits for each prompt to settle, accumulates custom entries, and tags turns/tool calls/custom entries with `promptIndex`.
+  - Covered by `tests/unit/harness/opencandle-runner.test.ts` test `runs multiple prompts sequentially and tags trace entries by prompt index`.
+  - Live evidence: `docs/internal/pr-evidence/feat-harness-multi-prompt/trace.json` and `summary.json`.
+- Existing `runOpenCandleSession({ prompt })` callers keep the original single-prompt shape: no `prompts` array and no prompt-index tags unless multi-prompt mode is explicitly used.
+  - Covered by `tests/unit/harness/opencandle-runner.test.ts` test `keeps single prompt traces in the original one-prompt shape`.
+  - Covered transitively by existing eval/product callers that still pass `prompt`.
+- IPC `send --ipc <dir> --prompt <text>` moves a completed or waiting session back to `running`, dispatches a follow-up prompt into the same live session, and the trace accumulates across sends.
+  - Covered by `tests/unit/harness/ipc.test.ts` test `writePromptRequest moves a completed session back to running for send`.
+  - Live evidence: `docs/internal/pr-evidence/feat-harness-multi-prompt/harness.log`, `trace.json`, and `summary.json`.
+
+## Gate notes
+
+- `npm run test:evals -- -t "no-tool"` remains blocked before cases execute by the existing `vitest-evals` loader failure: `TypeError: define is not a function`.
+- Full `npx biome ci .` passed with existing repository warnings.

--- a/docs/internal/pr-evidence/feat-harness-multi-prompt/harness.log
+++ b/docs/internal/pr-evidence/feat-harness-multi-prompt/harness.log
@@ -1,0 +1,4 @@
+IPC dir: docs/internal/pr-evidence/feat-harness-multi-prompt/ipc
+Session complete. Trace written.
+Follow-up complete. Trace written.
+Shutdown requested, writing partial trace...

--- a/docs/internal/pr-evidence/feat-harness-multi-prompt/summary.json
+++ b/docs/internal/pr-evidence/feat-harness-multi-prompt/summary.json
@@ -1,0 +1,22 @@
+{
+  "prompts": [
+    "Answer briefly: say READY.",
+    "Follow up briefly: say STILL READY."
+  ],
+  "turns": 2,
+  "promptIndexes": [
+    0,
+    1
+  ],
+  "customPromptIndexes": [
+    0,
+    0,
+    0,
+    0,
+    1,
+    1,
+    1,
+    1
+  ],
+  "finalText": "STILL READY."
+}

--- a/docs/internal/pr-evidence/feat-harness-multi-prompt/trace.json
+++ b/docs/internal/pr-evidence/feat-harness-multi-prompt/trace.json
@@ -1,0 +1,212 @@
+{
+  "prompt": "Answer briefly: say READY.",
+  "turns": [
+    {
+      "toolCalls": [],
+      "text": "READY.",
+      "promptIndex": 0
+    },
+    {
+      "toolCalls": [],
+      "text": "STILL READY.",
+      "promptIndex": 1
+    }
+  ],
+  "interactions": [],
+  "finalText": "STILL READY.",
+  "toolSequence": [],
+  "durationMs": 9259,
+  "prompts": [
+    "Answer briefly: say READY.",
+    "Follow up briefly: say STILL READY."
+  ],
+  "customEntries": [
+    {
+      "customType": "opencandle-router",
+      "data": {
+        "output": {
+          "routeKind": "pass_through",
+          "route": "fallback",
+          "entities": {
+            "symbols": []
+          },
+          "slots": {},
+          "preference_updates": [],
+          "missing_required": [],
+          "tool_bundles": [],
+          "diagnostics": [],
+          "reasoning": "The user's turn is a meta-instruction to confirm readiness, not a finance-related query. It falls outside the scope of known workflows."
+        }
+      },
+      "timestamp": "2026-07-04T03:46:17.138Z",
+      "promptIndex": 0
+    },
+    {
+      "customType": "opencandle-route-context",
+      "data": {
+        "userInput": "Answer briefly: say READY.",
+        "priorTurns": [],
+        "routeKind": "pass_through",
+        "legacyRoute": "fallback",
+        "entities": {
+          "symbols": []
+        },
+        "slots": {},
+        "missingRequired": [],
+        "toolBundles": [],
+        "activeToolNames": [],
+        "memoryQueryPlan": {
+          "routeKind": "pass_through",
+          "categories": [],
+          "symbols": [],
+          "slotKeys": []
+        },
+        "memoryProvenance": [],
+        "promptPlaybook": "pass_through",
+        "diagnostics": [],
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "general_fallback",
+          "commitmentMode": "framework",
+          "policyCardId": "general_fallback",
+          "evidencePlanId": "placeholder_general_fallback",
+          "answerContractId": "general_fallback",
+          "structuredCheckIds": [
+            "data_gap_disclosed"
+          ],
+          "capabilityGapIds": [],
+          "behaviorMode": "observe_only",
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "diagnostics": [
+            {
+              "code": "planning_observe_only",
+              "message": "planning metadata is recorded without changing active prompt, route, workflow, tools, or answer behavior"
+            }
+          ]
+        }
+      },
+      "timestamp": "2026-07-04T03:46:17.138Z",
+      "promptIndex": 0
+    },
+    {
+      "customType": "opencandle-tool-scope",
+      "data": {
+        "mode": "observe",
+        "routeKind": "pass_through",
+        "toolBundles": [],
+        "activeToolNames": [],
+        "enforced": false
+      },
+      "timestamp": "2026-07-04T03:46:17.138Z",
+      "promptIndex": 0
+    },
+    {
+      "customType": "opencandle-disclaimer",
+      "data": {
+        "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+      },
+      "timestamp": "2026-07-04T03:46:18.333Z",
+      "promptIndex": 0
+    },
+    {
+      "customType": "opencandle-router",
+      "data": {
+        "output": {
+          "routeKind": "pass_through",
+          "route": "fallback",
+          "entities": {
+            "symbols": []
+          },
+          "slots": {},
+          "preference_updates": [],
+          "missing_required": [],
+          "tool_bundles": [],
+          "diagnostics": [],
+          "reasoning": "The user's turn is a simple conversational instruction, not related to any financial workflows or tasks. It should be passed through."
+        }
+      },
+      "timestamp": "2026-07-04T03:46:23.820Z",
+      "promptIndex": 1
+    },
+    {
+      "customType": "opencandle-route-context",
+      "data": {
+        "userInput": "Follow up briefly: say STILL READY.",
+        "priorTurns": [
+          {
+            "role": "user",
+            "text": "Answer briefly: say READY."
+          },
+          {
+            "role": "assistant",
+            "text": "READY."
+          }
+        ],
+        "routeKind": "pass_through",
+        "legacyRoute": "fallback",
+        "entities": {
+          "symbols": []
+        },
+        "slots": {},
+        "missingRequired": [],
+        "toolBundles": [],
+        "activeToolNames": [],
+        "memoryQueryPlan": {
+          "routeKind": "pass_through",
+          "categories": [],
+          "symbols": [],
+          "slotKeys": []
+        },
+        "memoryProvenance": [],
+        "promptPlaybook": "pass_through",
+        "diagnostics": [],
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "general_fallback",
+          "commitmentMode": "framework",
+          "policyCardId": "general_fallback",
+          "evidencePlanId": "placeholder_general_fallback",
+          "answerContractId": "general_fallback",
+          "structuredCheckIds": [
+            "data_gap_disclosed"
+          ],
+          "capabilityGapIds": [],
+          "behaviorMode": "observe_only",
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "diagnostics": [
+            {
+              "code": "planning_observe_only",
+              "message": "planning metadata is recorded without changing active prompt, route, workflow, tools, or answer behavior"
+            }
+          ]
+        }
+      },
+      "timestamp": "2026-07-04T03:46:23.821Z",
+      "promptIndex": 1
+    },
+    {
+      "customType": "opencandle-tool-scope",
+      "data": {
+        "mode": "observe",
+        "routeKind": "pass_through",
+        "toolBundles": [],
+        "activeToolNames": [],
+        "enforced": false
+      },
+      "timestamp": "2026-07-04T03:46:23.821Z",
+      "promptIndex": 1
+    },
+    {
+      "customType": "opencandle-disclaimer",
+      "data": {
+        "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+      },
+      "timestamp": "2026-07-04T03:46:24.372Z",
+      "promptIndex": 1
+    }
+  ]
+}

--- a/tests/evals/types.ts
+++ b/tests/evals/types.ts
@@ -17,6 +17,7 @@ export interface TraceToolCall {
   name: string;
   args: Record<string, unknown>;
   result?: unknown;
+  promptIndex?: number;
 }
 
 export interface RouterTelemetry {

--- a/tests/harness/cli.ts
+++ b/tests/harness/cli.ts
@@ -3,6 +3,7 @@
  *
  * Usage:
  *   npx tsx tests/harness/cli.ts run    --prompt "..." --ipc <dir> [--timeout <ms>]
+ *   npx tsx tests/harness/cli.ts send   --prompt "..." --ipc <dir>
  *   npx tsx tests/harness/cli.ts wait   --ipc <dir> [--timeout <ms>]
  *   npx tsx tests/harness/cli.ts answer --ipc <dir> --value "..."
  *   npx tsx tests/harness/cli.ts trace  --ipc <dir>
@@ -37,6 +38,9 @@ switch (subcommand) {
   case "run":
     await cmdRun();
     break;
+  case "send":
+    cmdSend();
+    break;
   case "wait":
     await cmdWait();
     break;
@@ -47,7 +51,7 @@ switch (subcommand) {
     cmdTrace();
     break;
   default:
-    console.error(`Usage: cli.ts <run|wait|answer|trace> [options]`);
+    console.error(`Usage: cli.ts <run|send|wait|answer|trace> [options]`);
     process.exit(1);
 }
 
@@ -102,8 +106,13 @@ async function cmdRun() {
       askUserHandler: askHandler,
     });
 
+    const prompts = [prompt];
+    let customEntryOffset = 0;
+    const customEntries: CustomEntryTrace[] = [];
+
     collector = createTraceCollector(session, prompt, {
       jsonlPath: join(ipcDir, "events.jsonl"),
+      trackPromptIndex: true,
     });
 
     // Graceful shutdown
@@ -113,9 +122,16 @@ async function cmdRun() {
       shutdownRequested = true;
       console.error("Shutdown requested, writing partial trace...");
       if (collector) {
+        const drained = drainOpenCandleCustomEntries(
+          session.sessionManager,
+          customEntryOffset,
+          prompts.length - 1,
+        );
+        customEntries.push(...drained.entries);
         ipc.writeTrace({
           ...collector.getTrace(),
-          customEntries: drainOpenCandleCustomEntries(session.sessionManager),
+          prompts,
+          customEntries,
         });
       }
       session.dispose();
@@ -127,27 +143,40 @@ async function cmdRun() {
 
     cache.clear();
 
-    await new Promise<void>((resolve) => {
-      const unsub = session.subscribe((event) => {
-        if (event.type === "agent_end") {
-          unsub();
-          resolve();
-        }
+    const writeCurrentTrace = (promptIndex: number) => {
+      const drained = drainOpenCandleCustomEntries(
+        session.sessionManager,
+        customEntryOffset,
+        promptIndex,
+      );
+      customEntryOffset = drained.nextEntryOffset;
+      customEntries.push(...drained.entries);
+      if (!collector) throw new Error("Trace collector was not initialized");
+      ipc.writeTrace({
+        ...collector.getTrace(),
+        prompts,
+        customEntries,
       });
-      void session.prompt(prompt);
-    });
+    };
 
-    ipc.writeTrace({
-      ...collector.getTrace(),
-      customEntries: drainOpenCandleCustomEntries(session.sessionManager),
-    });
+    await promptAndWaitForAgentEnd(session, prompt);
+    writeCurrentTrace(0);
     console.log(`IPC dir: ${ipcDir}`);
     console.log("Session complete. Trace written.");
 
-    collector.dispose();
-    session.dispose();
-    cleanupHome();
-    process.exit(0);
+    while (!shutdownRequested) {
+      const request = ipc.readPromptRequest();
+      if (!request) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        continue;
+      }
+      const promptIndex = prompts.length;
+      prompts.push(request.prompt);
+      collector.setPromptIndex(promptIndex);
+      await promptAndWaitForAgentEnd(session, request.prompt);
+      writeCurrentTrace(promptIndex);
+      console.log("Follow-up complete. Trace written.");
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     ipc.writeError(message);
@@ -158,11 +187,16 @@ async function cmdRun() {
   }
 }
 
-function drainOpenCandleCustomEntries(sessionManager: {
-  getEntries(): Array<Record<string, unknown>>;
-}): CustomEntryTrace[] {
-  return sessionManager
-    .getEntries()
+function drainOpenCandleCustomEntries(
+  sessionManager: {
+    getEntries(): Array<Record<string, unknown>>;
+  },
+  startEntryOffset: number,
+  promptIndex: number,
+): { entries: CustomEntryTrace[]; nextEntryOffset: number } {
+  const allEntries = sessionManager.getEntries();
+  const entries = allEntries
+    .slice(startEntryOffset)
     .filter(
       (entry) =>
         entry.type === "custom" &&
@@ -173,7 +207,27 @@ function drainOpenCandleCustomEntries(sessionManager: {
       customType: String(entry.customType),
       data: entry.data,
       timestamp: String(entry.timestamp),
+      promptIndex,
     }));
+  return { entries, nextEntryOffset: allEntries.length };
+}
+
+async function promptAndWaitForAgentEnd(
+  session: Awaited<ReturnType<typeof createOpenCandleSession>>["session"],
+  prompt: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const unsub = session.subscribe((event) => {
+      if (event.type === "agent_end") {
+        unsub();
+        resolve();
+      }
+    });
+    void session.prompt(prompt).catch((error: unknown) => {
+      unsub();
+      reject(error);
+    });
+  });
 }
 
 async function cmdWait() {
@@ -226,6 +280,21 @@ async function cmdWait() {
 
   console.error("Timeout waiting for harness");
   process.exit(2);
+}
+
+function cmdSend() {
+  const ipcDir = args.ipc;
+  const prompt = args.prompt;
+  if (!ipcDir || !prompt) {
+    console.error("--ipc and --prompt are required");
+    process.exit(1);
+  }
+  const status = IpcChannel.readStatus(ipcDir);
+  if (status !== "done" && status !== "waiting") {
+    console.error(`Cannot send follow-up while harness status is ${status ?? "missing"}`);
+    process.exit(1);
+  }
+  IpcChannel.writePromptRequest(ipcDir, prompt);
 }
 
 function cmdAnswer() {

--- a/tests/harness/ipc.ts
+++ b/tests/harness/ipc.ts
@@ -14,6 +14,10 @@ export interface Question {
   reason?: string;
 }
 
+export interface PromptRequest {
+  prompt: string;
+}
+
 export class IpcChannel {
   constructor(private dir: string) {}
 
@@ -42,6 +46,11 @@ export class IpcChannel {
           cleanup();
           const raw = readFileSync(answerPath, "utf-8");
           resolve(JSON.parse(raw) as { value: string });
+          return true;
+        }
+        if (existsSync(join(this.dir, "prompt-request.json"))) {
+          cleanup();
+          resolve(null);
           return true;
         }
         return false;
@@ -76,6 +85,15 @@ export class IpcChannel {
   writeTrace(trace: AgentTrace): void {
     writeFileSync(join(this.dir, "trace.json"), JSON.stringify(trace, null, 2), "utf-8");
     this.setStatus("done");
+  }
+
+  /** Consume a pending follow-up prompt request, if one exists. */
+  readPromptRequest(): PromptRequest | null {
+    const p = join(this.dir, "prompt-request.json");
+    if (!existsSync(p)) return null;
+    const request = JSON.parse(readFileSync(p, "utf-8")) as PromptRequest;
+    rmSync(p, { force: true });
+    return request;
   }
 
   /** Write error.txt and set status=error. */
@@ -113,6 +131,13 @@ export class IpcChannel {
     const tmp = join(dir, "answer.json.tmp");
     writeFileSync(tmp, JSON.stringify({ value }), "utf-8");
     renameSync(tmp, join(dir, "answer.json"));
+  }
+
+  static writePromptRequest(dir: string, prompt: string): void {
+    const tmp = join(dir, "prompt-request.json.tmp");
+    writeFileSync(tmp, JSON.stringify({ prompt }, null, 2), "utf-8");
+    renameSync(tmp, join(dir, "prompt-request.json"));
+    new IpcChannel(dir).setStatus("running");
   }
 
   static readTrace(dir: string): AgentTrace | null {

--- a/tests/harness/opencandle-runner.ts
+++ b/tests/harness/opencandle-runner.ts
@@ -48,7 +48,8 @@ const MULTI_STEP_WORKFLOWS = new Set<WorkflowType>([
 ]);
 
 export interface RunOpenCandleSessionOptions {
-  prompt: string;
+  prompt?: string;
+  prompts?: string[];
   scriptedAnswers?: string[];
   cwd?: string;
   openCandleHome?: string;
@@ -69,6 +70,8 @@ export interface RunOpenCandleSessionResult {
 export async function runOpenCandleSession(
   options: RunOpenCandleSessionOptions,
 ): Promise<RunOpenCandleSessionResult> {
+  const prompts = normalizePrompts(options);
+  const tagsPromptIndex = options.prompts !== undefined;
   const openCandleHome = options.openCandleHome ?? mkdtempSync(join(tmpdir(), "oc-harness-home-"));
   const shouldRemoveOpenCandleHome = options.openCandleHome === undefined;
   const previousHome = process.env.OPENCANDLE_HOME;
@@ -100,19 +103,32 @@ export async function runOpenCandleSession(
     });
     session = created.session;
 
-    collector = createTraceCollector(session, options.prompt, {
+    collector = createTraceCollector(session, prompts[0], {
       jsonlPath: options.jsonlPath,
+      trackPromptIndex: tagsPromptIndex,
     });
 
     cache.clear();
-    await promptAndWaitForSettle(session, options.prompt, {
-      settleGraceMs: options.settleGraceMs ?? defaultSettleGraceMs(options.prompt),
-      timeoutMs: options.timeoutMs ?? 900_000,
-    });
+    const customEntries: CustomEntryTrace[] = [];
+    let customEntryOffset = 0;
+    for (const [promptIndex, prompt] of prompts.entries()) {
+      collector.setPromptIndex(promptIndex);
+      await promptAndWaitForSettle(session, prompt, {
+        settleGraceMs: options.settleGraceMs ?? defaultSettleGraceMs(prompt),
+        timeoutMs: options.timeoutMs ?? 900_000,
+      });
+      const drained = drainOpenCandleCustomEntries(
+        session.sessionManager,
+        customEntryOffset,
+        tagsPromptIndex ? promptIndex : undefined,
+      );
+      customEntries.push(...drained.entries);
+      customEntryOffset = drained.nextEntryOffset;
+    }
 
-    const customEntries = drainOpenCandleCustomEntries(session.sessionManager);
     const agentTrace: AgentTrace = {
       ...collector.getTrace(),
+      ...(tagsPromptIndex ? { prompts } : {}),
       customEntries,
     };
     return {
@@ -135,9 +151,22 @@ export async function runOpenCandleSession(
 
 export function drainOpenCandleCustomEntries(
   sessionManager: Pick<ReturnType<typeof PiSessionManager.inMemory>, "getEntries">,
-): CustomEntryTrace[] {
-  return sessionManager
-    .getEntries()
+  startEntryOffset?: undefined,
+  promptIndex?: number,
+): CustomEntryTrace[];
+export function drainOpenCandleCustomEntries(
+  sessionManager: Pick<ReturnType<typeof PiSessionManager.inMemory>, "getEntries">,
+  startEntryOffset: number,
+  promptIndex?: number,
+): { entries: CustomEntryTrace[]; nextEntryOffset: number };
+export function drainOpenCandleCustomEntries(
+  sessionManager: Pick<ReturnType<typeof PiSessionManager.inMemory>, "getEntries">,
+  startEntryOffset?: number,
+  promptIndex?: number,
+): CustomEntryTrace[] | { entries: CustomEntryTrace[]; nextEntryOffset: number } {
+  const allEntries = sessionManager.getEntries();
+  const entries = allEntries
+    .slice(startEntryOffset ?? 0)
     .filter((entry) => entry.type === "custom" && entry.customType.startsWith("opencandle-"))
     .map((entry) => {
       const customEntry = entry as Extract<
@@ -148,8 +177,11 @@ export function drainOpenCandleCustomEntries(
         customType: customEntry.customType,
         data: customEntry.data,
         timestamp: customEntry.timestamp,
+        ...(promptIndex === undefined ? {} : { promptIndex }),
       };
     });
+  if (startEntryOffset === undefined) return entries;
+  return { entries, nextEntryOffset: allEntries.length };
 }
 
 export function toEvalTrace(agentTrace: AgentTrace): EvalTrace {
@@ -159,6 +191,7 @@ export function toEvalTrace(agentTrace: AgentTrace): EvalTrace {
         name: tool.name,
         args: tool.args,
         result: tool.result,
+        ...(tool.promptIndex === undefined ? {} : { promptIndex: tool.promptIndex }),
       }),
     ),
   );
@@ -179,6 +212,17 @@ export function toEvalTrace(agentTrace: AgentTrace): EvalTrace {
     text: agentTrace.finalText || agentTrace.turns.map((turn) => turn.text).join(""),
     customEntries: agentTrace.customEntries,
   };
+}
+
+function normalizePrompts(options: RunOpenCandleSessionOptions): string[] {
+  if (options.prompts !== undefined) {
+    if (options.prompts.length === 0) {
+      throw new Error("runOpenCandleSession requires at least one prompt");
+    }
+    return options.prompts;
+  }
+  if (options.prompt !== undefined) return [options.prompt];
+  throw new Error("runOpenCandleSession requires prompt or prompts");
 }
 
 function createScriptedAskHandler(

--- a/tests/harness/trace-collector.ts
+++ b/tests/harness/trace-collector.ts
@@ -16,6 +16,8 @@ interface PendingToolCall {
 export interface TraceCollector {
   /** Get the current trace snapshot. */
   getTrace(): AgentTrace;
+  /** Set the prompt index applied to subsequently captured turns/interactions. */
+  setPromptIndex(promptIndex: number): void;
   /** Record an ask_user interaction. */
   addInteraction(interaction: InteractionTrace): void;
   /** Unsubscribe from session events. */
@@ -25,13 +27,19 @@ export interface TraceCollector {
 export function createTraceCollector(
   session: { subscribe: (cb: (event: AgentSessionEvent) => void) => () => void },
   prompt: string,
-  options?: { jsonlPath?: string },
+  options?: { jsonlPath?: string; trackPromptIndex?: boolean },
 ): TraceCollector {
   const startTime = Date.now();
   const pendingTools = new Map<string, PendingToolCall>();
   const turns: TurnTrace[] = [];
   const interactions: InteractionTrace[] = [];
-  let currentTurn: TurnTrace = { toolCalls: [], text: "" };
+  let currentPromptIndex = 0;
+  const createTurn = (): TurnTrace => ({
+    toolCalls: [],
+    text: "",
+    ...(options?.trackPromptIndex ? { promptIndex: currentPromptIndex } : {}),
+  });
+  let currentTurn: TurnTrace = createTurn();
   let finalText = "";
 
   if (options?.jsonlPath) {
@@ -40,7 +48,7 @@ export function createTraceCollector(
 
   function appendToJsonl(event: Record<string, unknown>) {
     if (options?.jsonlPath) {
-      appendFileSync(options.jsonlPath, JSON.stringify(event) + "\n", "utf-8");
+      appendFileSync(options.jsonlPath, `${JSON.stringify(event)}\n`, "utf-8");
     }
   }
 
@@ -70,6 +78,7 @@ export function createTraceCollector(
             result: event.result,
             isError: event.isError,
             durationMs: Date.now() - pending.startTime,
+            ...(options?.trackPromptIndex ? { promptIndex: currentPromptIndex } : {}),
           };
           currentTurn.toolCalls.push(trace);
           pendingTools.delete(event.toolCallId);
@@ -93,7 +102,7 @@ export function createTraceCollector(
         if (currentTurn.toolCalls.length > 0 || currentTurn.text.length > 0) {
           turns.push(currentTurn);
         }
-        currentTurn = { toolCalls: [], text: "" };
+        currentTurn = createTurn();
         appendToJsonl({ type: event.type, timestamp: Date.now() });
         break;
       }
@@ -101,7 +110,7 @@ export function createTraceCollector(
         // Push any remaining current turn
         if (currentTurn.toolCalls.length > 0 || currentTurn.text.length > 0) {
           turns.push(currentTurn);
-          currentTurn = { toolCalls: [], text: "" };
+          currentTurn = createTurn();
         }
         finalText = turns.length > 0 ? turns[turns.length - 1].text : "";
         appendToJsonl({ type: event.type, timestamp: Date.now() });
@@ -125,8 +134,21 @@ export function createTraceCollector(
         durationMs: Date.now() - startTime,
       };
     },
+    setPromptIndex(promptIndex: number) {
+      currentPromptIndex = promptIndex;
+      if (
+        options?.trackPromptIndex &&
+        currentTurn.toolCalls.length === 0 &&
+        currentTurn.text === ""
+      ) {
+        currentTurn.promptIndex = promptIndex;
+      }
+    },
     addInteraction(interaction: InteractionTrace) {
-      interactions.push(interaction);
+      interactions.push({
+        ...interaction,
+        ...(options?.trackPromptIndex ? { promptIndex: currentPromptIndex } : {}),
+      });
     },
     dispose() {
       unsub();

--- a/tests/harness/types.ts
+++ b/tests/harness/types.ts
@@ -6,11 +6,13 @@ export interface ToolCallTrace {
   result: unknown;
   isError: boolean;
   durationMs: number;
+  promptIndex?: number;
 }
 
 export interface TurnTrace {
   toolCalls: ToolCallTrace[];
   text: string;
+  promptIndex?: number;
 }
 
 export interface InteractionTrace {
@@ -18,6 +20,7 @@ export interface InteractionTrace {
   method: "select" | "text" | "confirm";
   options?: string[];
   answer: string | null;
+  promptIndex?: number;
 }
 
 /** Custom session entry captured from the session manager after settle.
@@ -31,10 +34,12 @@ export interface CustomEntryTrace {
   customType: string;
   data: unknown;
   timestamp: string;
+  promptIndex?: number;
 }
 
 export interface AgentTrace {
   prompt: string;
+  prompts?: string[];
   turns: TurnTrace[];
   interactions: InteractionTrace[];
   finalText: string;

--- a/tests/unit/harness/ipc.test.ts
+++ b/tests/unit/harness/ipc.test.ts
@@ -79,6 +79,16 @@ describe("IpcChannel", () => {
     expect(read).toEqual(trace);
   });
 
+  it("writePromptRequest moves a completed session back to running for send", () => {
+    ipc.setStatus("done");
+
+    IpcChannel.writePromptRequest(dir, "What about AMD?");
+
+    expect(IpcChannel.readStatus(dir)).toBe("running");
+    expect(ipc.readPromptRequest()).toEqual({ prompt: "What about AMD?" });
+    expect(ipc.readPromptRequest()).toBeNull();
+  });
+
   it("writeError writes error.txt and sets status=error", () => {
     ipc.writeError("something broke");
 

--- a/tests/unit/harness/opencandle-runner.test.ts
+++ b/tests/unit/harness/opencandle-runner.test.ts
@@ -162,4 +162,118 @@ describe("runOpenCandleSession", () => {
     expect(options.settingsManager.getDefaultModel()).toBe("gemini-2.5-flash");
     expect(process.env.OPENCANDLE_HOME).toBe(originalHome);
   });
+
+  it("keeps single prompt traces in the original one-prompt shape", async () => {
+    const listeners: Array<(event: Record<string, unknown>) => void> = [];
+    const session = {
+      subscribe: vi.fn((listener: (event: Record<string, unknown>) => void) => {
+        listeners.push(listener);
+        return () => {};
+      }),
+      prompt: vi.fn(async () => {
+        queueMicrotask(() => {
+          for (const listener of listeners) {
+            listener({
+              type: "message_update",
+              assistantMessageEvent: { type: "text_delta", delta: "done" },
+            });
+            listener({ type: "turn_end", message: {}, toolResults: [] });
+            listener({ type: "agent_end", messages: [] });
+          }
+        });
+      }),
+      dispose: vi.fn(),
+      sessionManager: {
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "opencandle-router",
+            data: { output: { workflow: "general_qa" } },
+            timestamp: "2026-07-04T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+    createOpenCandleSessionMock.mockResolvedValue({ session });
+
+    const result = await runOpenCandleSession({
+      prompt: "Answer briefly",
+      settleGraceMs: 0,
+      timeoutMs: 1000,
+    });
+
+    expect(result.agentTrace.prompt).toBe("Answer briefly");
+    expect(result.agentTrace.prompts).toBeUndefined();
+    expect(result.agentTrace.turns[0]?.promptIndex).toBeUndefined();
+    expect(result.agentTrace.customEntries?.[0]?.promptIndex).toBeUndefined();
+  });
+
+  it("runs multiple prompts sequentially and tags trace entries by prompt index", async () => {
+    const listeners: Array<(event: Record<string, unknown>) => void> = [];
+    const entries: Array<Record<string, unknown>> = [];
+    const session = {
+      subscribe: vi.fn((listener: (event: Record<string, unknown>) => void) => {
+        listeners.push(listener);
+        return () => {};
+      }),
+      prompt: vi.fn(async (prompt: string) => {
+        const promptIndex = session.prompt.mock.calls.length - 1;
+        entries.push({
+          type: "custom",
+          customType: "opencandle-router",
+          data: { prompt },
+          timestamp: `2026-07-04T00:00:0${promptIndex}.000Z`,
+        });
+        queueMicrotask(() => {
+          for (const listener of listeners) {
+            listener({
+              type: "tool_execution_start",
+              toolCallId: `tool-${promptIndex}`,
+              toolName: "get_stock_quote",
+              args: { symbol: promptIndex === 0 ? "NVDA" : "AMD" },
+            });
+            listener({
+              type: "tool_execution_end",
+              toolCallId: `tool-${promptIndex}`,
+              toolName: "get_stock_quote",
+              result: { promptIndex },
+              isError: false,
+            });
+            listener({
+              type: "message_update",
+              assistantMessageEvent: {
+                type: "text_delta",
+                delta: `answer ${promptIndex}`,
+              },
+            });
+            listener({ type: "turn_end", message: {}, toolResults: [] });
+            listener({ type: "agent_end", messages: [] });
+          }
+        });
+      }),
+      dispose: vi.fn(),
+      sessionManager: {
+        getEntries: () => entries,
+      },
+    };
+    createOpenCandleSessionMock.mockResolvedValue({ session });
+
+    const result = await runOpenCandleSession({
+      prompts: ["Tell me about NVDA", "Now compare AMD"],
+      settleGraceMs: 0,
+      timeoutMs: 1000,
+    });
+
+    expect(session.prompt).toHaveBeenCalledTimes(2);
+    expect(session.prompt.mock.calls.map((call) => call[0])).toEqual([
+      "Tell me about NVDA",
+      "Now compare AMD",
+    ]);
+    expect(result.agentTrace.prompt).toBe("Tell me about NVDA");
+    expect(result.agentTrace.prompts).toEqual(["Tell me about NVDA", "Now compare AMD"]);
+    expect(result.agentTrace.turns.map((turn) => turn.promptIndex)).toEqual([0, 1]);
+    expect(result.agentTrace.turns.map((turn) => turn.toolCalls[0]?.promptIndex)).toEqual([0, 1]);
+    expect(result.agentTrace.customEntries?.map((entry) => entry.promptIndex)).toEqual([0, 1]);
+    expect(result.evalTrace.customEntries?.map((entry) => entry.promptIndex)).toEqual([0, 1]);
+  });
 });


### PR DESCRIPTION
## Summary

Implements I1 harness multi-prompt support:

- `runOpenCandleSession` now accepts `prompts: string[]` and runs each prompt sequentially through the same session while waiting for settle between prompts.
- Existing `prompt: string` callers keep the original one-prompt trace shape with no `prompts` array or `promptIndex` fields.
- Trace turns, tool calls, interactions, and OpenCandle custom entries get `promptIndex` tags in multi-prompt mode.
- `tests/harness/cli.ts` adds `send --ipc <dir> --prompt <text>` so a completed or waiting IPC harness session can receive follow-up prompts and accumulate the trace.

## Evidence

Committed under `docs/internal/pr-evidence/feat-harness-multi-prompt/`:

- `trace.json`: live credentialed two-prompt IPC harness trace.
- `summary.json`: prompt/turn/custom-entry prompt-index summary.
- `harness.log`: run/send lifecycle log.

## Validation

- `npm test` ✅ 222 files, 2313 passed, 2 skipped
- `npx tsc --noEmit` ✅
- `npx biome ci .` ✅ (existing warnings only)
- Named I1 harness tests ✅ `npx vitest run tests/unit/harness/opencandle-runner.test.ts tests/unit/harness/ipc.test.ts tests/unit/harness/trace-collector.test.ts tests/unit/harness/ipc-ask-handler.test.ts tests/unit/harness/integration.test.ts`
- Live harness evidence ✅ real `GEMINI_API_KEY` from `.env`, two prompts via `run` + `send`
- `graphify update .` ✅

## Known blocker

- `npm run test:evals -- -t "no-tool"` still fails before eval cases execute with the existing `vitest-evals` loader error: `TypeError: define is not a function` from `node_modules/vitest-evals/src/index.ts:580`.
