### PR TITLE
test(evals): add ask-vs-guess boundary cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added opt-in E5 ask-instead-of-guess product evals for ambiguous calls/bank prompts and resolvable prior-turn twins, with committed live findings for current over-guessing and over-asking behavior.
 - Added deterministic E3 provider-outage eval coverage for zero-filled Yahoo quote payloads and partial correlation matrices under a mocked Yahoo fetch surface, with known-fail findings recorded for stale weekend quote freshness and turn-gap trace emission.
 
 ### Changed

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/FINDINGS.md
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/FINDINGS.md
@@ -1,0 +1,17 @@
+# E5 Current-Behavior Findings
+
+The E5 product eval cases are marked `tier: "opt-in"` because current live behavior does not satisfy three of the four boundary cases. This follows the I5 eval-author rule: failing current behavior is recorded as a finding, not fixed in production by this eval PR.
+
+## Findings
+
+- `ask-vs-guess-ambiguous-compare-the-banks`: OpenCandle calls `ask_user` exactly once, but the trace also resolves guessed bank symbols (`JPM`, `BAC`, `WFC`, `C`) before the user specifies tickers.
+- `ask-vs-guess-ambiguous-sell-my-calls`: OpenCandle does not call `ask_user`; it resolves both seeded option underlyings (`NVDA`, `AMD`) for the ambiguous pronoun-backed request.
+- `ask-vs-guess-prior-turn-sell-my-calls`: OpenCandle asks for clarification even though the prior turn names NVDA, routes as `general_finance_qa` instead of `options_screener`, and still includes AMD in resolved symbols.
+
+## Passing Twin
+
+- `ask-vs-guess-prior-turn-compare-the-banks`: OpenCandle correctly uses prior turn context, asks zero clarification questions, routes to `compare_assets`, and resolves `JPM`/`BAC`.
+
+## Promotion Criteria
+
+Promote these cases out of opt-in only after all paired cases pass in live traces: ambiguous cases must ask exactly once without pre-clarification ticker guessing, and resolvable twins must ask zero times while resolving only the contextual symbols.

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/NOTES.md
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/NOTES.md
@@ -1,0 +1,25 @@
+# E5 Ask-Instead-Of-Guess Eval Notes
+
+## Scope
+
+This PR adds E5 boundary eval coverage only. It does not modify production routing, prompts, workflow code, or tools.
+
+## Behavior Mapping
+
+- Ambiguous `"Should I sell my calls?"` with two saved option positions: `ask-vs-guess-ambiguous-sell-my-calls` expects exactly one focused `ask_user` and no guessed NVDA/AMD resolution before clarification.
+- Ambiguous `"Compare the banks."` with no tickers: `ask-vs-guess-ambiguous-compare-the-banks` expects exactly one focused `ask_user` and no guessed bank ticker resolution before clarification.
+- Resolvable calls twin: `ask-vs-guess-prior-turn-sell-my-calls` uses prior turn context plus the seeded saved option positions and expects zero `ask_user`, options workflow routing, and NVDA-only resolution.
+- Resolvable banks twin: `ask-vs-guess-prior-turn-compare-the-banks` uses prior turn context and expects zero `ask_user` plus JPM/BAC resolution.
+
+## Tests
+
+- `tests/unit/evals/product-evals.test.ts` verifies exact `ask_user` scoring, no-guess symbol assertions, prior-turn resolution assertions, E5 case pairing, and opt-in tiering.
+- `tests/evals/product/scorer.ts` now scores exact ask count, ask question focus, and resolved symbol presence/absence from trace evidence.
+- `tests/scripts/run-product-evals.ts` supports opt-in product cases, multi-prompt product cases, and disposable seeded market-state fixtures.
+
+## Live Evidence
+
+- `ambiguous-compare-the-banks.product-evals.json`: FAIL, asks once but still resolves JPM/BAC/WFC/C before user clarification.
+- `ambiguous-sell-my-calls.product-evals.json`: FAIL, does not ask and resolves both seeded option underlyings.
+- `prior-turn-compare-the-banks.product-evals.json`: PASS, no ask and resolves JPM/BAC.
+- `prior-turn-sell-my-calls.product-evals.json`: FAIL, asks despite prior context and includes AMD in resolution.

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/ambiguous-compare-the-banks.product-evals.json
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/ambiguous-compare-the-banks.product-evals.json
@@ -1,0 +1,787 @@
+{
+  "generatedAt": "2026-07-04T04:01:46.575Z",
+  "caseCount": 1,
+  "aggregate": 0.6666666666666666,
+  "passed": 0,
+  "failed": 1,
+  "byFamily": {
+    "compare_assets": {
+      "caseCount": 1,
+      "aggregate": 0.6666666666666666,
+      "passed": 0,
+      "failed": 1
+    }
+  },
+  "byDimension": {
+    "ask_instead_of_guess": {
+      "passed": 1,
+      "failed": 0
+    },
+    "ambiguous_banks_no_guess": {
+      "passed": 0,
+      "failed": 1
+    }
+  },
+  "results": [
+    {
+      "id": "ask-vs-guess-ambiguous-compare-the-banks",
+      "family": "compare_assets",
+      "prompt": "Compare the banks.",
+      "score": 0.6666666666666666,
+      "passed": false,
+      "mandatoryFailure": true,
+      "dimensions": [
+        {
+          "id": "ask_instead_of_guess",
+          "description": "Asks exactly one focused clarification question instead of guessing.",
+          "passed": true,
+          "score": 1,
+          "weight": 2,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "ambiguous_banks_no_guess",
+          "description": "Does not choose bank tickers before the user specifies them.",
+          "passed": false,
+          "score": 0,
+          "weight": 1,
+          "mandatory": true,
+          "message": "forbidden resolved symbol JPM; forbidden resolved symbol BAC; forbidden resolved symbol WFC; forbidden resolved symbol C"
+        }
+      ],
+      "trace": {
+        "prompt": "Compare the banks.",
+        "classification": {
+          "workflow": "compare_assets",
+          "confidence": 0.5,
+          "tier": "llm",
+          "entities": {
+            "symbols": []
+          }
+        },
+        "router": {
+          "routeKind": "clarification",
+          "legacyRoute": "fallback",
+          "workflow": "compare_assets",
+          "missingRequired": [
+            "symbols"
+          ],
+          "toolBundles": [
+            "clarification"
+          ],
+          "activeToolNames": [
+            "ask_user"
+          ],
+          "memoryCategories": [
+            "investor_profile",
+            "workflow_history"
+          ],
+          "memoryProvenance": [],
+          "diagnostics": [],
+          "toolScopeViolations": [
+            {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "compare_companies",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            }
+          ],
+          "toolScope": [
+            {
+              "mode": "observe",
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ],
+              "enforced": false
+            }
+          ]
+        },
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "general_fallback",
+          "commitmentMode": "framework",
+          "policyCardId": "general_fallback",
+          "evidencePlanId": "placeholder_general_fallback",
+          "answerContractId": "general_fallback",
+          "structuredCheckIds": [
+            "data_gap_disclosed"
+          ],
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "capabilityGapIds": [],
+          "evidenceRecords": [
+            {
+              "id": "tool_result:ask_user",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "ask_user"
+              },
+              "entityScope": {},
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "ask_user",
+                "args": {
+                  "question": "Which banks would you like to compare? Please provide a list of ticker symbols or company names.",
+                  "reason": "To compare companies, I need to know which specific companies (banks) you are interested in.",
+                  "question_type": "text"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 0,
+                "toolName": "ask_user"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:compare_companies",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "compare_companies"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM",
+                  "BAC",
+                  "WFC",
+                  "C"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "compare_companies",
+                "args": {
+                  "symbols": [
+                    "JPM",
+                    "BAC",
+                    "WFC",
+                    "C"
+                  ]
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 1,
+                "toolName": "compare_companies"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "BAC"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 2,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "C"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "C"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 3,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "WFC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "WFC"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 4,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "JPM"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 5,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            }
+          ],
+          "structuredCheckResults": [
+            {
+              "checkId": "required_evidence_present",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "freshness_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Data-gap disclosure metadata does not cover observed evidence gaps."
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: data_gap_disclosure"
+            },
+            {
+              "checkId": "source_coverage_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "capability_gap_disclosure",
+              "passed": true,
+              "observedOnly": true
+            }
+          ],
+          "structuredCheckFailures": [
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Data-gap disclosure metadata does not cover observed evidence gaps."
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: data_gap_disclosure"
+            }
+          ],
+          "retryEligibility": {
+            "eligible": true,
+            "activeRetryAllowed": false,
+            "reasons": [
+              "data_gap_disclosed: Data-gap disclosure metadata does not cover observed evidence gaps.",
+              "commitment_mode_respected: Expected framework metadata and fields: framework_or_checklist",
+              "required_final_fields_present: Missing required final fields: data_gap_disclosure"
+            ]
+          },
+          "parityStatus": "legacy_active",
+          "regressionClassification": "none"
+        },
+        "toolCalls": [
+          {
+            "name": "ask_user",
+            "args": {
+              "question": "Which banks would you like to compare? Please provide a list of ticker symbols or company names.",
+              "reason": "To compare companies, I need to know which specific companies (banks) you are interested in.",
+              "question_type": "text"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "User cancelled the selection. Proceed with your best judgment and disclose your assumption."
+                }
+              ],
+              "details": {
+                "question": "Which banks would you like to compare? Please provide a list of ticker symbols or company names.",
+                "questionType": "text",
+                "answer": null,
+                "cancelled": true
+              }
+            }
+          },
+          {
+            "name": "compare_companies",
+            "args": {
+              "symbols": [
+                "JPM",
+                "BAC",
+                "WFC",
+                "C"
+              ]
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "⚠ Company fundamentals unavailable for all symbols: JPM, BAC, WFC, C. Alpha Vantage may be rate limited."
+                }
+              ],
+              "details": null
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "BAC"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "BAC: $58.73 (+0.63%)\nOpen: $58.94 | High: $59.00 | Low: $57.94\nVolume: 24,345,325 | Market Cap: N/A\n52W Range: $44.75 - $59.20"
+                }
+              ],
+              "details": {
+                "symbol": "BAC",
+                "price": 58.73,
+                "change": 0.36999999999999744,
+                "changePercent": 0.6339958875942383,
+                "open": 58.939998626708984,
+                "high": 59,
+                "low": 57.94,
+                "previousClose": 58.36,
+                "volume": 24345325,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 59.2,
+                "week52Low": 44.75,
+                "timestamp": 1783137698625,
+                "currency": "USD"
+              }
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "C"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "C: $139.97 (-0.11%)\nOpen: $141.88 | High: $142.11 | Low: $138.22\nVolume: 6,188,688 | Market Cap: N/A\n52W Range: $85.48 - $147.96"
+                }
+              ],
+              "details": {
+                "symbol": "C",
+                "price": 139.97,
+                "change": -0.1599999999999966,
+                "changePercent": -0.11417969028758768,
+                "open": 141.8800048828125,
+                "high": 142.11,
+                "low": 138.22,
+                "previousClose": 140.13,
+                "volume": 6188688,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 147.96,
+                "week52Low": 85.48,
+                "timestamp": 1783137698649,
+                "currency": "USD"
+              }
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "WFC"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WFC: $85.51 (-0.50%)\nOpen: $86.61 | High: $86.74 | Low: $85.09\nVolume: 10,421,504 | Market Cap: N/A\n52W Range: $72.78 - $97.76"
+                }
+              ],
+              "details": {
+                "symbol": "WFC",
+                "price": 85.51,
+                "change": -0.4299999999999926,
+                "changePercent": -0.5003490807540059,
+                "open": 86.61000061035156,
+                "high": 86.74,
+                "low": 85.09,
+                "previousClose": 85.94,
+                "volume": 10421504,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 97.76,
+                "week52Low": 72.78,
+                "timestamp": 1783137698653,
+                "currency": "USD"
+              }
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "JPM"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "JPM: $334.47 (+0.12%)\nOpen: $338.02 | High: $338.84 | Low: $331.88\nVolume: 4,545,984 | Market Cap: N/A\n52W Range: $279.10 - $343.45"
+                }
+              ],
+              "details": {
+                "symbol": "JPM",
+                "price": 334.47,
+                "change": 0.4000000000000341,
+                "changePercent": 0.11973538479960312,
+                "open": 338.0199890136719,
+                "high": 338.844,
+                "low": 331.88,
+                "previousClose": 334.07,
+                "volume": 4545984,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 343.45,
+                "week52Low": 279.1,
+                "timestamp": 1783137698655,
+                "currency": "USD"
+              }
+            }
+          }
+        ],
+        "askUserTranscript": [
+          {
+            "question": "Which banks would you like to compare? Please provide a list of ticker symbols or company names.",
+            "answer": null
+          }
+        ],
+        "text": "Analyst View:\n\nTo compare the banks, I assumed you were interested in major US banks: JPMorgan Chase (JPM), Bank of America (BAC), Wells Fargo (WFC), and Citigroup (C).\n\nHere is a summary of their current stock quotes:\n\n| Symbol | Price    | Daily Change | 52-Week Range       |\n|--------|----------|--------------|---------------------|\n| JPM    | $334.47  | +0.12%       | $279.10 - $343.45   |\n| BAC    | $58.73   | +0.63%       | $44.75 - $59.20    |\n| WFC    | $85.51   | -0.50%       | $72.78 - $97.76    |\n| C      | $139.97  | -0.11%       | $85.48 - $147.96   |\n\n*Data as of 2026-07-04*\n\n**Reasoning Chain:**\nThe `compare_companies` tool, which provides side-by-side valuation and financial metrics, was unable to retrieve data. Therefore, I fetched individual stock quotes to provide current price, daily movement, and 52-week context for these major banking institutions.\n\n**Confidence Band:**\nHigh confidence in the accuracy of the current quote data. Low confidence in providing a comprehensive comparison due to the unavailability of fundamental data via the `compare_companies` tool.\n\n**Invalidation Level:**\nThis summary would be invalidated if the user had different banks in mind for comparison, or if a full fundamental comparison became possible through an alternative data source.",
+        "customEntries": [
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "clarification",
+                "route": "fallback",
+                "workflow": "compare_assets",
+                "entities": {
+                  "symbols": []
+                },
+                "slots": {},
+                "preference_updates": [],
+                "missing_required": [
+                  "symbols"
+                ],
+                "tool_bundles": [
+                  "clarification"
+                ],
+                "diagnostics": [],
+                "reasoning": "The user wants to compare assets, but has not specified which symbols to compare. 'The banks' is too broad and requires clarification."
+              }
+            },
+            "timestamp": "2026-07-04T04:01:31.004Z"
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "Compare the banks.",
+              "priorTurns": [],
+              "routeKind": "clarification",
+              "legacyRoute": "fallback",
+              "workflow": "compare_assets",
+              "entities": {
+                "symbols": []
+              },
+              "slots": {},
+              "missingRequired": [
+                "symbols"
+              ],
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "clarification",
+                "workflow": "compare_assets",
+                "categories": [
+                  "investor_profile",
+                  "workflow_history"
+                ],
+                "symbols": [],
+                "slotKeys": []
+              },
+              "memoryProvenance": [],
+              "promptPlaybook": "clarification",
+              "diagnostics": [],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "general_fallback",
+                "commitmentMode": "framework",
+                "policyCardId": "general_fallback",
+                "evidencePlanId": "placeholder_general_fallback",
+                "answerContractId": "general_fallback",
+                "structuredCheckIds": [
+                  "data_gap_disclosed"
+                ],
+                "capabilityGapIds": [],
+                "behaviorMode": "observe_only",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": [
+                  {
+                    "code": "planning_task_family_corrected",
+                    "message": "general_fallback is not supported for clarification/compare_assets; using general_fallback"
+                  },
+                  {
+                    "code": "planning_observe_only",
+                    "message": "planning metadata is recorded without changing active prompt, route, workflow, tools, or answer behavior"
+                  }
+                ]
+              }
+            },
+            "timestamp": "2026-07-04T04:01:31.004Z"
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:01:31.004Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "compare_companies",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:01:35.491Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:01:38.478Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:01:38.478Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:01:38.478Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "clarification",
+              "workflow": "compare_assets",
+              "toolName": "get_stock_quote",
+              "toolBundles": [
+                "clarification"
+              ],
+              "activeToolNames": [
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:01:38.478Z"
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:01:41.795Z"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/ambiguous-sell-my-calls.product-evals.json
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/ambiguous-sell-my-calls.product-evals.json
@@ -1,0 +1,849 @@
+{
+  "generatedAt": "2026-07-04T04:02:39.444Z",
+  "caseCount": 1,
+  "aggregate": 0,
+  "passed": 0,
+  "failed": 1,
+  "byFamily": {
+    "options": {
+      "caseCount": 1,
+      "aggregate": 0,
+      "passed": 0,
+      "failed": 1
+    }
+  },
+  "byDimension": {
+    "ask_instead_of_guess": {
+      "passed": 0,
+      "failed": 1
+    },
+    "ambiguous_calls_no_guess": {
+      "passed": 0,
+      "failed": 1
+    }
+  },
+  "results": [
+    {
+      "id": "ask-vs-guess-ambiguous-sell-my-calls",
+      "family": "options",
+      "prompt": "Should I sell my calls?",
+      "score": 0,
+      "passed": false,
+      "mandatoryFailure": true,
+      "dimensions": [
+        {
+          "id": "ask_instead_of_guess",
+          "description": "Asks exactly one focused clarification question instead of guessing.",
+          "passed": false,
+          "score": 0,
+          "weight": 2,
+          "mandatory": true,
+          "message": "expected exactly 1 ask_user calls, got 0; missing ask_user question pattern /\\b(which|what|ticker|symbol|position|bank|calls?)\\b/i"
+        },
+        {
+          "id": "ambiguous_calls_no_guess",
+          "description": "Does not resolve either saved option position before the user clarifies.",
+          "passed": false,
+          "score": 0,
+          "weight": 1,
+          "mandatory": true,
+          "message": "forbidden resolved symbol NVDA; forbidden resolved symbol AMD"
+        }
+      ],
+      "trace": {
+        "prompt": "Should I sell my calls?",
+        "classification": {
+          "workflow": "general_finance_qa",
+          "confidence": 0.5,
+          "tier": "llm",
+          "entities": {
+            "symbols": [],
+            "direction": "bullish"
+          }
+        },
+        "router": {
+          "routeKind": "agent_task",
+          "legacyRoute": "fallback",
+          "workflow": "general_finance_qa",
+          "missingRequired": [],
+          "toolBundles": [
+            "core_market",
+            "macro",
+            "sentiment",
+            "sec",
+            "clarification"
+          ],
+          "activeToolNames": [
+            "search_ticker",
+            "get_stock_quote",
+            "get_stock_history",
+            "screen_stocks",
+            "get_crypto_price",
+            "get_crypto_history",
+            "get_company_overview",
+            "get_financials",
+            "get_earnings",
+            "compare_companies",
+            "compute_dcf",
+            "get_technical_indicators",
+            "backtest_strategy",
+            "analyze_risk",
+            "analyze_correlation",
+            "analyze_holdings_overlap",
+            "track_portfolio",
+            "manage_watchlist",
+            "manage_alerts",
+            "daily_watchlist_report",
+            "manage_notifications",
+            "search_web",
+            "get_economic_data",
+            "get_fear_greed",
+            "get_reddit_sentiment",
+            "get_twitter_sentiment",
+            "get_web_sentiment",
+            "get_sentiment_trend",
+            "get_sentiment_summary",
+            "get_sec_filings",
+            "ask_user"
+          ],
+          "memoryCategories": [
+            "investor_profile",
+            "workflow_history"
+          ],
+          "memoryProvenance": [],
+          "diagnostics": [
+            {
+              "code": "tool_bundles_corrected",
+              "message": "unsupported emitted bundles dropped: options"
+            }
+          ],
+          "toolScopeViolations": [
+            {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            }
+          ],
+          "toolScope": [
+            {
+              "mode": "observe",
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "enforced": false
+            }
+          ]
+        },
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "general_fallback",
+          "commitmentMode": "framework",
+          "policyCardId": "general_fallback",
+          "evidencePlanId": "placeholder_general_fallback",
+          "answerContractId": "general_fallback",
+          "structuredCheckIds": [
+            "data_gap_disclosed"
+          ],
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "capabilityGapIds": [],
+          "evidenceRecords": [
+            {
+              "id": "tool_result:track_portfolio",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "track_portfolio"
+              },
+              "entityScope": {},
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "track_portfolio",
+                "args": {
+                  "action": "view"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 0,
+                "toolName": "track_portfolio"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_option_chain",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_option_chain"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_option_chain",
+                "args": {
+                  "type": "call",
+                  "expiration": "2026-01-16",
+                  "symbol": "NVDA"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 1,
+                "toolName": "get_option_chain"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "NVDA"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 2,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "AMD"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "AMD"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 3,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            }
+          ],
+          "structuredCheckResults": [
+            {
+              "checkId": "required_evidence_present",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "freshness_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Data-gap disclosure metadata does not cover observed evidence gaps."
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: data_gap_disclosure"
+            },
+            {
+              "checkId": "source_coverage_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "capability_gap_disclosure",
+              "passed": true,
+              "observedOnly": true
+            }
+          ],
+          "structuredCheckFailures": [
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Data-gap disclosure metadata does not cover observed evidence gaps."
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: data_gap_disclosure"
+            }
+          ],
+          "retryEligibility": {
+            "eligible": true,
+            "activeRetryAllowed": false,
+            "reasons": [
+              "data_gap_disclosed: Data-gap disclosure metadata does not cover observed evidence gaps.",
+              "commitment_mode_respected: Expected framework metadata and fields: framework_or_checklist",
+              "required_final_fields_present: Missing required final fields: data_gap_disclosure"
+            ]
+          },
+          "parityStatus": "legacy_active",
+          "regressionClassification": "none"
+        },
+        "toolCalls": [
+          {
+            "name": "track_portfolio",
+            "args": {
+              "action": "view"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**Portfolio** — 2 positions | Value: $0.00 | P&L: $0.00 (+0.00%)\n  NVDA260116C00200000: 2 @ $32.50 → unavailable | P&L: unavailable [excluded from USD totals: Quote unavailable: HTTP 404 Not Found]\n  AMD260116C00150000: 3 @ $12.10 → unavailable | P&L: unavailable [excluded from USD totals: Quote unavailable: HTTP 404 Not Found]\nExcluded from USD totals: NVDA260116C00200000 (USD), AMD260116C00150000 (USD)"
+                }
+              ],
+              "details": {
+                "positions": [
+                  {
+                    "symbol": "NVDA260116C00200000",
+                    "shares": 2,
+                    "avgCost": 32.5,
+                    "currency": "USD",
+                    "addedAt": "2026-07-04T04:02:12.917Z",
+                    "currentPrice": null,
+                    "marketValue": null,
+                    "totalCost": 65,
+                    "pnl": null,
+                    "pnlPercent": null,
+                    "includedInTotals": false,
+                    "quoteStatus": "unavailable",
+                    "exclusionReason": "Quote unavailable: HTTP 404 Not Found"
+                  },
+                  {
+                    "symbol": "AMD260116C00150000",
+                    "shares": 3,
+                    "avgCost": 12.1,
+                    "currency": "USD",
+                    "addedAt": "2026-07-04T04:02:12.917Z",
+                    "currentPrice": null,
+                    "marketValue": null,
+                    "totalCost": 36.3,
+                    "pnl": null,
+                    "pnlPercent": null,
+                    "includedInTotals": false,
+                    "quoteStatus": "unavailable",
+                    "exclusionReason": "Quote unavailable: HTTP 404 Not Found"
+                  }
+                ],
+                "baseCurrency": "USD",
+                "totalValue": 0,
+                "totalCost": 0,
+                "totalPnl": 0,
+                "totalPnlPercent": 0,
+                "excludedFromTotals": [
+                  {
+                    "symbol": "NVDA260116C00200000",
+                    "currency": "USD",
+                    "reason": "Quote unavailable: HTTP 404 Not Found"
+                  },
+                  {
+                    "symbol": "AMD260116C00150000",
+                    "currency": "USD",
+                    "reason": "Quote unavailable: HTTP 404 Not Found"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "get_option_chain",
+            "args": {
+              "type": "call",
+              "expiration": "2026-01-16",
+              "symbol": "NVDA"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**NVDA Options Chain** — Expiry: 2026-01-16\nUnderlying: $194.83\nQuote status: closed / mixed_or_unknown\nOption bid/ask and last prices are quoted per share; multiply by 100 for one standard contract premium.\n⚠ Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens. do not treat zero bid/ask as confirmed live illiquidity without broker verification; do not stop at the stale quote caveat. Disclose the gap, avoid naming tradable live premiums, and finish the strategy explanation with mechanics, assignment outcomes, labeled hypotheticals, and what live broker quotes would change.\nAvailable expirations: 2026-07-06, 2026-07-08, 2026-07-10, 2026-07-17, 2026-07-24, 2026-07-31, 2026-08-07, 2026-08-21, 2026-09-18, 2026-10-16, 2026-11-20, 2026-12-18, 2027-01-15, 2027-03-19, 2027-06-17, 2027-09-17, 2027-12-17, 2028-01-21, 2028-06-16, 2028-12-15\n\nPut/Call Ratio: 0.00"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "underlyingPrice": 194.83,
+                "expirationDate": "2026-01-16",
+                "expirationDates": [
+                  "2026-07-06",
+                  "2026-07-08",
+                  "2026-07-10",
+                  "2026-07-17",
+                  "2026-07-24",
+                  "2026-07-31",
+                  "2026-08-07",
+                  "2026-08-21",
+                  "2026-09-18",
+                  "2026-10-16",
+                  "2026-11-20",
+                  "2026-12-18",
+                  "2027-01-15",
+                  "2027-03-19",
+                  "2027-06-17",
+                  "2027-09-17",
+                  "2027-12-17",
+                  "2028-01-21",
+                  "2028-06-16",
+                  "2028-12-15"
+                ],
+                "calls": [],
+                "puts": [],
+                "totalCallVolume": 0,
+                "totalPutVolume": 0,
+                "putCallRatio": 0,
+                "quoteStatus": {
+                  "marketSession": "closed",
+                  "bidAskState": "mixed_or_unknown",
+                  "zeroBidAskContracts": 0,
+                  "totalContracts": 0,
+                  "warning": "Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens."
+                },
+                "fetchedAt": "2026-07-04T04:02:19.629Z"
+              }
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "NVDA"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "NVDA: $194.83 (-1.39%)\nOpen: $197.14 | High: $200.06 | Low: $192.35\nVolume: 129,935,067 | Market Cap: N/A\n52W Range: $157.34 - $236.54"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "price": 194.83,
+                "change": -2.75,
+                "changePercent": -1.3918412794817288,
+                "open": 197.13999938964844,
+                "high": 200.055,
+                "low": 192.35,
+                "previousClose": 197.58,
+                "volume": 129935067,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 236.54,
+                "week52Low": 157.34,
+                "timestamp": 1783137743462,
+                "currency": "USD"
+              }
+            }
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "AMD"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "AMD: $517.82 (-4.26%)\nOpen: $538.16 | High: $547.65 | Low: $506.00\nVolume: 27,272,794 | Market Cap: N/A\n52W Range: $133.50 - $584.73"
+                }
+              ],
+              "details": {
+                "symbol": "AMD",
+                "price": 517.82,
+                "change": -23.059999999999945,
+                "changePercent": -4.263422570625637,
+                "open": 538.1599731445312,
+                "high": 547.65,
+                "low": 506,
+                "previousClose": 540.88,
+                "volume": 27272794,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 584.73,
+                "week52Low": 133.5,
+                "timestamp": 1783137744557,
+                "currency": "USD"
+              }
+            }
+          }
+        ],
+        "askUserTranscript": [],
+        "text": "Our read is that the decision to sell your calls depends heavily on your outlook for NVDA and AMD, your risk tolerance, and your original investment thesis for these options.\n\n**NVDA Jan 16 2026 200 Call (2 contracts @ $32.50 average cost):**\n*   **Current Status:** This call is currently out-of-the-money (OTM). With NVDA at $194.83 and a strike of $200, it has no intrinsic value. Its value is purely extrinsic (time value and implied volatility).\n*   **Recommendation:** If you believe NVDA will trade above $200 (plus the premium you paid per share) by January 16, 2026, you might consider holding. However, if your conviction in NVDA's near-term upside is weakening, selling now would allow you to capture any remaining time value before it erodes further. Given the current price is below the strike, the risk of this option expiring worthless increases as time passes.\n\n**AMD Jan 16 2026 150 Call (3 contracts @ $12.10 average cost):**\n*   **Current Status:** This call is deep in-the-money (ITM). With AMD at $517.82 and a strike of $150, it has significant intrinsic value ($517.82 - $150.00 = $367.82 per share).\n*   **Recommendation:** This option has generated substantial gains if your average cost of $12.10 reflects the premium paid per share. Selling now would lock in these profits. Holding carries the risk that AMD's stock price could decline, reducing the option's intrinsic value. Given the long expiration date (Jan 2026), there is still significant time value, but the primary driver of its value is the intrinsic value.\n\n**Commitment:**\nWe recommend considering selling the **AMD Jan 16 2026 150 Call** to realize significant profits, and evaluating your conviction in **NVDA Jan 16 2026 200 Call** for a potential sale to mitigate further time decay risk.\n\n**Reasoning Chain:**\n*   **AMD:** The AMD call is deep in-the-money, meaning a substantial portion of its value is intrinsic and represents a realized profit. Locking in profits for ITM options, especially when a significant gain has been made, is a prudent risk management strategy. Current AMD price: $517.82, Strike: $150.00.\n*   **NVDA:** The NVDA call is currently out-of-the-money. While there's still over a year until expiration, the option is losing time value daily. The underlying stock price is currently below the strike. Current NVDA price: $194.83, Strike: $200.00.\n\n**Confidence Band:**\nModerate conviction. The inability to fetch live options quotes due to market closure or illiquidity introduces uncertainty regarding the exact current premium and bid/ask spread, which would influence the optimal execution. (Data as of 2026-07-04)\n\n**Invalidation Level:**\n*   **AMD:** Our view to sell would be invalidated if you have strong fundamental reasons to believe AMD will continue a rapid, sustained upward trend, significantly beyond its current price, and you are comfortable with the increased risk of holding a highly profitable position.\n*   **NVDA:** Our view to consider selling would be invalidated if NVDA shows strong price action above $200 (and ideally well above your cost basis for the option) in the near term, confirming a renewed bullish trend before significant time decay occurs.",
+        "customEntries": [
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "agent_task",
+                "route": "fallback",
+                "workflow": "general_finance_qa",
+                "entities": {
+                  "symbols": [],
+                  "direction": "bullish"
+                },
+                "slots": {},
+                "preference_updates": [],
+                "missing_required": [],
+                "tool_bundles": [
+                  "core_market",
+                  "macro",
+                  "sentiment",
+                  "sec",
+                  "clarification"
+                ],
+                "diagnostics": [
+                  {
+                    "code": "tool_bundles_corrected",
+                    "message": "unsupported emitted bundles dropped: options"
+                  }
+                ],
+                "reasoning": "The user is asking for advice on managing an existing options position, which falls under general finance strategy. No specific symbol or action for a dispatchable workflow is provided."
+              }
+            },
+            "timestamp": "2026-07-04T04:02:15.057Z"
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "Should I sell my calls?",
+              "priorTurns": [],
+              "routeKind": "agent_task",
+              "legacyRoute": "fallback",
+              "workflow": "general_finance_qa",
+              "entities": {
+                "symbols": [],
+                "direction": "bullish"
+              },
+              "slots": {},
+              "missingRequired": [],
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "agent_task",
+                "workflow": "general_finance_qa",
+                "categories": [
+                  "investor_profile",
+                  "workflow_history"
+                ],
+                "symbols": [],
+                "slotKeys": []
+              },
+              "memoryProvenance": [],
+              "promptPlaybook": "agent_task",
+              "diagnostics": [
+                {
+                  "code": "tool_bundles_corrected",
+                  "message": "unsupported emitted bundles dropped: options"
+                }
+              ],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "general_fallback",
+                "commitmentMode": "framework",
+                "policyCardId": "general_fallback",
+                "evidencePlanId": "placeholder_general_fallback",
+                "answerContractId": "general_fallback",
+                "structuredCheckIds": [
+                  "data_gap_disclosed"
+                ],
+                "capabilityGapIds": [],
+                "behaviorMode": "observe_only",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": [
+                  {
+                    "code": "planning_after_router_corrections",
+                    "message": "planning selected after router diagnostics were applied"
+                  },
+                  {
+                    "code": "planning_observe_only",
+                    "message": "planning metadata is recorded without changing active prompt, route, workflow, tools, or answer behavior"
+                  }
+                ]
+              }
+            },
+            "timestamp": "2026-07-04T04:02:15.057Z"
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:02:15.057Z"
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:02:19.093Z"
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:02:34.692Z"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/biome-ci.log
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/biome-ci.log
@@ -1,0 +1,3 @@
+[0m[34mChecked 599 files in 634[0m[0m[2m[34mms[0m[0m[34m.[0m[0m[34m No fixes applied.[0m[0m
+[0m[0m[33mFound [0m[0m[33m494[0m[0m[33m warnings.[0m[0m
+[0m[0m[34mFound [0m[0m[34m36[0m[0m[34m infos.[0m

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/focused-product-evals-vitest.log
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/focused-product-evals-vitest.log
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-ask-vs-guess
+
+
+ Test Files  1 passed (1)
+      Tests  18 passed (18)
+   Start at  00:05:57
+   Duration  141ms (transform 46ms, setup 0ms, import 57ms, tests 8ms, environment 0ms)
+

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/graphify-update.log
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/graphify-update.log
@@ -1,0 +1,18 @@
+Re-extracting code files in . (no LLM needed)...
+  AST extraction: 100/1171 uncached files (8%) [10 workers]
+  AST extraction: 200/1171 uncached files (17%) [10 workers]
+  AST extraction: 300/1171 uncached files (25%) [10 workers]
+  AST extraction: 400/1171 uncached files (34%) [10 workers]
+  AST extraction: 500/1171 uncached files (42%) [10 workers]
+  AST extraction: 600/1171 uncached files (51%) [10 workers]
+  AST extraction: 700/1171 uncached files (59%) [10 workers]
+  AST extraction: 800/1171 uncached files (68%) [10 workers]
+  AST extraction: 900/1171 uncached files (76%) [10 workers]
+  AST extraction: 1000/1171 uncached files (85%) [10 workers]
+  AST extraction: 1100/1171 uncached files (93%) [10 workers]
+  AST extraction: 1173/1173 files (100%) [10 workers]
+[graphify watch] Skipped graph.html: Graph has 11174 nodes - too large for HTML viz (limit: 5000). Use --no-viz, raise GRAPHIFY_VIZ_NODE_LIMIT, or reduce input size.
+[graphify watch] Rebuilt: 11174 nodes, 16123 edges, 861 communities
+[graphify watch] graph.json and GRAPH_REPORT.md updated in graphify-out
+Code graph updated. For doc/paper/image changes run /graphify --update in your AI assistant.
+Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction.

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/npm-test.log
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/npm-test.log
@@ -1,0 +1,21 @@
+
+> opencandle@0.11.0 pretest
+> npm run check:node
+
+
+> opencandle@0.11.0 check:node
+> node scripts/check-node-version.mjs
+
+
+> opencandle@0.11.0 test
+> vitest run
+
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-ask-vs-guess
+
+
+ Test Files  222 passed (222)
+      Tests  2331 passed | 2 skipped (2333)
+   Start at  00:06:01
+   Duration  17.18s (transform 11.05s, setup 0ms, import 38.44s, tests 56.72s, environment 16ms)
+

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/prior-turn-compare-the-banks.product-evals.json
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/prior-turn-compare-the-banks.product-evals.json
@@ -1,0 +1,9170 @@
+{
+  "generatedAt": "2026-07-04T04:03:44.183Z",
+  "caseCount": 1,
+  "aggregate": 1,
+  "passed": 1,
+  "failed": 0,
+  "byFamily": {
+    "compare_assets": {
+      "caseCount": 1,
+      "aggregate": 1,
+      "passed": 1,
+      "failed": 0
+    }
+  },
+  "byDimension": {
+    "workflow_fit": {
+      "passed": 1,
+      "failed": 0
+    },
+    "tool_selection": {
+      "passed": 1,
+      "failed": 0
+    },
+    "no_unneeded_clarification": {
+      "passed": 1,
+      "failed": 0
+    },
+    "prior_turn_banks_resolution": {
+      "passed": 1,
+      "failed": 0
+    },
+    "risk_framing": {
+      "passed": 1,
+      "failed": 0
+    }
+  },
+  "results": [
+    {
+      "id": "ask-vs-guess-prior-turn-compare-the-banks",
+      "family": "compare_assets",
+      "prompt": "Compare the banks.",
+      "score": 1,
+      "passed": true,
+      "mandatoryFailure": false,
+      "dimensions": [
+        {
+          "id": "workflow_fit",
+          "description": "Routes to compare_assets.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "tool_selection",
+          "description": "Uses required tools and avoids forbidden tools.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "no_unneeded_clarification",
+          "description": "Does not ask for clarification when context resolves the request.",
+          "passed": true,
+          "score": 1,
+          "weight": 2,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "prior_turn_banks_resolution",
+          "description": "Resolves the bank comparison to JPM and BAC from prior turn context.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "risk_framing",
+          "description": "Names downside, uncertainty, invalidation, or tradeoffs.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        }
+      ],
+      "trace": {
+        "prompt": "I'm deciding between JPM and BAC.",
+        "classification": {
+          "workflow": "compare_assets",
+          "confidence": 0.5,
+          "tier": "llm",
+          "entities": {
+            "symbols": [
+              "JPM",
+              "BAC"
+            ]
+          }
+        },
+        "router": {
+          "routeKind": "workflow_dispatch",
+          "legacyRoute": "workflow",
+          "workflow": "compare_assets",
+          "missingRequired": [],
+          "toolBundles": [
+            "core_market",
+            "macro",
+            "sentiment",
+            "clarification"
+          ],
+          "activeToolNames": [
+            "search_ticker",
+            "get_stock_quote",
+            "get_stock_history",
+            "screen_stocks",
+            "get_crypto_price",
+            "get_crypto_history",
+            "get_company_overview",
+            "get_financials",
+            "get_earnings",
+            "compare_companies",
+            "compute_dcf",
+            "get_technical_indicators",
+            "backtest_strategy",
+            "analyze_risk",
+            "analyze_correlation",
+            "analyze_holdings_overlap",
+            "track_portfolio",
+            "manage_watchlist",
+            "manage_alerts",
+            "daily_watchlist_report",
+            "manage_notifications",
+            "search_web",
+            "get_economic_data",
+            "get_fear_greed",
+            "get_reddit_sentiment",
+            "get_twitter_sentiment",
+            "get_web_sentiment",
+            "get_sentiment_trend",
+            "get_sentiment_summary",
+            "ask_user"
+          ],
+          "memoryCategories": [
+            "investor_profile",
+            "workflow_history"
+          ],
+          "memoryProvenance": [
+            {
+              "category": "workflow_history",
+              "key": "workflow_run_1",
+              "recordedAt": "2026-07-04T04:02:47.235Z"
+            }
+          ],
+          "diagnostics": [],
+          "toolScope": [
+            {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "enforced": false
+            }
+          ]
+        },
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "asset_compare",
+          "commitmentMode": "compare_tradeoffs",
+          "policyCardId": "asset_compare",
+          "evidencePlanId": "placeholder_asset_compare",
+          "answerContractId": "asset_compare_tradeoff",
+          "structuredCheckIds": [
+            "required_evidence_present",
+            "data_gap_disclosed",
+            "capability_gap_disclosure"
+          ],
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "capabilityGapIds": [
+            "etf_holdings_overlap"
+          ],
+          "evidenceRecords": [
+            {
+              "id": "tool_result:compare_companies",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "compare_companies"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "compare_companies",
+                "args": {
+                  "symbols": [
+                    "JPM",
+                    "BAC"
+                  ]
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 0,
+                "toolName": "compare_companies"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "JPM"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 1,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "BAC"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 2,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:analyze_risk",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "analyze_risk"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "analyze_risk",
+                "args": {
+                  "symbol": "JPM"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 3,
+                "toolName": "analyze_risk"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_technical_indicators",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_technical_indicators"
+              },
+              "entityScope": {
+                "symbols": [
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_technical_indicators",
+                "args": {
+                  "symbol": "BAC"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 4,
+                "toolName": "get_technical_indicators"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_technical_indicators",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_technical_indicators"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_technical_indicators",
+                "args": {
+                  "symbol": "JPM"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 5,
+                "toolName": "get_technical_indicators"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:analyze_risk",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "analyze_risk"
+              },
+              "entityScope": {
+                "symbols": [
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "analyze_risk",
+                "args": {
+                  "symbol": "BAC"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 6,
+                "toolName": "analyze_risk"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:analyze_correlation",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "analyze_correlation"
+              },
+              "entityScope": {
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "analyze_correlation",
+                "args": {
+                  "symbols": [
+                    "JPM",
+                    "BAC"
+                  ]
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 7,
+                "toolName": "analyze_correlation"
+              },
+              "gaps": [],
+              "caveats": []
+            }
+          ],
+          "structuredCheckResults": [
+            {
+              "checkId": "required_evidence_present",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "freshness_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected compare_tradeoffs metadata and fields: comparison_tradeoffs, risk_downside"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: comparison_tradeoffs, source_coverage"
+            },
+            {
+              "checkId": "source_coverage_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Source-coverage metadata is missing."
+            },
+            {
+              "checkId": "capability_gap_disclosure",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing capability-gap disclosures: etf_holdings_overlap"
+            }
+          ],
+          "structuredCheckFailures": [
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected compare_tradeoffs metadata and fields: comparison_tradeoffs, risk_downside"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing required final fields: comparison_tradeoffs, source_coverage"
+            },
+            {
+              "checkId": "source_coverage_disclosed",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Source-coverage metadata is missing."
+            },
+            {
+              "checkId": "capability_gap_disclosure",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Missing capability-gap disclosures: etf_holdings_overlap"
+            }
+          ],
+          "retryEligibility": {
+            "eligible": true,
+            "activeRetryAllowed": false,
+            "reasons": [
+              "commitment_mode_respected: Expected compare_tradeoffs metadata and fields: comparison_tradeoffs, risk_downside",
+              "required_final_fields_present: Missing required final fields: comparison_tradeoffs, source_coverage",
+              "source_coverage_disclosed: Source-coverage metadata is missing.",
+              "capability_gap_disclosure: Missing capability-gap disclosures: etf_holdings_overlap"
+            ]
+          },
+          "parityStatus": "legacy_active",
+          "regressionClassification": "none"
+        },
+        "toolCalls": [
+          {
+            "name": "compare_companies",
+            "args": {
+              "symbols": [
+                "JPM",
+                "BAC"
+              ]
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "⚠ Company fundamentals unavailable for all symbols: JPM, BAC. Alpha Vantage may be rate limited."
+                }
+              ],
+              "details": null
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "JPM"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "JPM: $334.47 (+0.12%)\nOpen: $338.02 | High: $338.84 | Low: $331.88\nVolume: 4,545,984 | Market Cap: N/A\n52W Range: $279.10 - $343.45"
+                }
+              ],
+              "details": {
+                "symbol": "JPM",
+                "price": 334.47,
+                "change": 0.4000000000000341,
+                "changePercent": 0.11973538479960312,
+                "open": 338.0199890136719,
+                "high": 338.844,
+                "low": 331.88,
+                "previousClose": 334.07,
+                "volume": 4545984,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 343.45,
+                "week52Low": 279.1,
+                "timestamp": 1783137770385,
+                "currency": "USD"
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "BAC"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "BAC: $58.73 (+0.63%)\nOpen: $58.94 | High: $59.00 | Low: $57.94\nVolume: 24,345,325 | Market Cap: N/A\n52W Range: $44.75 - $59.20"
+                }
+              ],
+              "details": {
+                "symbol": "BAC",
+                "price": 58.73,
+                "change": 0.36999999999999744,
+                "changePercent": 0.6339958875942383,
+                "open": 58.939998626708984,
+                "high": 59,
+                "low": 57.94,
+                "previousClose": 58.36,
+                "volume": 24345325,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 59.2,
+                "week52Low": 44.75,
+                "timestamp": 1783137770442,
+                "currency": "USD"
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "analyze_risk",
+            "args": {
+              "symbol": "JPM"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**JPM Risk Analysis** (2025-07-03 to 2026-07-02, 251 days)\n\nAnnualized Return: 14.77%\nAnnualized Volatility: 22.11%\nSharpe Ratio: 0.44 (Below average)\nMax Drawdown: 15.47%\nValue at Risk (95%, daily): 2.34%\n\nRisk profile appears moderate"
+                }
+              ],
+              "details": {
+                "symbol": "JPM",
+                "annualizedReturn": 0.14769605498025923,
+                "annualizedVolatility": 0.22106916569257118,
+                "sharpeRatio": 0.4419252891926132,
+                "maxDrawdown": 0.15471740617447216,
+                "var95": 0.02343845508259872
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_technical_indicators",
+            "args": {
+              "symbol": "BAC"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**BAC Technical Analysis** (2025-07-03 to 2026-07-02)\nPrice: $58.73\n\nSMA(20): $56.41 | SMA(50): $53.65\nRSI(14): 70.1 (Overbought)\nMACD: 1.48 | Signal: 1.41 | Histogram: 0.07\nBollinger Bands: Upper $59.61 | Mid $56.41 | Lower $53.22\nOBV Trend: Rising | VWAP (cumulative): $51.58\n\nSignals: Price above SMA(20) — short-term bullish | Golden cross pattern (SMA20 > SMA50) | RSI overbought — potential reversal | MACD bullish (histogram positive) | Volume confirming price advance (OBV rising) | Price above cumulative VWAP — bullish volume-weighted bias"
+                }
+              ],
+              "details": {
+                "symbol": "BAC",
+                "range": "1y",
+                "prices": [
+                  48.93000030517578,
+                  48.65999984741211,
+                  47.150001525878906,
+                  46.84000015258789,
+                  46.970001220703125,
+                  46.72999954223633,
+                  47.06999969482422,
+                  46.150001525878906,
+                  46.029998779296875,
+                  47.02000045776367,
+                  47.31999969482422,
+                  47.47999954223633,
+                  47.77000045776367,
+                  48.13999938964844,
+                  48.38999938964844,
+                  48.45000076293945,
+                  48.22999954223633,
+                  47.95000076293945,
+                  47.959999084472656,
+                  47.27000045776367,
+                  45.65999984741211,
+                  45.849998474121094,
+                  45.560001373291016,
+                  45.41999816894531,
+                  44.91999816894531,
+                  46.0099983215332,
+                  46.15999984741211,
+                  47.5,
+                  47.2400016784668,
+                  47.709999084472656,
+                  46.939998626708984,
+                  47.91999816894531,
+                  48.08000183105469,
+                  48.349998474121094,
+                  48.2599983215332,
+                  49.47999954223633,
+                  49.47999954223633,
+                  50.25,
+                  50.380001068115234,
+                  50.4900016784668,
+                  50.7400016784668,
+                  50.41999816894531,
+                  50.060001373291016,
+                  50.619998931884766,
+                  49.77000045776367,
+                  49.459999084472656,
+                  50.290000915527344,
+                  50.130001068115234,
+                  50.75,
+                  50.58000183105469,
+                  50.59000015258789,
+                  50.65999984741211,
+                  51.400001525878906,
+                  52.130001068115234,
+                  52.25,
+                  51.91999816894531,
+                  51.70000076293945,
+                  51.70000076293945,
+                  51.849998474121094,
+                  52.209999084472656,
+                  52.41999816894531,
+                  51.59000015258789,
+                  50.68000030517578,
+                  50.47999954223633,
+                  50.63999938964844,
+                  50.38999938964844,
+                  50.290000915527344,
+                  49.84000015258789,
+                  49.790000915527344,
+                  48.650001525878906,
+                  48.86000061035156,
+                  50.09000015258789,
+                  52.279998779296875,
+                  50.439998626708984,
+                  51.279998779296875,
+                  52.040000915527344,
+                  51.52000045776367,
+                  51.099998474121094,
+                  51.7599983215332,
+                  52.56999969482422,
+                  53.02000045776367,
+                  52.869998931884766,
+                  52.58000183105469,
+                  53.029998779296875,
+                  53.45000076293945,
+                  53.560001373291016,
+                  53.540000915527344,
+                  52.45000076293945,
+                  53.290000915527344,
+                  53.20000076293945,
+                  53.41999816894531,
+                  53.630001068115234,
+                  54.11000061035156,
+                  52.869998931884766,
+                  52.61000061035156,
+                  51.47999954223633,
+                  51.63999938964844,
+                  52.02000045776367,
+                  51,
+                  51.560001373291016,
+                  51.93000030517578,
+                  52.47999954223633,
+                  52.9900016784668,
+                  53.650001525878906,
+                  53.2400016784668,
+                  53.189998626708984,
+                  54.09000015258789,
+                  54.15999984741211,
+                  53.95000076293945,
+                  53.900001525878906,
+                  53.540000915527344,
+                  54.08000183105469,
+                  54.560001373291016,
+                  55.13999938964844,
+                  55.33000183105469,
+                  54.810001373291016,
+                  54.54999923706055,
+                  54.2599983215332,
+                  55.27000045776367,
+                  55.880001068115234,
+                  55.970001220703125,
+                  56.25,
+                  56.16999816894531,
+                  55.349998474121094,
+                  55.279998779296875,
+                  55,
+                  55.95000076293945,
+                  56.88999938964844,
+                  57.25,
+                  55.63999938964844,
+                  56.18000030517578,
+                  55.849998474121094,
+                  55.189998626708984,
+                  54.540000915527344,
+                  52.47999954223633,
+                  52.59000015258789,
+                  52.970001220703125,
+                  52.099998474121094,
+                  52.06999969482422,
+                  52.45000076293945,
+                  51.720001220703125,
+                  52.02000045776367,
+                  52.16999816894531,
+                  51.810001373291016,
+                  53.08000183105469,
+                  53.20000076293945,
+                  54.029998779296875,
+                  54.45000076293945,
+                  55.380001068115234,
+                  54.939998626708984,
+                  56.529998779296875,
+                  56.40999984741211,
+                  55.38999938964844,
+                  53.849998474121094,
+                  52.52000045776367,
+                  52.54999923706055,
+                  52.7400016784668,
+                  53.36000061035156,
+                  52.77000045776367,
+                  53.060001373291016,
+                  51.06999969482422,
+                  50.40999984741211,
+                  51.689998626708984,
+                  52.29999923706055,
+                  49.83000183105469,
+                  49.810001373291016,
+                  49.970001220703125,
+                  50.29999923706055,
+                  49.810001373291016,
+                  48.63999938964844,
+                  47.900001525878906,
+                  48.560001373291016,
+                  48.52000045776367,
+                  47.130001068115234,
+                  46.720001220703125,
+                  47.060001373291016,
+                  47.279998779296875,
+                  46.83000183105469,
+                  47.0099983215332,
+                  47.15999984741211,
+                  47.52000045776367,
+                  48.13999938964844,
+                  48.75,
+                  48.2400016784668,
+                  46.970001220703125,
+                  47.22999954223633,
+                  48.75,
+                  49.27000045776367,
+                  49.380001068115234,
+                  50.060001373291016,
+                  50.279998779296875,
+                  51.880001068115234,
+                  52.709999084472656,
+                  52.540000915527344,
+                  53.349998474121094,
+                  53.349998474121094,
+                  54.31999969482422,
+                  53.5099983215332,
+                  53.90999984741211,
+                  53.95000076293945,
+                  53.47999954223633,
+                  53.119998931884766,
+                  52.470001220703125,
+                  52.04999923706055,
+                  52.630001068115234,
+                  52.65999984741211,
+                  52.880001068115234,
+                  53.459999084472656,
+                  53.2400016784668,
+                  52.189998626708984,
+                  53.119998931884766,
+                  53.599998474121094,
+                  52.75,
+                  51.310001373291016,
+                  50.54999923706055,
+                  50.779998779296875,
+                  49.84000015258789,
+                  49.849998474121094,
+                  49.77000045776367,
+                  50.689998626708984,
+                  50.70000076293945,
+                  51.22999954223633,
+                  51.4900016784668,
+                  51.79999923706055,
+                  52.20000076293945,
+                  51.099998474121094,
+                  50.77000045776367,
+                  51.599998474121094,
+                  51.5099983215332,
+                  52.47999954223633,
+                  52.400001525878906,
+                  54.16999816894531,
+                  53.83000183105469,
+                  53.630001068115234,
+                  54.41999816894531,
+                  54.540000915527344,
+                  55.15999984741211,
+                  56.02000045776367,
+                  55.869998931884766,
+                  56.84000015258789,
+                  56.529998779296875,
+                  56.20000076293945,
+                  57.369998931884766,
+                  57.90999984741211,
+                  57.72999954223633,
+                  58.189998626708984,
+                  57.880001068115234,
+                  57.880001068115234,
+                  56.97999954223633,
+                  58.36000061035156,
+                  58.72999954223633
+                ],
+                "dates": [
+                  "2025-07-03",
+                  "2025-07-07",
+                  "2025-07-08",
+                  "2025-07-09",
+                  "2025-07-10",
+                  "2025-07-11",
+                  "2025-07-14",
+                  "2025-07-15",
+                  "2025-07-16",
+                  "2025-07-17",
+                  "2025-07-18",
+                  "2025-07-21",
+                  "2025-07-22",
+                  "2025-07-23",
+                  "2025-07-24",
+                  "2025-07-25",
+                  "2025-07-28",
+                  "2025-07-29",
+                  "2025-07-30",
+                  "2025-07-31",
+                  "2025-08-01",
+                  "2025-08-04",
+                  "2025-08-05",
+                  "2025-08-06",
+                  "2025-08-07",
+                  "2025-08-08",
+                  "2025-08-11",
+                  "2025-08-12",
+                  "2025-08-13",
+                  "2025-08-14",
+                  "2025-08-15",
+                  "2025-08-18",
+                  "2025-08-19",
+                  "2025-08-20",
+                  "2025-08-21",
+                  "2025-08-22",
+                  "2025-08-25",
+                  "2025-08-26",
+                  "2025-08-27",
+                  "2025-08-28",
+                  "2025-08-29",
+                  "2025-09-02",
+                  "2025-09-03",
+                  "2025-09-04",
+                  "2025-09-05",
+                  "2025-09-08",
+                  "2025-09-09",
+                  "2025-09-10",
+                  "2025-09-11",
+                  "2025-09-12",
+                  "2025-09-15",
+                  "2025-09-16",
+                  "2025-09-17",
+                  "2025-09-18",
+                  "2025-09-19",
+                  "2025-09-22",
+                  "2025-09-23",
+                  "2025-09-24",
+                  "2025-09-25",
+                  "2025-09-26",
+                  "2025-09-29",
+                  "2025-09-30",
+                  "2025-10-01",
+                  "2025-10-02",
+                  "2025-10-03",
+                  "2025-10-06",
+                  "2025-10-07",
+                  "2025-10-08",
+                  "2025-10-09",
+                  "2025-10-10",
+                  "2025-10-13",
+                  "2025-10-14",
+                  "2025-10-15",
+                  "2025-10-16",
+                  "2025-10-17",
+                  "2025-10-20",
+                  "2025-10-21",
+                  "2025-10-22",
+                  "2025-10-23",
+                  "2025-10-24",
+                  "2025-10-27",
+                  "2025-10-28",
+                  "2025-10-29",
+                  "2025-10-30",
+                  "2025-10-31",
+                  "2025-11-03",
+                  "2025-11-04",
+                  "2025-11-05",
+                  "2025-11-06",
+                  "2025-11-07",
+                  "2025-11-10",
+                  "2025-11-11",
+                  "2025-11-12",
+                  "2025-11-13",
+                  "2025-11-14",
+                  "2025-11-17",
+                  "2025-11-18",
+                  "2025-11-19",
+                  "2025-11-20",
+                  "2025-11-21",
+                  "2025-11-24",
+                  "2025-11-25",
+                  "2025-11-26",
+                  "2025-11-28",
+                  "2025-12-01",
+                  "2025-12-02",
+                  "2025-12-03",
+                  "2025-12-04",
+                  "2025-12-05",
+                  "2025-12-08",
+                  "2025-12-09",
+                  "2025-12-10",
+                  "2025-12-11",
+                  "2025-12-12",
+                  "2025-12-15",
+                  "2025-12-16",
+                  "2025-12-17",
+                  "2025-12-18",
+                  "2025-12-19",
+                  "2025-12-22",
+                  "2025-12-23",
+                  "2025-12-24",
+                  "2025-12-26",
+                  "2025-12-29",
+                  "2025-12-30",
+                  "2025-12-31",
+                  "2026-01-02",
+                  "2026-01-05",
+                  "2026-01-06",
+                  "2026-01-07",
+                  "2026-01-08",
+                  "2026-01-09",
+                  "2026-01-12",
+                  "2026-01-13",
+                  "2026-01-14",
+                  "2026-01-15",
+                  "2026-01-16",
+                  "2026-01-20",
+                  "2026-01-21",
+                  "2026-01-22",
+                  "2026-01-23",
+                  "2026-01-26",
+                  "2026-01-27",
+                  "2026-01-28",
+                  "2026-01-29",
+                  "2026-01-30",
+                  "2026-02-02",
+                  "2026-02-03",
+                  "2026-02-04",
+                  "2026-02-05",
+                  "2026-02-06",
+                  "2026-02-09",
+                  "2026-02-10",
+                  "2026-02-11",
+                  "2026-02-12",
+                  "2026-02-13",
+                  "2026-02-17",
+                  "2026-02-18",
+                  "2026-02-19",
+                  "2026-02-20",
+                  "2026-02-23",
+                  "2026-02-24",
+                  "2026-02-25",
+                  "2026-02-26",
+                  "2026-02-27",
+                  "2026-03-02",
+                  "2026-03-03",
+                  "2026-03-04",
+                  "2026-03-05",
+                  "2026-03-06",
+                  "2026-03-09",
+                  "2026-03-10",
+                  "2026-03-11",
+                  "2026-03-12",
+                  "2026-03-13",
+                  "2026-03-16",
+                  "2026-03-17",
+                  "2026-03-18",
+                  "2026-03-19",
+                  "2026-03-20",
+                  "2026-03-23",
+                  "2026-03-24",
+                  "2026-03-25",
+                  "2026-03-26",
+                  "2026-03-27",
+                  "2026-03-30",
+                  "2026-03-31",
+                  "2026-04-01",
+                  "2026-04-02",
+                  "2026-04-06",
+                  "2026-04-07",
+                  "2026-04-08",
+                  "2026-04-09",
+                  "2026-04-10",
+                  "2026-04-13",
+                  "2026-04-14",
+                  "2026-04-15",
+                  "2026-04-16",
+                  "2026-04-17",
+                  "2026-04-20",
+                  "2026-04-21",
+                  "2026-04-22",
+                  "2026-04-23",
+                  "2026-04-24",
+                  "2026-04-27",
+                  "2026-04-28",
+                  "2026-04-29",
+                  "2026-04-30",
+                  "2026-05-01",
+                  "2026-05-04",
+                  "2026-05-05",
+                  "2026-05-06",
+                  "2026-05-07",
+                  "2026-05-08",
+                  "2026-05-11",
+                  "2026-05-12",
+                  "2026-05-13",
+                  "2026-05-14",
+                  "2026-05-15",
+                  "2026-05-18",
+                  "2026-05-19",
+                  "2026-05-20",
+                  "2026-05-21",
+                  "2026-05-22",
+                  "2026-05-26",
+                  "2026-05-27",
+                  "2026-05-28",
+                  "2026-05-29",
+                  "2026-06-01",
+                  "2026-06-02",
+                  "2026-06-03",
+                  "2026-06-04",
+                  "2026-06-05",
+                  "2026-06-08",
+                  "2026-06-09",
+                  "2026-06-10",
+                  "2026-06-11",
+                  "2026-06-12",
+                  "2026-06-15",
+                  "2026-06-16",
+                  "2026-06-17",
+                  "2026-06-18",
+                  "2026-06-22",
+                  "2026-06-23",
+                  "2026-06-24",
+                  "2026-06-25",
+                  "2026-06-26",
+                  "2026-06-29",
+                  "2026-06-30",
+                  "2026-07-01",
+                  "2026-07-02"
+                ],
+                "sma20": [
+                  47.52550010681152,
+                  47.36200008392334,
+                  47.22150001525879,
+                  47.14200000762939,
+                  47.07099990844726,
+                  46.968499755859376,
+                  46.932499694824216,
+                  46.886999702453615,
+                  46.95449962615967,
+                  47.01499977111816,
+                  47.049499702453616,
+                  47.030499649047854,
+                  47.0524995803833,
+                  47.06799964904785,
+                  47.07849960327148,
+                  47.07199954986572,
+                  47.12349948883057,
+                  47.18599948883057,
+                  47.30099945068359,
+                  47.421999549865724,
+                  47.58299961090088,
+                  47.83699970245361,
+                  48.06549968719482,
+                  48.290499687194824,
+                  48.550499725341794,
+                  48.792999839782716,
+                  48.96549987792969,
+                  49.17199993133545,
+                  49.30349998474121,
+                  49.47899990081787,
+                  49.622500038146974,
+                  49.805000114440915,
+                  49.942000198364255,
+                  50.10800018310547,
+                  50.297000312805174,
+                  50.496500396728514,
+                  50.618500328063966,
+                  50.72950038909912,
+                  50.80200042724609,
+                  50.87550029754639,
+                  50.96150016784668,
+                  51.04549999237061,
+                  51.104000091552734,
+                  51.13500003814697,
+                  51.12800006866455,
+                  51.171500015258786,
+                  51.21800003051758,
+                  51.21800003051758,
+                  51.203499984741214,
+                  51.15550003051758,
+                  51.05900001525879,
+                  50.972500038146975,
+                  50.94400005340576,
+                  50.98799991607666,
+                  50.90349979400635,
+                  50.854999732971194,
+                  50.86099987030029,
+                  50.851999855041505,
+                  50.82199974060059,
+                  50.81749973297119,
+                  50.83549976348877,
+                  50.865499877929686,
+                  50.929499816894534,
+                  51.02449989318848,
+                  51.1519998550415,
+                  51.29249992370605,
+                  51.45100002288818,
+                  51.61350002288818,
+                  51.74400005340576,
+                  51.91900005340576,
+                  52.14650001525879,
+                  52.37449989318848,
+                  52.551499938964845,
+                  52.64300003051758,
+                  52.764500045776366,
+                  52.8310001373291,
+                  52.80300006866455,
+                  52.80900001525879,
+                  52.85500011444092,
+                  52.817000198364255,
+                  52.766500282287595,
+                  52.7120002746582,
+                  52.692500305175784,
+                  52.71300029754639,
+                  52.74400043487549,
+                  52.733500480651855,
+                  52.71500034332276,
+                  52.74250030517578,
+                  52.82800025939942,
+                  52.86100025177002,
+                  52.89600028991699,
+                  52.902000427246094,
+                  52.924500465393066,
+                  52.94700050354004,
+                  53.06050052642822,
+                  53.196500587463376,
+                  53.36300067901611,
+                  53.50850067138672,
+                  53.620500564575195,
+                  53.83400058746338,
+                  54.05000057220459,
+                  54.252000617980954,
+                  54.44050064086914,
+                  54.599500465393064,
+                  54.68450031280518,
+                  54.78650016784668,
+                  54.87700023651123,
+                  54.97000026702881,
+                  55.106500244140626,
+                  55.271500205993654,
+                  55.35850009918213,
+                  55.49050006866455,
+                  55.57899990081787,
+                  55.61049976348877,
+                  55.58049983978272,
+                  55.4379997253418,
+                  55.32699966430664,
+                  55.24799976348877,
+                  55.13999977111816,
+                  54.979999732971194,
+                  54.8084997177124,
+                  54.5959997177124,
+                  54.38449974060059,
+                  54.184499740600586,
+                  54.007499885559085,
+                  53.89750003814697,
+                  53.80750007629395,
+                  53.711499977111814,
+                  53.58950004577637,
+                  53.496000099182126,
+                  53.46100006103516,
+                  53.47849998474121,
+                  53.50650005340576,
+                  53.516500091552736,
+                  53.48199996948242,
+                  53.484000015258786,
+                  53.48199996948242,
+                  53.470499992370605,
+                  53.53350009918213,
+                  53.5685001373291,
+                  53.59900016784668,
+                  53.56650009155273,
+                  53.486000061035156,
+                  53.46200008392334,
+                  53.48649997711182,
+                  53.32399997711182,
+                  53.154500007629395,
+                  52.95150012969971,
+                  52.74400005340576,
+                  52.465500068664554,
+                  52.15050010681152,
+                  51.719000244140624,
+                  51.32650032043457,
+                  50.98300037384033,
+                  50.64700050354004,
+                  50.357000541687015,
+                  50.08250064849854,
+                  49.809500503540036,
+                  49.48300056457519,
+                  49.19500045776367,
+                  48.900000381469724,
+                  48.7225004196167,
+                  48.60900039672852,
+                  48.46200046539307,
+                  48.259000587463376,
+                  48.1160005569458,
+                  47.987000465393066,
+                  47.92600040435791,
+                  47.87450046539307,
+                  47.853000450134275,
+                  47.9240005493164,
+                  48.04300041198731,
+                  48.20900039672851,
+                  48.41850032806396,
+                  48.68900032043457,
+                  49.02050018310547,
+                  49.33500003814697,
+                  49.68700008392334,
+                  50.020999908447266,
+                  50.36599998474121,
+                  50.70550003051758,
+                  51.00349998474121,
+                  51.252499961853026,
+                  51.438500022888185,
+                  51.628999900817874,
+                  51.91199989318848,
+                  52.18349990844727,
+                  52.38999996185303,
+                  52.59949989318848,
+                  52.79249992370605,
+                  52.898999786376955,
+                  53.040999794006346,
+                  53.12699966430664,
+                  53.12899971008301,
+                  53.06749973297119,
+                  52.927499771118164,
+                  52.79899978637695,
+                  52.57499980926514,
+                  52.39199981689453,
+                  52.18499984741211,
+                  52.021999740600585,
+                  51.88299980163574,
+                  51.78849983215332,
+                  51.7394998550415,
+                  51.726999855041505,
+                  51.70549983978272,
+                  51.62749977111817,
+                  51.521999740600585,
+                  51.428999710083005,
+                  51.342499542236325,
+                  51.3569995880127,
+                  51.320999717712404,
+                  51.34949970245361,
+                  51.40349979400635,
+                  51.51949977874756,
+                  51.712999725341795,
+                  51.90099983215332,
+                  52.16699981689453,
+                  52.47549991607666,
+                  52.78049983978271,
+                  53.08799991607666,
+                  53.37949981689453,
+                  53.62799987792969,
+                  53.92199974060058,
+                  54.22749977111816,
+                  54.50399971008301,
+                  54.858499717712405,
+                  55.21399974822998,
+                  55.52799987792969,
+                  55.801499938964845,
+                  56.095499992370605,
+                  56.41199989318848
+                ],
+                "sma50": [
+                  48.099799957275394,
+                  48.132999954223635,
+                  48.172999954223634,
+                  48.257999954223635,
+                  48.36379997253418,
+                  48.46939994812012,
+                  48.5731999206543,
+                  48.665799942016605,
+                  48.77679992675781,
+                  48.8931999206543,
+                  48.99699989318847,
+                  49.0989998626709,
+                  49.18119987487793,
+                  49.23939987182617,
+                  49.28619987487793,
+                  49.33119987487793,
+                  49.36999984741211,
+                  49.41119987487793,
+                  49.448999862670895,
+                  49.48559989929199,
+                  49.513199920654294,
+                  49.577199935913086,
+                  49.66199996948242,
+                  49.79639991760254,
+                  49.896799926757815,
+                  50.02399993896484,
+                  50.144599990844725,
+                  50.251800003051756,
+                  50.32379997253418,
+                  50.414199905395506,
+                  50.51139991760254,
+                  50.632999954223635,
+                  50.73199996948242,
+                  50.82199996948242,
+                  50.915599975585934,
+                  51.01940002441406,
+                  51.10100006103516,
+                  51.18220008850098,
+                  51.226200103759766,
+                  51.284400100708005,
+                  51.33860008239746,
+                  51.392200012207034,
+                  51.456400070190426,
+                  51.53740005493164,
+                  51.58240005493164,
+                  51.6392000579834,
+                  51.67960006713867,
+                  51.7066000366211,
+                  51.74440002441406,
+                  51.749400024414065,
+                  51.76900001525879,
+                  51.795800018310544,
+                  51.83220001220703,
+                  51.86400001525879,
+                  51.89440002441406,
+                  51.9142000579834,
+                  51.93960006713867,
+                  51.98740005493164,
+                  52.036600036621095,
+                  52.07860008239746,
+                  52.112400131225584,
+                  52.13480018615723,
+                  52.18460021972656,
+                  52.26220024108887,
+                  52.355400238037106,
+                  52.449200286865235,
+                  52.53760032653808,
+                  52.62280029296875,
+                  52.71120025634766,
+                  52.82080024719238,
+                  52.96540023803711,
+                  53.10760025024414,
+                  53.230800247192384,
+                  53.30860023498535,
+                  53.406800231933595,
+                  53.48680023193359,
+                  53.546000213623046,
+                  53.634600219726565,
+                  53.75040023803711,
+                  53.860200271606445,
+                  53.92160026550293,
+                  53.984800262451174,
+                  54.0444002532959,
+                  54.096600189208985,
+                  54.12680023193359,
+                  54.10740020751953,
+                  54.08800018310547,
+                  54.07660018920898,
+                  54.069600143432616,
+                  54.04520011901855,
+                  54.03020011901855,
+                  53.99620018005371,
+                  53.96400016784668,
+                  53.925200119018555,
+                  53.90400016784668,
+                  53.913400192260745,
+                  53.94780021667481,
+                  53.99560020446777,
+                  54.04420021057129,
+                  54.131800231933596,
+                  54.199400177001955,
+                  54.29140014648438,
+                  54.37000015258789,
+                  54.418000106811526,
+                  54.422000045776365,
+                  54.407600021362306,
+                  54.39480003356934,
+                  54.367800064086914,
+                  54.3518000793457,
+                  54.328200073242186,
+                  54.31140007019043,
+                  54.26200004577637,
+                  54.18860000610351,
+                  54.13119995117187,
+                  54.07439994812012,
+                  53.96439994812012,
+                  53.864399948120116,
+                  53.77279998779297,
+                  53.693600006103516,
+                  53.584400024414066,
+                  53.43959999084473,
+                  53.278199996948246,
+                  53.124400024414065,
+                  52.97140007019043,
+                  52.80700012207031,
+                  52.635800170898435,
+                  52.47700019836426,
+                  52.30360015869141,
+                  52.10240020751953,
+                  51.897600173950195,
+                  51.72800018310547,
+                  51.55480018615722,
+                  51.40060020446777,
+                  51.2718002319336,
+                  51.14580024719238,
+                  51.03560028076172,
+                  50.92840026855469,
+                  50.844000244140624,
+                  50.787400283813476,
+                  50.7336003112793,
+                  50.685800323486326,
+                  50.6570002746582,
+                  50.65420028686523,
+                  50.66500030517578,
+                  50.67960029602051,
+                  50.68500022888183,
+                  50.688000183105466,
+                  50.69380020141602,
+                  50.67500015258789,
+                  50.645600128173825,
+                  50.62580017089844,
+                  50.56480018615723,
+                  50.49900016784668,
+                  50.44060020446777,
+                  50.40460021972656,
+                  50.406800231933595,
+                  50.40900024414063,
+                  50.4118002319336,
+                  50.41380020141602,
+                  50.42320022583008,
+                  50.40580017089844,
+                  50.44680015563965,
+                  50.51060012817383,
+                  50.53180015563965,
+                  50.512000198364255,
+                  50.52640014648438,
+                  50.545800094604495,
+                  50.54320007324219,
+                  50.5342000579834,
+                  50.53340003967285,
+                  50.57440002441406,
+                  50.630400009155274,
+                  50.68379997253418,
+                  50.74319999694824,
+                  50.83659996032715,
+                  50.94619995117188,
+                  51.026999893188474,
+                  51.09679992675781,
+                  51.19219985961914,
+                  51.28219985961914,
+                  51.38859985351562,
+                  51.48619987487793,
+                  51.606799850463865,
+                  51.70839988708496,
+                  51.81619987487793,
+                  51.96519981384277,
+                  52.1113998413086,
+                  52.23959983825684,
+                  52.374599838256835,
+                  52.50439979553223,
+                  52.63999977111816,
+                  52.76499977111816,
+                  52.85139976501465,
+                  52.94459976196289,
+                  53.051999740600586,
+                  53.13959976196289,
+                  53.236399765014646,
+                  53.30759979248047,
+                  53.39499984741211,
+                  53.456399841308595,
+                  53.544599838256836,
+                  53.64959983825683
+                ],
+                "rsi": [
+                  45.64515712234217,
+                  46.205803842685484,
+                  44.397553068248506,
+                  42.137361756357144,
+                  42.2504169877627,
+                  36.893142572371325,
+                  27.978564088638507,
+                  30.124367921678413,
+                  28.7179649366621,
+                  28.037416818513307,
+                  25.695462955093916,
+                  37.87774820639956,
+                  39.35137726308652,
+                  50.62031873590463,
+                  48.72843256786567,
+                  52.205832400096035,
+                  46.62639879462865,
+                  53.44584503189993,
+                  54.46871688050778,
+                  56.21688253865726,
+                  55.45258223124589,
+                  62.829818041270684,
+                  62.82981804127068,
+                  66.84842376181193,
+                  67.48752745914629,
+                  68.04881699798176,
+                  69.34414564647669,
+                  65.67397908183858,
+                  61.71660951754481,
+                  65.22679585219652,
+                  56.72499478909924,
+                  53.962465855751226,
+                  59.63111114754367,
+                  58.14482143780054,
+                  62.08813880002835,
+                  60.40762426342002,
+                  60.47538355161761,
+                  60.9788963939256,
+                  65.92138886221679,
+                  69.96318918009851,
+                  70.58086742599984,
+                  66.52910633836723,
+                  63.89572045584564,
+                  63.89572045584564,
+                  64.99147447381665,
+                  67.53791799106574,
+                  68.9564228714986,
+                  58.14230612864644,
+                  49.058293753705485,
+                  47.30883878466138,
+                  48.87941404259277,
+                  46.5448912149004,
+                  45.606599516917676,
+                  41.547622507058115,
+                  41.109828935794795,
+                  32.65973117712558,
+                  35.29807114966518,
+                  48.119402226705894,
+                  62.40431196033039,
+                  49.95810116829613,
+                  54.42677357596415,
+                  58.07466119146136,
+                  54.84018343395067,
+                  52.306204552963,
+                  55.765165627301855,
+                  59.63437372765648,
+                  61.6417493853054,
+                  60.56062804740235,
+                  58.427108907504746,
+                  60.73850111224535,
+                  62.816476566949014,
+                  63.36338834396024,
+                  63.18142426180759,
+                  54.06840761285485,
+                  58.97882428028504,
+                  58.260158331695614,
+                  59.557423537658636,
+                  60.80955682432599,
+                  63.5847621060025,
+                  53.11980315900459,
+                  51.21641818833181,
+                  43.86050203681365,
+                  45.06363299212917,
+                  47.918449588111734,
+                  41.66036310422922,
+                  45.84225484451497,
+                  48.47047225504063,
+                  52.18506005766717,
+                  55.39593573578628,
+                  59.21306984352143,
+                  56.00660294904445,
+                  55.611083323844554,
+                  60.95571410416061,
+                  61.34554859477711,
+                  59.42854121636534,
+                  58.95615141277461,
+                  55.53333397826188,
+                  59.34604070241364,
+                  62.42975326108418,
+                  65.80498933029827,
+                  66.85547295990543,
+                  61.30474593309026,
+                  58.68130932923973,
+                  55.812415780653296,
+                  62.659456092772864,
+                  66.07825439300211,
+                  66.56465742844759,
+                  68.09730745720725,
+                  67.15017043639125,
+                  58.21297752512305,
+                  57.509323124007594,
+                  54.66304029654376,
+                  61.606149086217016,
+                  66.99258011710643,
+                  68.79801706348734,
+                  54.45302674284481,
+                  57.64310675389049,
+                  55.10315729784752,
+                  50.326876604026744,
+                  46.08975942518913,
+                  35.80204874477691,
+                  36.61564445181953,
+                  39.469526105031335,
+                  35.525706074197046,
+                  35.394378142227694,
+                  38.49596476887537,
+                  35.0179838413037,
+                  37.51637509226566,
+                  38.78368724943307,
+                  36.85182958682115,
+                  46.90045689020275,
+                  47.746551848510364,
+                  53.29048560847706,
+                  55.84351905086379,
+                  60.93511709749551,
+                  57.55376736754599,
+                  65.09206618367705,
+                  64.1658695869512,
+                  56.771319099884806,
+                  47.81243614997832,
+                  41.693106740906316,
+                  41.873812532153295,
+                  43.077127337514405,
+                  46.93735368288575,
+                  43.88727893765789,
+                  45.75321938707991,
+                  36.72775445090529,
+                  34.31035607456316,
+                  42.249280262328185,
+                  45.62209594461882,
+                  36.361687396557734,
+                  36.29743948345702,
+                  37.252597153654115,
+                  39.27497511567255,
+                  37.350001701109136,
+                  33.16953049560634,
+                  30.819926055479257,
+                  35.22697298963793,
+                  35.08110811050619,
+                  30.37444491558348,
+                  29.132859227317354,
+                  31.62872999805461,
+                  33.26646800162156,
+                  31.599133833957907,
+                  33.04470682495764,
+                  34.29099827647859,
+                  37.307095483861666,
+                  42.225550136484436,
+                  46.659505624131675,
+                  43.64372022746981,
+                  37.19637744133293,
+                  39.17733774874271,
+                  49.2546591607334,
+                  52.17402301100565,
+                  52.792718706104004,
+                  56.53591403884086,
+                  57.70439562241864,
+                  65.06116956264805,
+                  68.1555068509016,
+                  66.84960656810804,
+                  69.81712744936821,
+                  69.81712744936821,
+                  73.1547039706356,
+                  66.53804354928393,
+                  68.07373942990553,
+                  68.2307589682191,
+                  64.23333812713418,
+                  61.27224284381425,
+                  56.231816455426504,
+                  53.187185187495885,
+                  56.675746685860226,
+                  56.85483722388108,
+                  58.21887949356323,
+                  61.66024754397131,
+                  59.65318721319394,
+                  51.10327625608272,
+                  56.98405238579011,
+                  59.67945529132535,
+                  53.30917992959307,
+                  44.61978655206921,
+                  40.83646690242189,
+                  42.427422513317744,
+                  37.93732662161668,
+                  38.01247123478679,
+                  37.61998646241455,
+                  44.69249098713543,
+                  44.765811624551105,
+                  48.65040814146534,
+                  50.489984143348146,
+                  52.667235886323674,
+                  55.39310875294086,
+                  47.322154859253736,
+                  45.194706058205384,
+                  51.14396938851089,
+                  50.50376985560795,
+                  56.7827835612487,
+                  56.15013613863154,
+                  65.34907621470947,
+                  62.63109755366631,
+                  61.023253062280936,
+                  64.86056673432012,
+                  65.41753194386666,
+                  68.22018369104559,
+                  71.65202850357257,
+                  70.22751953351057,
+                  73.84826863839334,
+                  70.88144326088474,
+                  67.76067317614218,
+                  72.40038294561023,
+                  74.24283781957729,
+                  72.50532844532123,
+                  74.16905265399646,
+                  71.04889789728867,
+                  71.04889789728867,
+                  62.23367692681879,
+                  68.65549666238033,
+                  70.1224107843688
+                ],
+                "macd": [
+                  {
+                    "macd": 0.029665421343807452,
+                    "signal": -0.35144700037687926,
+                    "histogram": 0.3811124217206867
+                  },
+                  {
+                    "macd": 0.10113483732722983,
+                    "signal": -0.2609306328360575,
+                    "histogram": 0.36206547016328733
+                  },
+                  {
+                    "macd": 0.25329889495064606,
+                    "signal": -0.15808472727871678,
+                    "histogram": 0.41138362222936287
+                  },
+                  {
+                    "macd": 0.36962915212055236,
+                    "signal": -0.05254195139886296,
+                    "histogram": 0.42217110351941534
+                  },
+                  {
+                    "macd": 0.5179833314100861,
+                    "signal": 0.06156310516292686,
+                    "histogram": 0.4564202262471593
+                  },
+                  {
+                    "macd": 0.6386827498893055,
+                    "signal": 0.1769870341082026,
+                    "histogram": 0.4616957157811029
+                  },
+                  {
+                    "macd": 0.7347443629151442,
+                    "signal": 0.2885384998695909,
+                    "histogram": 0.4462058630455533
+                  },
+                  {
+                    "macd": 0.8215761752526021,
+                    "signal": 0.39514603494619316,
+                    "histogram": 0.4264301403064089
+                  },
+                  {
+                    "macd": 0.8547167605095538,
+                    "signal": 0.4870601800588653,
+                    "histogram": 0.3676565804506885
+                  },
+                  {
+                    "macd": 0.8422235514648264,
+                    "signal": 0.5580928543400575,
+                    "histogram": 0.2841306971247689
+                  },
+                  {
+                    "macd": 0.8675096054462159,
+                    "signal": 0.6199762045612892,
+                    "histogram": 0.2475334008849267
+                  },
+                  {
+                    "macd": 0.8096283209667448,
+                    "signal": 0.6579066278423804,
+                    "histogram": 0.15172169312436434
+                  },
+                  {
+                    "macd": 0.7303237484087148,
+                    "signal": 0.6723900519556474,
+                    "histogram": 0.05793369645306745
+                  },
+                  {
+                    "macd": 0.7260787308088226,
+                    "signal": 0.6831277877262825,
+                    "histogram": 0.042950943082540105
+                  },
+                  {
+                    "macd": 0.7017149402368901,
+                    "signal": 0.6868452182284039,
+                    "histogram": 0.01486972200848613
+                  },
+                  {
+                    "macd": 0.7240883531273354,
+                    "signal": 0.6942938452081903,
+                    "histogram": 0.029794507919145174
+                  },
+                  {
+                    "macd": 0.7198045537025308,
+                    "signal": 0.6993959869070584,
+                    "histogram": 0.020408566795472427
+                  },
+                  {
+                    "macd": 0.7090429865979715,
+                    "signal": 0.701325386845241,
+                    "histogram": 0.007717599752730453
+                  },
+                  {
+                    "macd": 0.6981153186633051,
+                    "signal": 0.700683373208854,
+                    "histogram": -0.00256805454554887
+                  },
+                  {
+                    "macd": 0.7406294982655339,
+                    "signal": 0.70867259822019,
+                    "histogram": 0.031956900045343906
+                  },
+                  {
+                    "macd": 0.8237316879526304,
+                    "signal": 0.7316844161666782,
+                    "histogram": 0.09204727178595218
+                  },
+                  {
+                    "macd": 0.8890255497899986,
+                    "signal": 0.7631526428913423,
+                    "histogram": 0.12587290689865627
+                  },
+                  {
+                    "macd": 0.9037254316605967,
+                    "signal": 0.7912672006451933,
+                    "histogram": 0.11245823101540342
+                  },
+                  {
+                    "macd": 0.8873939171865572,
+                    "signal": 0.8104925439534661,
+                    "histogram": 0.0769013732330911
+                  },
+                  {
+                    "macd": 0.8644858198956555,
+                    "signal": 0.8212911991419041,
+                    "histogram": 0.04319462075375147
+                  },
+                  {
+                    "macd": 0.8486518195495094,
+                    "signal": 0.8267633232234253,
+                    "histogram": 0.02188849632608414
+                  },
+                  {
+                    "macd": 0.8552930153228999,
+                    "signal": 0.8324692616433202,
+                    "histogram": 0.022823753679579672
+                  },
+                  {
+                    "macd": 0.8675013661537392,
+                    "signal": 0.8394756825454042,
+                    "histogram": 0.028025683608335017
+                  },
+                  {
+                    "macd": 0.8009695899595997,
+                    "signal": 0.8317744640282433,
+                    "histogram": -0.03080487406864363
+                  },
+                  {
+                    "macd": 0.667123115484479,
+                    "signal": 0.7988441943194905,
+                    "histogram": -0.1317210788350115
+                  },
+                  {
+                    "macd": 0.538700624587328,
+                    "signal": 0.7468154803730581,
+                    "histogram": -0.20811485578573008
+                  },
+                  {
+                    "macd": 0.44470919505020845,
+                    "signal": 0.6863942233084882,
+                    "histogram": -0.24168502825827975
+                  },
+                  {
+                    "macd": 0.3460582551558886,
+                    "signal": 0.6183270296779684,
+                    "histogram": -0.27226877452207976
+                  },
+                  {
+                    "macd": 0.25684686265744716,
+                    "signal": 0.5460309962738641,
+                    "histogram": -0.2891841336164169
+                  },
+                  {
+                    "macd": 0.14812737049218327,
+                    "signal": 0.4664502711175279,
+                    "histogram": -0.31832290062534463
+                  },
+                  {
+                    "macd": 0.05727167685938639,
+                    "signal": 0.38461455226589963,
+                    "histogram": -0.32734287540651325
+                  },
+                  {
+                    "macd": -0.105504349826127,
+                    "signal": 0.2865907718474943,
+                    "histogram": -0.3920951216736213
+                  },
+                  {
+                    "macd": -0.21508103237305676,
+                    "signal": 0.1862564110033841,
+                    "histogram": -0.40133744337644084
+                  },
+                  {
+                    "macd": -0.20036102208331386,
+                    "signal": 0.10893292438604453,
+                    "histogram": -0.30929394646935837
+                  },
+                  {
+                    "macd": -0.011844188847220494,
+                    "signal": 0.08477750173939153,
+                    "histogram": -0.09662169058661202
+                  },
+                  {
+                    "macd": -0.010791477670998972,
+                    "signal": 0.06566370585731342,
+                    "histogram": -0.07645518352831239
+                  },
+                  {
+                    "macd": 0.05716483502587266,
+                    "signal": 0.06396393169102527,
+                    "histogram": -0.006799096665152604
+                  },
+                  {
+                    "macd": 0.17038246028509718,
+                    "signal": 0.08524763740983965,
+                    "histogram": 0.08513482287525753
+                  },
+                  {
+                    "macd": 0.2156625294810155,
+                    "signal": 0.11133061582407482,
+                    "histogram": 0.10433191365694068
+                  },
+                  {
+                    "macd": 0.2151762427828956,
+                    "signal": 0.13209974121583898,
+                    "histogram": 0.08307650156705662
+                  },
+                  {
+                    "macd": 0.2649926584935045,
+                    "signal": 0.1586783246713721,
+                    "histogram": 0.1063143338221324
+                  },
+                  {
+                    "macd": 0.3656182486319466,
+                    "signal": 0.20006630946348702,
+                    "histogram": 0.16555193916845956
+                  },
+                  {
+                    "macd": 0.4761868687340751,
+                    "signal": 0.25529042131760465,
+                    "histogram": 0.22089644741647046
+                  },
+                  {
+                    "macd": 0.545422140325357,
+                    "signal": 0.3133167651191551,
+                    "histogram": 0.23210537520620184
+                  },
+                  {
+                    "macd": 0.5703169901916212,
+                    "signal": 0.3647168101336483,
+                    "histogram": 0.20560018005797287
+                  },
+                  {
+                    "macd": 0.619219355727914,
+                    "signal": 0.4156173192525015,
+                    "histogram": 0.20360203647541247
+                  },
+                  {
+                    "macd": 0.6839809757893391,
+                    "signal": 0.46929005055986905,
+                    "histogram": 0.2146909252294701
+                  },
+                  {
+                    "macd": 0.7357004592753142,
+                    "signal": 0.5225721323029581,
+                    "histogram": 0.21312832697235617
+                  },
+                  {
+                    "macd": 0.7662418931903048,
+                    "signal": 0.5713060844804274,
+                    "histogram": 0.19493580870987737
+                  },
+                  {
+                    "macd": 0.6944866865846038,
+                    "signal": 0.5959422049012627,
+                    "histogram": 0.09854448168334107
+                  },
+                  {
+                    "macd": 0.6973624008568393,
+                    "signal": 0.616226244092378,
+                    "histogram": 0.08113615676446129
+                  },
+                  {
+                    "macd": 0.6844888041302681,
+                    "signal": 0.629878756099956,
+                    "histogram": 0.05461004803031211
+                  },
+                  {
+                    "macd": 0.684151861258016,
+                    "signal": 0.6407333771315681,
+                    "histogram": 0.04341848412644789
+                  },
+                  {
+                    "macd": 0.6928436402946403,
+                    "signal": 0.6511554297641825,
+                    "histogram": 0.04168821053045779
+                  },
+                  {
+                    "macd": 0.7300483464385437,
+                    "signal": 0.6669340130990548,
+                    "histogram": 0.0631143333394889
+                  },
+                  {
+                    "macd": 0.6519601806458013,
+                    "signal": 0.6639392466084041,
+                    "histogram": -0.011979065962602786
+                  },
+                  {
+                    "macd": 0.5626096412768078,
+                    "signal": 0.6436733255420849,
+                    "histogram": -0.0810636842652771
+                  },
+                  {
+                    "macd": 0.396051616208986,
+                    "signal": 0.5941489836754652,
+                    "histogram": -0.1980973674664792
+                  },
+                  {
+                    "macd": 0.2738075488843421,
+                    "signal": 0.5300806967172406,
+                    "histogram": -0.25627314783289845
+                  },
+                  {
+                    "macd": 0.2052254440336725,
+                    "signal": 0.46510964618052697,
+                    "histogram": -0.2598842021468545
+                  },
+                  {
+                    "macd": 0.06778671632012845,
+                    "signal": 0.3856450602084473,
+                    "histogram": -0.31785834388831885
+                  },
+                  {
+                    "macd": 0.0040067774758156816,
+                    "signal": 0.309317403661921,
+                    "histogram": -0.3053106261861053
+                  },
+                  {
+                    "macd": -0.016493337052153834,
+                    "signal": 0.24415525551910605,
+                    "histogram": -0.2606485925712599
+                  },
+                  {
+                    "macd": 0.011507860927089553,
+                    "signal": 0.19762577660070277,
+                    "histogram": -0.18611791567361322
+                  },
+                  {
+                    "macd": 0.07399890883316829,
+                    "signal": 0.1729004030471959,
+                    "histogram": -0.09890149421402761
+                  },
+                  {
+                    "macd": 0.17476539962057558,
+                    "signal": 0.17327340236187183,
+                    "histogram": 0.0014919972587037478
+                  },
+                  {
+                    "macd": 0.21901533591832845,
+                    "signal": 0.18242178907316317,
+                    "histogram": 0.036593546845165276
+                  },
+                  {
+                    "macd": 0.24719934073027616,
+                    "signal": 0.19537729940458576,
+                    "histogram": 0.051822041325690404
+                  },
+                  {
+                    "macd": 0.33825873299515763,
+                    "signal": 0.22395358612270014,
+                    "histogram": 0.11430514687245749
+                  },
+                  {
+                    "macd": 0.41133078255624866,
+                    "signal": 0.2614290254094099,
+                    "histogram": 0.1499017571468388
+                  },
+                  {
+                    "macd": 0.4471413698321527,
+                    "signal": 0.29857149429395846,
+                    "histogram": 0.14856987553819423
+                  },
+                  {
+                    "macd": 0.4661139264812917,
+                    "signal": 0.33207998073142514,
+                    "histogram": 0.13403394574986655
+                  },
+                  {
+                    "macd": 0.44694862814152714,
+                    "signal": 0.35505371021344556,
+                    "histogram": 0.09189491792808158
+                  },
+                  {
+                    "macd": 0.4699166454599464,
+                    "signal": 0.3780262972627457,
+                    "histogram": 0.09189034819720066
+                  },
+                  {
+                    "macd": 0.5208469171503793,
+                    "signal": 0.40659042124027245,
+                    "histogram": 0.11425649591010689
+                  },
+                  {
+                    "macd": 0.6010816222907565,
+                    "signal": 0.44548866145036925,
+                    "histogram": 0.1555929608403872
+                  },
+                  {
+                    "macd": 0.6722505276577593,
+                    "signal": 0.49084103469184726,
+                    "histogram": 0.18140949296591202
+                  },
+                  {
+                    "macd": 0.6788671488768898,
+                    "signal": 0.5284462575288558,
+                    "histogram": 0.15042089134803405
+                  },
+                  {
+                    "macd": 0.6555738224532419,
+                    "signal": 0.553871770513733,
+                    "histogram": 0.10170205193950888
+                  },
+                  {
+                    "macd": 0.6067191623646906,
+                    "signal": 0.5644412488839246,
+                    "histogram": 0.04227791348076604
+                  },
+                  {
+                    "macd": 0.6420985117682321,
+                    "signal": 0.579972701460786,
+                    "histogram": 0.06212581030744602
+                  },
+                  {
+                    "macd": 0.7111610306535354,
+                    "signal": 0.606210367299336,
+                    "histogram": 0.10495066335419945
+                  },
+                  {
+                    "macd": 0.7643449418880266,
+                    "signal": 0.6378372822170741,
+                    "histogram": 0.12650765967095245
+                  },
+                  {
+                    "macd": 0.819638849700695,
+                    "signal": 0.6741975957137983,
+                    "histogram": 0.14544125398689667
+                  },
+                  {
+                    "macd": 0.8472377613250544,
+                    "signal": 0.7088056288360496,
+                    "histogram": 0.13843213248900477
+                  },
+                  {
+                    "macd": 0.7937926279812331,
+                    "signal": 0.7258030286650863,
+                    "histogram": 0.06798959931614679
+                  },
+                  {
+                    "macd": 0.7372895691876238,
+                    "signal": 0.7281003367695937,
+                    "histogram": 0.009189232418030047
+                  },
+                  {
+                    "macd": 0.6622825456397479,
+                    "signal": 0.7149367785436246,
+                    "histogram": -0.05265423290387672
+                  },
+                  {
+                    "macd": 0.6717525163066398,
+                    "signal": 0.7062999260962277,
+                    "histogram": -0.034547409789587924
+                  },
+                  {
+                    "macd": 0.7465023550987269,
+                    "signal": 0.7143404118967276,
+                    "histogram": 0.03216194320199928
+                  },
+                  {
+                    "macd": 0.825277891672151,
+                    "signal": 0.7365279078518123,
+                    "histogram": 0.08874998382033872
+                  },
+                  {
+                    "macd": 0.7491586435273092,
+                    "signal": 0.7390540549869118,
+                    "histogram": 0.010104588540397419
+                  },
+                  {
+                    "macd": 0.7240606316208371,
+                    "signal": 0.7360553703136968,
+                    "histogram": -0.011994738692859719
+                  },
+                  {
+                    "macd": 0.6698206114775402,
+                    "signal": 0.7228084185464655,
+                    "histogram": -0.05298780706892525
+                  },
+                  {
+                    "macd": 0.5670420254010295,
+                    "signal": 0.6916551399173783,
+                    "histogram": -0.12461311451634871
+                  },
+                  {
+                    "macd": 0.42820380549866144,
+                    "signal": 0.6389648730336349,
+                    "histogram": -0.21076106753497348
+                  },
+                  {
+                    "macd": 0.1502170130562277,
+                    "signal": 0.5412153010381534,
+                    "histogram": -0.3909982879819257
+                  },
+                  {
+                    "macd": -0.06051580427725156,
+                    "signal": 0.42086907997507245,
+                    "histogram": -0.481384884252324
+                  },
+                  {
+                    "macd": -0.19461674912730587,
+                    "signal": 0.2977719141545968,
+                    "histogram": -0.49238866328190267
+                  },
+                  {
+                    "macd": -0.3668656657699074,
+                    "signal": 0.16484439816969598,
+                    "histogram": -0.5317100639396034
+                  },
+                  {
+                    "macd": -0.5000307803965427,
+                    "signal": 0.03186936245644825,
+                    "histogram": -0.5319001428529909
+                  },
+                  {
+                    "macd": -0.5683505909193656,
+                    "signal": -0.08817462821871452,
+                    "histogram": -0.48017596270065105
+                  },
+                  {
+                    "macd": -0.6736341599014679,
+                    "signal": -0.20526653455526522,
+                    "histogram": -0.4683676253462027
+                  },
+                  {
+                    "macd": -0.7245129809635031,
+                    "signal": -0.30911582383691283,
+                    "histogram": -0.4153971571265903
+                  },
+                  {
+                    "macd": -0.7441531175877785,
+                    "signal": -0.39612328258708596,
+                    "histogram": -0.3480298350006925
+                  },
+                  {
+                    "macd": -0.7797780047092786,
+                    "signal": -0.4728542270115245,
+                    "histogram": -0.3069237776977541
+                  },
+                  {
+                    "macd": -0.6974923042026973,
+                    "signal": -0.5177818424497591,
+                    "histogram": -0.17971046175293814
+                  },
+                  {
+                    "macd": -0.6155022559152599,
+                    "signal": -0.5373259251428593,
+                    "histogram": -0.0781763307724006
+                  },
+                  {
+                    "macd": -0.4780400999018255,
+                    "signal": -0.5254687600946526,
+                    "histogram": 0.0474286601928271
+                  },
+                  {
+                    "macd": -0.33138964735113063,
+                    "signal": -0.48665293754594824,
+                    "histogram": 0.1552632901948176
+                  },
+                  {
+                    "macd": -0.13852799041162456,
+                    "signal": -0.41702794811908356,
+                    "histogram": 0.278499957707459
+                  },
+                  {
+                    "macd": -0.02094679593687232,
+                    "signal": -0.33781171768264134,
+                    "histogram": 0.316864921745769
+                  },
+                  {
+                    "macd": 0.19825155146131834,
+                    "signal": -0.23059906385384943,
+                    "histogram": 0.42885061531516777
+                  },
+                  {
+                    "macd": 0.35815630711910273,
+                    "signal": -0.112847989659259,
+                    "histogram": 0.47100429677836175
+                  },
+                  {
+                    "macd": 0.3979886995978248,
+                    "signal": -0.010680651807842237,
+                    "histogram": 0.408669351405667
+                  },
+                  {
+                    "macd": 0.3018118548641837,
+                    "signal": 0.05181784952656296,
+                    "histogram": 0.24999400533762076
+                  },
+                  {
+                    "macd": 0.11692346688920452,
+                    "signal": 0.06483897299909128,
+                    "histogram": 0.05208449389011324
+                  },
+                  {
+                    "macd": -0.026871503881061187,
+                    "signal": 0.04649687762306078,
+                    "histogram": -0.07336838150412198
+                  },
+                  {
+                    "macd": -0.12406826338796861,
+                    "signal": 0.012383849420854902,
+                    "histogram": -0.13645211280882352
+                  },
+                  {
+                    "macd": -0.14934708309757383,
+                    "signal": -0.019962337082830846,
+                    "histogram": -0.12938474601474298
+                  },
+                  {
+                    "macd": -0.21451600435174356,
+                    "signal": -0.05887307053661339,
+                    "histogram": -0.15564293381513017
+                  },
+                  {
+                    "macd": -0.23999567299198787,
+                    "signal": -0.0950975910276883,
+                    "histogram": -0.14489808196429957
+                  },
+                  {
+                    "macd": -0.41596995555941874,
+                    "signal": -0.1592720639340344,
+                    "histogram": -0.25669789162538437
+                  },
+                  {
+                    "macd": -0.601750706588895,
+                    "signal": -0.24776779246500652,
+                    "histogram": -0.35398291412388844
+                  },
+                  {
+                    "macd": -0.6383397034163494,
+                    "signal": -0.32588217465527514,
+                    "histogram": -0.31245752876107424
+                  },
+                  {
+                    "macd": -0.6110707524876915,
+                    "signal": -0.38291989022175843,
+                    "histogram": -0.22815086226593306
+                  },
+                  {
+                    "macd": -0.7797792506439052,
+                    "signal": -0.4622917623061878,
+                    "histogram": -0.3174874883377174
+                  },
+                  {
+                    "macd": -0.9046673783013617,
+                    "signal": -0.5507668855052226,
+                    "histogram": -0.3539004927961391
+                  },
+                  {
+                    "macd": -0.9794410816206067,
+                    "signal": -0.6365017247282994,
+                    "histogram": -0.34293935689230737
+                  },
+                  {
+                    "macd": -1.0005381175986798,
+                    "signal": -0.7093090033023755,
+                    "histogram": -0.2912291142963044
+                  },
+                  {
+                    "macd": -1.0447531392770912,
+                    "signal": -0.7763978304973187,
+                    "histogram": -0.26835530877977254
+                  },
+                  {
+                    "macd": -1.1608220109193894,
+                    "signal": -0.8532826665817329,
+                    "histogram": -0.3075393443376565
+                  },
+                  {
+                    "macd": -1.2975615888210967,
+                    "signal": -0.9421384510296057,
+                    "histogram": -0.35542313779149104
+                  },
+                  {
+                    "macd": -1.3372571496192407,
+                    "signal": -1.0211621907475328,
+                    "histogram": -0.3160949588717079
+                  },
+                  {
+                    "macd": -1.3563092187240215,
+                    "signal": -1.0881915963428306,
+                    "histogram": -0.26811762238119097
+                  },
+                  {
+                    "macd": -1.4666626803738083,
+                    "signal": -1.1638858131490262,
+                    "histogram": -0.30277686722478214
+                  },
+                  {
+                    "macd": -1.5691143811137849,
+                    "signal": -1.244931526741978,
+                    "histogram": -0.32418285437180683
+                  },
+                  {
+                    "macd": -1.6043786429558935,
+                    "signal": -1.3168209499847612,
+                    "histogram": -0.2875576929711323
+                  },
+                  {
+                    "macd": -1.5961741702111354,
+                    "signal": -1.3726915940300362,
+                    "histogram": -0.22348257618109924
+                  },
+                  {
+                    "macd": -1.6074533379180593,
+                    "signal": -1.419643942807641,
+                    "histogram": -0.18780939511041828
+                  },
+                  {
+                    "macd": -1.5836130417195733,
+                    "signal": -1.4524377625900275,
+                    "histogram": -0.13117527912954574
+                  },
+                  {
+                    "macd": -1.5349219410185313,
+                    "signal": -1.4689345982757283,
+                    "histogram": -0.06598734274280305
+                  },
+                  {
+                    "macd": -1.450563657409674,
+                    "signal": -1.4652604101025175,
+                    "histogram": 0.014696752692843429
+                  },
+                  {
+                    "macd": -1.3184817408431613,
+                    "signal": -1.4359046762506464,
+                    "histogram": 0.11742293540748516
+                  },
+                  {
+                    "macd": -1.1513123074841616,
+                    "signal": -1.3789862024973494,
+                    "histogram": 0.2276738950131878
+                  },
+                  {
+                    "macd": -1.0479023633225353,
+                    "signal": -1.3127694346623868,
+                    "histogram": 0.26486707133985155
+                  },
+                  {
+                    "macd": -1.0562518468542805,
+                    "signal": -1.2614659171007656,
+                    "histogram": 0.20521407024648508
+                  },
+                  {
+                    "macd": -1.0300158000761712,
+                    "signal": -1.2151758936958468,
+                    "histogram": 0.18516009361967556
+                  },
+                  {
+                    "macd": -0.8764688232053359,
+                    "signal": -1.1474344795977447,
+                    "histogram": 0.27096565639240877
+                  },
+                  {
+                    "macd": -0.7046987185053766,
+                    "signal": -1.0588873273792712,
+                    "histogram": 0.3541886088738946
+                  },
+                  {
+                    "macd": -0.5533152690570802,
+                    "signal": -0.957772915714833,
+                    "histogram": 0.40445764665775286
+                  },
+                  {
+                    "macd": -0.3741593766940241,
+                    "signal": -0.8410502079106713,
+                    "histogram": 0.4668908312166472
+                  },
+                  {
+                    "macd": -0.2119814984182895,
+                    "signal": -0.7152364660121949,
+                    "histogram": 0.5032549675939054
+                  },
+                  {
+                    "macd": 0.04513219561707871,
+                    "signal": -0.5631627336863403,
+                    "histogram": 0.608294929303419
+                  },
+                  {
+                    "macd": 0.31227088944974213,
+                    "signal": -0.3880760090591238,
+                    "histogram": 0.7003468985088659
+                  },
+                  {
+                    "macd": 0.5044478367879677,
+                    "signal": -0.20957123988970555,
+                    "histogram": 0.7140190766776733
+                  },
+                  {
+                    "macd": 0.713880317732368,
+                    "signal": -0.024880928365290822,
+                    "histogram": 0.7387612460976589
+                  },
+                  {
+                    "macd": 0.8698302065892918,
+                    "signal": 0.1540612986256257,
+                    "histogram": 0.7157689079636661
+                  },
+                  {
+                    "macd": 1.0594795877544883,
+                    "signal": 0.3351449564513982,
+                    "histogram": 0.7243346313030901
+                  },
+                  {
+                    "macd": 1.131375949627028,
+                    "signal": 0.4943911550865242,
+                    "histogram": 0.6369847945405037
+                  },
+                  {
+                    "macd": 1.206720788490422,
+                    "signal": 0.6368570817673038,
+                    "histogram": 0.5698637067231183
+                  },
+                  {
+                    "macd": 1.2551907975167325,
+                    "signal": 0.7605238249171896,
+                    "histogram": 0.49466697259954284
+                  },
+                  {
+                    "macd": 1.2413687323101286,
+                    "signal": 0.8566928063957775,
+                    "histogram": 0.38467592591435107
+                  },
+                  {
+                    "macd": 1.1876748293161086,
+                    "signal": 0.9228892109798438,
+                    "histogram": 0.2647856183362648
+                  },
+                  {
+                    "macd": 1.0802205314422935,
+                    "signal": 0.9543554750723338,
+                    "histogram": 0.1258650563699597
+                  },
+                  {
+                    "macd": 0.9502180539976877,
+                    "signal": 0.9535279908574046,
+                    "histogram": -0.003309936859716922
+                  },
+                  {
+                    "macd": 0.8838035176907724,
+                    "signal": 0.9395830962240781,
+                    "histogram": -0.05577957853330573
+                  },
+                  {
+                    "macd": 0.824090566879228,
+                    "signal": 0.9164845903551081,
+                    "histogram": -0.0923940234758801
+                  },
+                  {
+                    "macd": 0.7854655253948835,
+                    "signal": 0.8902807773630632,
+                    "histogram": -0.10481525196817976
+                  },
+                  {
+                    "macd": 0.7925202147060872,
+                    "signal": 0.8707286648316681,
+                    "histogram": -0.07820845012558086
+                  },
+                  {
+                    "macd": 0.771466172921464,
+                    "signal": 0.8508761664496273,
+                    "histogram": -0.07940999352816325
+                  },
+                  {
+                    "macd": 0.6624182765349147,
+                    "signal": 0.8131845884666847,
+                    "histogram": -0.15076631193177004
+                  },
+                  {
+                    "macd": 0.6436210227812964,
+                    "signal": 0.7792718753296072,
+                    "histogram": -0.13565085254831077
+                  },
+                  {
+                    "macd": 0.659849678933,
+                    "signal": 0.7553874360502858,
+                    "histogram": -0.09553775711728585
+                  },
+                  {
+                    "macd": 0.597238637481702,
+                    "signal": 0.7237576763365692,
+                    "histogram": -0.12651903885486715
+                  },
+                  {
+                    "macd": 0.4265065790860234,
+                    "signal": 0.6643074568864601,
+                    "histogram": -0.23780087780043668
+                  },
+                  {
+                    "macd": 0.22725472099596544,
+                    "signal": 0.5768969097083612,
+                    "histogram": -0.3496421887123957
+                  },
+                  {
+                    "macd": 0.08690345981040792,
+                    "signal": 0.47889821972877056,
+                    "histogram": -0.39199475991836263
+                  },
+                  {
+                    "macd": -0.09903435276259387,
+                    "signal": 0.36331170523049766,
+                    "histogram": -0.46234605799309153
+                  },
+                  {
+                    "macd": -0.242785942630384,
+                    "signal": 0.24209217565832133,
+                    "histogram": -0.4848781182887053
+                  },
+                  {
+                    "macd": -0.35902664890140557,
+                    "signal": 0.12186841074637597,
+                    "histogram": -0.48089505964778156
+                  },
+                  {
+                    "macd": -0.37261678821325006,
+                    "signal": 0.022971370954450773,
+                    "histogram": -0.39558815916770085
+                  },
+                  {
+                    "macd": -0.3782200968840499,
+                    "signal": -0.05726692261324936,
+                    "histogram": -0.32095317427080056
+                  },
+                  {
+                    "macd": -0.3360208480994942,
+                    "signal": -0.11301770771049832,
+                    "histogram": -0.22300314038899585
+                  },
+                  {
+                    "macd": -0.27838855002939766,
+                    "signal": -0.1460918761742782,
+                    "histogram": -0.13229667385511945
+                  },
+                  {
+                    "macd": -0.20533337108346927,
+                    "signal": -0.1579401751561164,
+                    "histogram": -0.04739319592735286
+                  },
+                  {
+                    "macd": -0.11384747245363513,
+                    "signal": -0.14912163461562017,
+                    "histogram": 0.035274162161985034
+                  },
+                  {
+                    "macd": -0.1286225495872415,
+                    "signal": -0.14502181760994443,
+                    "histogram": 0.016399268022702918
+                  },
+                  {
+                    "macd": -0.16505730876501445,
+                    "signal": -0.14902891584095845,
+                    "histogram": -0.016028392924056
+                  },
+                  {
+                    "macd": -0.12551139731436223,
+                    "signal": -0.1443254121356392,
+                    "histogram": 0.01881401482127698
+                  },
+                  {
+                    "macd": -0.10027730339491825,
+                    "signal": -0.13551579038749503,
+                    "histogram": 0.035238486992576784
+                  },
+                  {
+                    "macd": -0.0019852258418850965,
+                    "signal": -0.10880967747837306,
+                    "histogram": 0.10682445163648796
+                  },
+                  {
+                    "macd": 0.06866525214228858,
+                    "signal": -0.07331469155424072,
+                    "histogram": 0.1419799436965293
+                  },
+                  {
+                    "macd": 0.26443199414495666,
+                    "signal": -0.00576535441440125,
+                    "histogram": 0.2701973485593579
+                  },
+                  {
+                    "macd": 0.38767481070682663,
+                    "signal": 0.07292267860984433,
+                    "histogram": 0.3147521320969823
+                  },
+                  {
+                    "macd": 0.4638601495939554,
+                    "signal": 0.15111017280666655,
+                    "histogram": 0.31274997678728883
+                  },
+                  {
+                    "macd": 0.5812830738641139,
+                    "signal": 0.23714475301815602,
+                    "histogram": 0.3441383208459579
+                  },
+                  {
+                    "macd": 0.6762296515938431,
+                    "signal": 0.32496173273329343,
+                    "histogram": 0.35126791886054964
+                  },
+                  {
+                    "macd": 0.7923702794060219,
+                    "signal": 0.4184434420678391,
+                    "histogram": 0.37392683733818277
+                  },
+                  {
+                    "macd": 0.9429378253335656,
+                    "signal": 0.5233423187209845,
+                    "histogram": 0.41959550661258116
+                  },
+                  {
+                    "macd": 1.0381921874536033,
+                    "signal": 0.6263122924675083,
+                    "histogram": 0.411879894986095
+                  },
+                  {
+                    "macd": 1.1783694382025516,
+                    "signal": 0.736723721614517,
+                    "histogram": 0.44164571658803453
+                  },
+                  {
+                    "macd": 1.2500367537324806,
+                    "signal": 0.8393863280381098,
+                    "histogram": 0.4106504256943708
+                  },
+                  {
+                    "macd": 1.2656162987404258,
+                    "signal": 0.924632322178573,
+                    "histogram": 0.34098397656185275
+                  },
+                  {
+                    "macd": 1.3567327044746023,
+                    "signal": 1.0110523986377788,
+                    "histogram": 0.3456803058368234
+                  },
+                  {
+                    "macd": 1.4557358565935914,
+                    "signal": 1.0999890902289415,
+                    "histogram": 0.35574676636464986
+                  },
+                  {
+                    "macd": 1.5023538476517828,
+                    "signal": 1.1804620417135099,
+                    "histogram": 0.32189180593827293
+                  },
+                  {
+                    "macd": 1.558452156813118,
+                    "signal": 1.2560600647334317,
+                    "histogram": 0.3023920920796863
+                  },
+                  {
+                    "macd": 1.559914535022493,
+                    "signal": 1.316830958791244,
+                    "histogram": 0.2430835762312491
+                  },
+                  {
+                    "macd": 1.5432834691179025,
+                    "signal": 1.3621214608565757,
+                    "histogram": 0.18116200826132678
+                  },
+                  {
+                    "macd": 1.4408711622095183,
+                    "signal": 1.3778714011271642,
+                    "histogram": 0.06299976108235406
+                  },
+                  {
+                    "macd": 1.4542989709234249,
+                    "signal": 1.3931569150864163,
+                    "histogram": 0.0611420558370086
+                  },
+                  {
+                    "macd": 1.4777617105399585,
+                    "signal": 1.4100778741771247,
+                    "histogram": 0.06768383636283382
+                  }
+                ],
+                "bb": [
+                  {
+                    "upper": 49.10143740036504,
+                    "middle": 47.52550010681152,
+                    "lower": 45.949562813258
+                  },
+                  {
+                    "upper": 48.99850349222956,
+                    "middle": 47.36200008392334,
+                    "lower": 45.72549667561712
+                  },
+                  {
+                    "upper": 48.87057594578001,
+                    "middle": 47.22150001525879,
+                    "lower": 45.57242408473757
+                  },
+                  {
+                    "upper": 48.943461514414246,
+                    "middle": 47.14200000762939,
+                    "lower": 45.34053850084454
+                  },
+                  {
+                    "upper": 49.02033743388746,
+                    "middle": 47.07099990844726,
+                    "lower": 45.12166238300706
+                  },
+                  {
+                    "upper": 49.13211090684054,
+                    "middle": 46.968499755859376,
+                    "lower": 44.804888604878215
+                  },
+                  {
+                    "upper": 49.134407441441525,
+                    "middle": 46.932499694824216,
+                    "lower": 44.73059194820691
+                  },
+                  {
+                    "upper": 49.11313686809296,
+                    "middle": 46.886999702453615,
+                    "lower": 44.66086253681427
+                  },
+                  {
+                    "upper": 49.16899332268331,
+                    "middle": 46.95449962615967,
+                    "lower": 44.74000592963602
+                  },
+                  {
+                    "upper": 49.19093708248246,
+                    "middle": 47.01499977111816,
+                    "lower": 44.83906245975386
+                  },
+                  {
+                    "upper": 49.246438939136766,
+                    "middle": 47.049499702453616,
+                    "lower": 44.852560465770466
+                  },
+                  {
+                    "upper": 49.22432326308422,
+                    "middle": 47.030499649047854,
+                    "lower": 44.836676035011486
+                  },
+                  {
+                    "upper": 49.27258010914193,
+                    "middle": 47.0524995803833,
+                    "lower": 44.83241905162467
+                  },
+                  {
+                    "upper": 49.31210018576126,
+                    "middle": 47.06799964904785,
+                    "lower": 44.82389911233444
+                  },
+                  {
+                    "upper": 49.34442407938513,
+                    "middle": 47.07849960327148,
+                    "lower": 44.812575127157835
+                  },
+                  {
+                    "upper": 49.32353818710721,
+                    "middle": 47.07199954986572,
+                    "lower": 44.820460912624235
+                  },
+                  {
+                    "upper": 49.539846439113695,
+                    "middle": 47.12349948883057,
+                    "lower": 44.70715253854744
+                  },
+                  {
+                    "upper": 49.77228207409565,
+                    "middle": 47.18599948883057,
+                    "lower": 44.599716903565486
+                  },
+                  {
+                    "upper": 50.19872923157448,
+                    "middle": 47.30099945068359,
+                    "lower": 44.4032696697927
+                  },
+                  {
+                    "upper": 50.6075085948405,
+                    "middle": 47.421999549865724,
+                    "lower": 44.236490504890945
+                  },
+                  {
+                    "upper": 51.03577971748499,
+                    "middle": 47.58299961090088,
+                    "lower": 44.13021950431676
+                  },
+                  {
+                    "upper": 51.43107441943368,
+                    "middle": 47.83699970245361,
+                    "lower": 44.24292498547354
+                  },
+                  {
+                    "upper": 51.706003160401394,
+                    "middle": 48.06549968719482,
+                    "lower": 44.42499621398825
+                  },
+                  {
+                    "upper": 51.83886107992278,
+                    "middle": 48.290499687194824,
+                    "lower": 44.74213829446687
+                  },
+                  {
+                    "upper": 51.97946838180458,
+                    "middle": 48.550499725341794,
+                    "lower": 45.12153106887901
+                  },
+                  {
+                    "upper": 51.82349962068764,
+                    "middle": 48.792999839782716,
+                    "lower": 45.76250005887779
+                  },
+                  {
+                    "upper": 51.723191299715225,
+                    "middle": 48.96549987792969,
+                    "lower": 46.20780845614415
+                  },
+                  {
+                    "upper": 51.664185198332234,
+                    "middle": 49.17199993133545,
+                    "lower": 46.679814664338664
+                  },
+                  {
+                    "upper": 51.70480272083886,
+                    "middle": 49.30349998474121,
+                    "lower": 46.90219724864355
+                  },
+                  {
+                    "upper": 51.761525115365934,
+                    "middle": 49.47899990081787,
+                    "lower": 47.1964746862698
+                  },
+                  {
+                    "upper": 51.800600235526524,
+                    "middle": 49.622500038146974,
+                    "lower": 47.444399840767424
+                  },
+                  {
+                    "upper": 51.63774229168543,
+                    "middle": 49.805000114440915,
+                    "lower": 47.9722579371964
+                  },
+                  {
+                    "upper": 51.59106849229348,
+                    "middle": 49.942000198364255,
+                    "lower": 48.29293190443503
+                  },
+                  {
+                    "upper": 51.63801595052112,
+                    "middle": 50.10800018310547,
+                    "lower": 48.57798441568981
+                  },
+                  {
+                    "upper": 51.845434220491306,
+                    "middle": 50.297000312805174,
+                    "lower": 48.74856640511904
+                  },
+                  {
+                    "upper": 51.97007176102611,
+                    "middle": 50.496500396728514,
+                    "lower": 49.022929032430916
+                  },
+                  {
+                    "upper": 52.13853026749248,
+                    "middle": 50.618500328063966,
+                    "lower": 49.098470388635455
+                  },
+                  {
+                    "upper": 52.22479259894339,
+                    "middle": 50.72950038909912,
+                    "lower": 49.23420817925486
+                  },
+                  {
+                    "upper": 52.33733877470938,
+                    "middle": 50.80200042724609,
+                    "lower": 49.266662079782805
+                  },
+                  {
+                    "upper": 52.46285602544233,
+                    "middle": 50.87550029754639,
+                    "lower": 49.28814456965045
+                  },
+                  {
+                    "upper": 52.63976411059123,
+                    "middle": 50.96150016784668,
+                    "lower": 49.28323622510213
+                  },
+                  {
+                    "upper": 52.835465619727316,
+                    "middle": 51.04549999237061,
+                    "lower": 49.2555343650139
+                  },
+                  {
+                    "upper": 52.88482391197262,
+                    "middle": 51.104000091552734,
+                    "lower": 49.32317627113285
+                  },
+                  {
+                    "upper": 52.86284782995116,
+                    "middle": 51.13500003814697,
+                    "lower": 49.40715224634278
+                  },
+                  {
+                    "upper": 52.865245559489026,
+                    "middle": 51.12800006866455,
+                    "lower": 49.39075457784007
+                  },
+                  {
+                    "upper": 52.811393078198506,
+                    "middle": 51.171500015258786,
+                    "lower": 49.531606952319066
+                  },
+                  {
+                    "upper": 52.70692642579407,
+                    "middle": 51.21800003051758,
+                    "lower": 49.729073635241086
+                  },
+                  {
+                    "upper": 52.70692642579407,
+                    "middle": 51.21800003051758,
+                    "lower": 49.729073635241086
+                  },
+                  {
+                    "upper": 52.73943266214545,
+                    "middle": 51.203499984741214,
+                    "lower": 49.66756730733698
+                  },
+                  {
+                    "upper": 52.80120251991166,
+                    "middle": 51.15550003051758,
+                    "lower": 49.5097975411235
+                  },
+                  {
+                    "upper": 53.023778014843074,
+                    "middle": 51.05900001525879,
+                    "lower": 49.094222015674504
+                  },
+                  {
+                    "upper": 53.15276403725544,
+                    "middle": 50.972500038146975,
+                    "lower": 48.792236039038514
+                  },
+                  {
+                    "upper": 53.15455022136123,
+                    "middle": 50.94400005340576,
+                    "lower": 48.73344988545029
+                  },
+                  {
+                    "upper": 53.267074101776785,
+                    "middle": 50.98799991607666,
+                    "lower": 48.708925730376535
+                  },
+                  {
+                    "upper": 53.13169319175785,
+                    "middle": 50.90349979400635,
+                    "lower": 48.675306396254854
+                  },
+                  {
+                    "upper": 53.00469146211248,
+                    "middle": 50.854999732971194,
+                    "lower": 48.705308003829906
+                  },
+                  {
+                    "upper": 53.02318204360416,
+                    "middle": 50.86099987030029,
+                    "lower": 48.69881769699642
+                  },
+                  {
+                    "upper": 53.001599725887225,
+                    "middle": 50.851999855041505,
+                    "lower": 48.702399984195786
+                  },
+                  {
+                    "upper": 52.93993721189855,
+                    "middle": 50.82199974060059,
+                    "lower": 48.704062269302625
+                  },
+                  {
+                    "upper": 52.927047106318305,
+                    "middle": 50.81749973297119,
+                    "lower": 48.70795235962408
+                  },
+                  {
+                    "upper": 52.99775193436842,
+                    "middle": 50.83549976348877,
+                    "lower": 48.67324759260912
+                  },
+                  {
+                    "upper": 53.12912883168658,
+                    "middle": 50.865499877929686,
+                    "lower": 48.60187092417279
+                  },
+                  {
+                    "upper": 53.339117054839576,
+                    "middle": 50.929499816894534,
+                    "lower": 48.51988257894949
+                  },
+                  {
+                    "upper": 53.534985215571034,
+                    "middle": 51.02449989318848,
+                    "lower": 48.51401457080592
+                  },
+                  {
+                    "upper": 53.794464731403565,
+                    "middle": 51.1519998550415,
+                    "lower": 48.50953497867944
+                  },
+                  {
+                    "upper": 54.104508509193586,
+                    "middle": 51.29249992370605,
+                    "lower": 48.48049133821852
+                  },
+                  {
+                    "upper": 54.39587935506323,
+                    "middle": 51.45100002288818,
+                    "lower": 48.50612069071313
+                  },
+                  {
+                    "upper": 54.64168271907787,
+                    "middle": 51.61350002288818,
+                    "lower": 48.585317326698494
+                  },
+                  {
+                    "upper": 54.67873270720449,
+                    "middle": 51.74400005340576,
+                    "lower": 48.80926739960704
+                  },
+                  {
+                    "upper": 54.78335983462088,
+                    "middle": 51.91900005340576,
+                    "lower": 49.05464027219064
+                  },
+                  {
+                    "upper": 54.634160425089846,
+                    "middle": 52.14650001525879,
+                    "lower": 49.65883960542773
+                  },
+                  {
+                    "upper": 54.41034428289377,
+                    "middle": 52.37449989318848,
+                    "lower": 50.33865550348319
+                  },
+                  {
+                    "upper": 54.36556034076045,
+                    "middle": 52.551499938964845,
+                    "lower": 50.73743953716924
+                  },
+                  {
+                    "upper": 54.57389836211056,
+                    "middle": 52.64300003051758,
+                    "lower": 50.71210169892459
+                  },
+                  {
+                    "upper": 54.410398589224556,
+                    "middle": 52.764500045776366,
+                    "lower": 51.118601502328175
+                  },
+                  {
+                    "upper": 54.33277181760951,
+                    "middle": 52.8310001373291,
+                    "lower": 51.329228457048686
+                  },
+                  {
+                    "upper": 54.381634520373176,
+                    "middle": 52.80300006866455,
+                    "lower": 51.22436561695593
+                  },
+                  {
+                    "upper": 54.36888438605327,
+                    "middle": 52.80900001525879,
+                    "lower": 51.24911564446431
+                  },
+                  {
+                    "upper": 54.25683534747407,
+                    "middle": 52.85500011444092,
+                    "lower": 51.453164881407766
+                  },
+                  {
+                    "upper": 54.36869776738559,
+                    "middle": 52.817000198364255,
+                    "lower": 51.26530262934292
+                  },
+                  {
+                    "upper": 54.41008530871885,
+                    "middle": 52.766500282287595,
+                    "lower": 51.12291525585634
+                  },
+                  {
+                    "upper": 54.39026864125841,
+                    "middle": 52.7120002746582,
+                    "lower": 51.033731908057995
+                  },
+                  {
+                    "upper": 54.372034725163495,
+                    "middle": 52.692500305175784,
+                    "lower": 51.01296588518807
+                  },
+                  {
+                    "upper": 54.396545693804164,
+                    "middle": 52.71300029754639,
+                    "lower": 51.02945490128861
+                  },
+                  {
+                    "upper": 54.47199861777268,
+                    "middle": 52.74400043487549,
+                    "lower": 51.0160022519783
+                  },
+                  {
+                    "upper": 54.446700083157275,
+                    "middle": 52.733500480651855,
+                    "lower": 51.020300878146436
+                  },
+                  {
+                    "upper": 54.399856783516995,
+                    "middle": 52.71500034332276,
+                    "lower": 51.03014390312852
+                  },
+                  {
+                    "upper": 54.49684232961816,
+                    "middle": 52.74250030517578,
+                    "lower": 50.9881582807334
+                  },
+                  {
+                    "upper": 54.68089657707128,
+                    "middle": 52.82800025939942,
+                    "lower": 50.97510394172755
+                  },
+                  {
+                    "upper": 54.76834313410461,
+                    "middle": 52.86100025177002,
+                    "lower": 50.95365736943543
+                  },
+                  {
+                    "upper": 54.85201085234159,
+                    "middle": 52.89600028991699,
+                    "lower": 50.93998972749239
+                  },
+                  {
+                    "upper": 54.86512699459645,
+                    "middle": 52.902000427246094,
+                    "lower": 50.938873859895736
+                  },
+                  {
+                    "upper": 54.93033729510384,
+                    "middle": 52.924500465393066,
+                    "lower": 50.91866363568229
+                  },
+                  {
+                    "upper": 55.014667523581075,
+                    "middle": 52.94700050354004,
+                    "lower": 50.879333483499
+                  },
+                  {
+                    "upper": 55.337424077948995,
+                    "middle": 53.06050052642822,
+                    "lower": 50.78357697490745
+                  },
+                  {
+                    "upper": 55.666305031650595,
+                    "middle": 53.196500587463376,
+                    "lower": 50.72669614327616
+                  },
+                  {
+                    "upper": 55.796197477489024,
+                    "middle": 53.36300067901611,
+                    "lower": 50.9298038805432
+                  },
+                  {
+                    "upper": 55.858779824105994,
+                    "middle": 53.50850067138672,
+                    "lower": 51.158221518667446
+                  },
+                  {
+                    "upper": 55.88842017467029,
+                    "middle": 53.620500564575195,
+                    "lower": 51.3525809544801
+                  },
+                  {
+                    "upper": 55.86670707303841,
+                    "middle": 53.83400058746338,
+                    "lower": 51.801294101888345
+                  },
+                  {
+                    "upper": 55.98604829656993,
+                    "middle": 54.05000057220459,
+                    "lower": 52.11395284783924
+                  },
+                  {
+                    "upper": 56.10226140734339,
+                    "middle": 54.252000617980954,
+                    "lower": 52.40173982861852
+                  },
+                  {
+                    "upper": 56.298386185718016,
+                    "middle": 54.44050064086914,
+                    "lower": 52.58261509602026
+                  },
+                  {
+                    "upper": 56.47781295614164,
+                    "middle": 54.599500465393064,
+                    "lower": 52.72118797464449
+                  },
+                  {
+                    "upper": 56.5369305332602,
+                    "middle": 54.68450031280518,
+                    "lower": 52.83207009235016
+                  },
+                  {
+                    "upper": 56.53106035991195,
+                    "middle": 54.78650016784668,
+                    "lower": 53.04193997578142
+                  },
+                  {
+                    "upper": 56.46132413506245,
+                    "middle": 54.87700023651123,
+                    "lower": 53.29267633796001
+                  },
+                  {
+                    "upper": 56.57682271905623,
+                    "middle": 54.97000026702881,
+                    "lower": 53.363177815001386
+                  },
+                  {
+                    "upper": 56.87098561034503,
+                    "middle": 55.106500244140626,
+                    "lower": 53.34201487793622
+                  },
+                  {
+                    "upper": 57.18354850260481,
+                    "middle": 55.271500205993654,
+                    "lower": 53.3594519093825
+                  },
+                  {
+                    "upper": 57.16864080273916,
+                    "middle": 55.35850009918213,
+                    "lower": 53.5483593956251
+                  },
+                  {
+                    "upper": 57.12772273537773,
+                    "middle": 55.49050006866455,
+                    "lower": 53.853277401951374
+                  },
+                  {
+                    "upper": 57.088011479394986,
+                    "middle": 55.57899990081787,
+                    "lower": 54.069988322240754
+                  },
+                  {
+                    "upper": 57.05816677537995,
+                    "middle": 55.61049976348877,
+                    "lower": 54.162832751597584
+                  },
+                  {
+                    "upper": 57.08949262703156,
+                    "middle": 55.58049983978272,
+                    "lower": 54.071507052533875
+                  },
+                  {
+                    "upper": 57.46430292823322,
+                    "middle": 55.4379997253418,
+                    "lower": 53.41169652245038
+                  },
+                  {
+                    "upper": 57.69342408589597,
+                    "middle": 55.32699966430664,
+                    "lower": 52.96057524271731
+                  },
+                  {
+                    "upper": 57.81029229277172,
+                    "middle": 55.24799976348877,
+                    "lower": 52.68570723420582
+                  },
+                  {
+                    "upper": 58.02191581186638,
+                    "middle": 55.13999977111816,
+                    "lower": 52.25808373036995
+                  },
+                  {
+                    "upper": 58.155631965311244,
+                    "middle": 54.979999732971194,
+                    "lower": 51.804367500631145
+                  },
+                  {
+                    "upper": 58.13793954013931,
+                    "middle": 54.8084997177124,
+                    "lower": 51.479059895285495
+                  },
+                  {
+                    "upper": 58.1375377982754,
+                    "middle": 54.5959997177124,
+                    "lower": 51.0544616371494
+                  },
+                  {
+                    "upper": 58.0099064854355,
+                    "middle": 54.38449974060059,
+                    "lower": 50.75909299576568
+                  },
+                  {
+                    "upper": 57.835085526490694,
+                    "middle": 54.184499740600586,
+                    "lower": 50.53391395471048
+                  },
+                  {
+                    "upper": 57.75682406800952,
+                    "middle": 54.007499885559085,
+                    "lower": 50.25817570310865
+                  },
+                  {
+                    "upper": 57.620030333617244,
+                    "middle": 53.89750003814697,
+                    "lower": 50.1749697426767
+                  },
+                  {
+                    "upper": 57.506017568853046,
+                    "middle": 53.80750007629395,
+                    "lower": 50.10898258373485
+                  },
+                  {
+                    "upper": 57.279974001496186,
+                    "middle": 53.711499977111814,
+                    "lower": 50.14302595272744
+                  },
+                  {
+                    "upper": 56.87019751868622,
+                    "middle": 53.58950004577637,
+                    "lower": 50.30880257286652
+                  },
+                  {
+                    "upper": 56.44376768634527,
+                    "middle": 53.496000099182126,
+                    "lower": 50.548232512018984
+                  },
+                  {
+                    "upper": 56.32143944952854,
+                    "middle": 53.46100006103516,
+                    "lower": 50.600560672541775
+                  },
+                  {
+                    "upper": 56.40869565515925,
+                    "middle": 53.47849998474121,
+                    "lower": 50.548304314323175
+                  },
+                  {
+                    "upper": 56.535831320120806,
+                    "middle": 53.50650005340576,
+                    "lower": 50.47716878669071
+                  },
+                  {
+                    "upper": 56.56922483857926,
+                    "middle": 53.516500091552736,
+                    "lower": 50.46377534452621
+                  },
+                  {
+                    "upper": 56.503109168819066,
+                    "middle": 53.48199996948242,
+                    "lower": 50.46089077014578
+                  },
+                  {
+                    "upper": 56.502505015164076,
+                    "middle": 53.484000015258786,
+                    "lower": 50.4654950153535
+                  },
+                  {
+                    "upper": 56.50292379731467,
+                    "middle": 53.48199996948242,
+                    "lower": 50.461076141650175
+                  },
+                  {
+                    "upper": 56.50086886838126,
+                    "middle": 53.470499992370605,
+                    "lower": 50.44013111635995
+                  },
+                  {
+                    "upper": 56.49897588077966,
+                    "middle": 53.53350009918213,
+                    "lower": 50.568024317584594
+                  },
+                  {
+                    "upper": 56.48009184193646,
+                    "middle": 53.5685001373291,
+                    "lower": 50.65690843272174
+                  },
+                  {
+                    "upper": 56.47565643431228,
+                    "middle": 53.59900016784668,
+                    "lower": 50.72234390138109
+                  },
+                  {
+                    "upper": 56.54038097776784,
+                    "middle": 53.56650009155273,
+                    "lower": 50.59261920533763
+                  },
+                  {
+                    "upper": 56.70040716663523,
+                    "middle": 53.486000061035156,
+                    "lower": 50.27159295543508
+                  },
+                  {
+                    "upper": 56.7221934952642,
+                    "middle": 53.46200008392334,
+                    "lower": 50.201806672582485
+                  },
+                  {
+                    "upper": 56.70374870015471,
+                    "middle": 53.48649997711182,
+                    "lower": 50.26925125406893
+                  },
+                  {
+                    "upper": 56.913709148590115,
+                    "middle": 53.32399997711182,
+                    "lower": 49.73429080563352
+                  },
+                  {
+                    "upper": 57.05804366098913,
+                    "middle": 53.154500007629395,
+                    "lower": 49.25095635426966
+                  },
+                  {
+                    "upper": 57.06826149476277,
+                    "middle": 52.95150012969971,
+                    "lower": 48.83473876463665
+                  },
+                  {
+                    "upper": 56.95499632238977,
+                    "middle": 52.74400005340576,
+                    "lower": 48.53300378442176
+                  },
+                  {
+                    "upper": 56.67907455981419,
+                    "middle": 52.465500068664554,
+                    "lower": 48.25192557751492
+                  },
+                  {
+                    "upper": 56.516227143042144,
+                    "middle": 52.15050010681152,
+                    "lower": 47.7847730705809
+                  },
+                  {
+                    "upper": 55.97248704226013,
+                    "middle": 51.719000244140624,
+                    "lower": 47.46551344602112
+                  },
+                  {
+                    "upper": 55.208598271152326,
+                    "middle": 51.32650032043457,
+                    "lower": 47.44440236971681
+                  },
+                  {
+                    "upper": 54.5707014489663,
+                    "middle": 50.98300037384033,
+                    "lower": 47.39529929871437
+                  },
+                  {
+                    "upper": 54.35445252098729,
+                    "middle": 50.64700050354004,
+                    "lower": 46.9395484860928
+                  },
+                  {
+                    "upper": 54.33084495962169,
+                    "middle": 50.357000541687015,
+                    "lower": 46.383156123752336
+                  },
+                  {
+                    "upper": 54.16933692368836,
+                    "middle": 50.08250064849854,
+                    "lower": 45.99566437330871
+                  },
+                  {
+                    "upper": 53.87920017601432,
+                    "middle": 49.809500503540036,
+                    "lower": 45.73980083106575
+                  },
+                  {
+                    "upper": 53.40605025196583,
+                    "middle": 49.48300056457519,
+                    "lower": 45.559950877184555
+                  },
+                  {
+                    "upper": 52.95276800817121,
+                    "middle": 49.19500045776367,
+                    "lower": 45.437232907356126
+                  },
+                  {
+                    "upper": 52.30783193016209,
+                    "middle": 48.900000381469724,
+                    "lower": 45.49216883277736
+                  },
+                  {
+                    "upper": 52.02800968027921,
+                    "middle": 48.7225004196167,
+                    "lower": 45.41699115895419
+                  },
+                  {
+                    "upper": 51.8297445774675,
+                    "middle": 48.60900039672852,
+                    "lower": 45.388256215989536
+                  },
+                  {
+                    "upper": 51.35893389878595,
+                    "middle": 48.46200046539307,
+                    "lower": 45.56506703200019
+                  },
+                  {
+                    "upper": 50.55926085399122,
+                    "middle": 48.259000587463376,
+                    "lower": 45.95874032093553
+                  },
+                  {
+                    "upper": 50.36279742156957,
+                    "middle": 48.1160005569458,
+                    "lower": 45.86920369232203
+                  },
+                  {
+                    "upper": 50.123493822007674,
+                    "middle": 47.987000465393066,
+                    "lower": 45.85050710877846
+                  },
+                  {
+                    "upper": 49.8956945663849,
+                    "middle": 47.92600040435791,
+                    "lower": 45.95630624233092
+                  },
+                  {
+                    "upper": 49.63608476773171,
+                    "middle": 47.87450046539307,
+                    "lower": 46.11291616305443
+                  },
+                  {
+                    "upper": 49.52793445232242,
+                    "middle": 47.853000450134275,
+                    "lower": 46.17806644794613
+                  },
+                  {
+                    "upper": 49.83070897069451,
+                    "middle": 47.9240005493164,
+                    "lower": 46.0172921279383
+                  },
+                  {
+                    "upper": 50.20839263424185,
+                    "middle": 48.04300041198731,
+                    "lower": 45.87760818973277
+                  },
+                  {
+                    "upper": 50.94208588838287,
+                    "middle": 48.20900039672851,
+                    "lower": 45.475914905074156
+                  },
+                  {
+                    "upper": 51.78400906369301,
+                    "middle": 48.41850032806396,
+                    "lower": 45.052991592434914
+                  },
+                  {
+                    "upper": 52.44390050765926,
+                    "middle": 48.68900032043457,
+                    "lower": 44.93410013320989
+                  },
+                  {
+                    "upper": 53.171318903189714,
+                    "middle": 49.02050018310547,
+                    "lower": 44.86968146302122
+                  },
+                  {
+                    "upper": 53.786275741295675,
+                    "middle": 49.33500003814697,
+                    "lower": 44.88372433499827
+                  },
+                  {
+                    "upper": 54.52886723794306,
+                    "middle": 49.68700008392334,
+                    "lower": 44.84513292990361
+                  },
+                  {
+                    "upper": 54.9492885878594,
+                    "middle": 50.020999908447266,
+                    "lower": 45.09271122903513
+                  },
+                  {
+                    "upper": 55.368356138677505,
+                    "middle": 50.36599998474121,
+                    "lower": 45.36364383080491
+                  },
+                  {
+                    "upper": 55.71307937647007,
+                    "middle": 50.70550003051758,
+                    "lower": 45.697920684565084
+                  },
+                  {
+                    "upper": 55.92597121549953,
+                    "middle": 51.00349998474121,
+                    "lower": 46.08102875398289
+                  },
+                  {
+                    "upper": 56.07315401397803,
+                    "middle": 51.252499961853026,
+                    "lower": 46.431845909728025
+                  },
+                  {
+                    "upper": 56.14427116593098,
+                    "middle": 51.438500022888185,
+                    "lower": 46.73272887984539
+                  },
+                  {
+                    "upper": 56.104246169199406,
+                    "middle": 51.628999900817874,
+                    "lower": 47.15375363243634
+                  },
+                  {
+                    "upper": 55.857455520496906,
+                    "middle": 51.91199989318848,
+                    "lower": 47.96654426588005
+                  },
+                  {
+                    "upper": 55.50004123985837,
+                    "middle": 52.18349990844727,
+                    "lower": 48.866958577036165
+                  },
+                  {
+                    "upper": 55.317134356368264,
+                    "middle": 52.38999996185303,
+                    "lower": 49.46286556733779
+                  },
+                  {
+                    "upper": 55.18303528524597,
+                    "middle": 52.59949989318848,
+                    "lower": 50.01596450113099
+                  },
+                  {
+                    "upper": 54.921977100234095,
+                    "middle": 52.79249992370605,
+                    "lower": 50.66302274717801
+                  },
+                  {
+                    "upper": 54.65074065172512,
+                    "middle": 52.898999786376955,
+                    "lower": 51.14725892102879
+                  },
+                  {
+                    "upper": 54.31609779812583,
+                    "middle": 53.040999794006346,
+                    "lower": 51.76590178988686
+                  },
+                  {
+                    "upper": 54.305644354581304,
+                    "middle": 53.12699966430664,
+                    "lower": 51.94835497403197
+                  },
+                  {
+                    "upper": 54.304939826688155,
+                    "middle": 53.12899971008301,
+                    "lower": 51.95305959347786
+                  },
+                  {
+                    "upper": 54.467525890925074,
+                    "middle": 53.06749973297119,
+                    "lower": 51.66747357501731
+                  },
+                  {
+                    "upper": 54.697605397150554,
+                    "middle": 52.927499771118164,
+                    "lower": 51.157394145085775
+                  },
+                  {
+                    "upper": 54.787435355905025,
+                    "middle": 52.79899978637695,
+                    "lower": 50.81056421684888
+                  },
+                  {
+                    "upper": 54.82035494318794,
+                    "middle": 52.57499980926514,
+                    "lower": 50.32964467534234
+                  },
+                  {
+                    "upper": 54.88558071598756,
+                    "middle": 52.39199981689453,
+                    "lower": 49.89841891780151
+                  },
+                  {
+                    "upper": 54.823306323200114,
+                    "middle": 52.18499984741211,
+                    "lower": 49.5466933716241
+                  },
+                  {
+                    "upper": 54.60624914894355,
+                    "middle": 52.021999740600585,
+                    "lower": 49.43775033225762
+                  },
+                  {
+                    "upper": 54.43749479036942,
+                    "middle": 51.88299980163574,
+                    "lower": 49.32850481290206
+                  },
+                  {
+                    "upper": 54.292291390698985,
+                    "middle": 51.78849983215332,
+                    "lower": 49.284708273607656
+                  },
+                  {
+                    "upper": 54.22632505570368,
+                    "middle": 51.7394998550415,
+                    "lower": 49.25267465437932
+                  },
+                  {
+                    "upper": 54.20996675785084,
+                    "middle": 51.726999855041505,
+                    "lower": 49.24403295223217
+                  },
+                  {
+                    "upper": 54.16414568077609,
+                    "middle": 51.70549983978272,
+                    "lower": 49.24685399878935
+                  },
+                  {
+                    "upper": 54.058901765120396,
+                    "middle": 51.62749977111817,
+                    "lower": 49.19609777711594
+                  },
+                  {
+                    "upper": 53.90957251339014,
+                    "middle": 51.521999740600585,
+                    "lower": 49.13442696781103
+                  },
+                  {
+                    "upper": 53.64619527921474,
+                    "middle": 51.428999710083005,
+                    "lower": 49.21180414095127
+                  },
+                  {
+                    "upper": 53.39953469136255,
+                    "middle": 51.342499542236325,
+                    "lower": 49.285464393110104
+                  },
+                  {
+                    "upper": 53.441629749406864,
+                    "middle": 51.3569995880127,
+                    "lower": 49.27236942661853
+                  },
+                  {
+                    "upper": 53.30504513511786,
+                    "middle": 51.320999717712404,
+                    "lower": 49.33695430030695
+                  },
+                  {
+                    "upper": 53.475006369225,
+                    "middle": 51.34949970245361,
+                    "lower": 49.22399303568223
+                  },
+                  {
+                    "upper": 53.71529833545675,
+                    "middle": 51.40349979400635,
+                    "lower": 49.09170125255595
+                  },
+                  {
+                    "upper": 54.02555279179393,
+                    "middle": 51.51949977874756,
+                    "lower": 49.01344676570119
+                  },
+                  {
+                    "upper": 54.47436256081137,
+                    "middle": 51.712999725341795,
+                    "lower": 48.95163688987222
+                  },
+                  {
+                    "upper": 54.885633401164085,
+                    "middle": 51.90099983215332,
+                    "lower": 48.91636626314255
+                  },
+                  {
+                    "upper": 55.313376440535485,
+                    "middle": 52.16699981689453,
+                    "lower": 49.02062319325358
+                  },
+                  {
+                    "upper": 55.85402331487643,
+                    "middle": 52.47549991607666,
+                    "lower": 49.096976517276886
+                  },
+                  {
+                    "upper": 56.227658059573734,
+                    "middle": 52.78049983978271,
+                    "lower": 49.33334161999169
+                  },
+                  {
+                    "upper": 56.81982843546902,
+                    "middle": 53.08799991607666,
+                    "lower": 49.3561713966843
+                  },
+                  {
+                    "upper": 57.228606021359134,
+                    "middle": 53.37949981689453,
+                    "lower": 49.530393612429926
+                  },
+                  {
+                    "upper": 57.531278536069145,
+                    "middle": 53.62799987792969,
+                    "lower": 49.72472121979023
+                  },
+                  {
+                    "upper": 58.017868968232705,
+                    "middle": 53.92199974060058,
+                    "lower": 49.82613051296846
+                  },
+                  {
+                    "upper": 58.54989209461908,
+                    "middle": 54.22749977111816,
+                    "lower": 49.90510744761724
+                  },
+                  {
+                    "upper": 58.97709897311897,
+                    "middle": 54.50399971008301,
+                    "lower": 50.030900447047046
+                  },
+                  {
+                    "upper": 59.32009233864088,
+                    "middle": 54.858499717712405,
+                    "lower": 50.39690709678393
+                  },
+                  {
+                    "upper": 59.44283132098248,
+                    "middle": 55.21399974822998,
+                    "lower": 50.98516817547748
+                  },
+                  {
+                    "upper": 59.5650710577055,
+                    "middle": 55.52799987792969,
+                    "lower": 51.49092869815387
+                  },
+                  {
+                    "upper": 59.433514239682836,
+                    "middle": 55.801499938964845,
+                    "lower": 52.169485638246854
+                  },
+                  {
+                    "upper": 59.55215963934387,
+                    "middle": 56.095499992370605,
+                    "lower": 52.63884034539734
+                  },
+                  {
+                    "upper": 59.60646118715065,
+                    "middle": 56.41199989318848,
+                    "lower": 53.21753859922631
+                  }
+                ],
+                "obv": [
+                  0,
+                  -35567900,
+                  -123654400,
+                  -169882300,
+                  -125657300,
+                  -157310300,
+                  -120929100,
+                  -176074100,
+                  -237370700,
+                  -180890000,
+                  -132575800,
+                  -100376100,
+                  -65626700,
+                  -34246600,
+                  8721000,
+                  33182200,
+                  12591800,
+                  -13624700,
+                  18641200,
+                  -21375100,
+                  -73685500,
+                  -42646600,
+                  -79444900,
+                  -107361700,
+                  -137971600,
+                  -100840000,
+                  -65280600,
+                  -29799400,
+                  -59264500,
+                  -38190700,
+                  -64467600,
+                  -21342500,
+                  12440900,
+                  43263100,
+                  14549900,
+                  59628800,
+                  59628800,
+                  100238100,
+                  142666300,
+                  175615700,
+                  208112200,
+                  155392400,
+                  117048200,
+                  151845100,
+                  111781800,
+                  63748700,
+                  103808800,
+                  72102500,
+                  100157700,
+                  72306600,
+                  101350200,
+                  132974600,
+                  171312500,
+                  206559400,
+                  305530100,
+                  278062100,
+                  249783900,
+                  249783900,
+                  272741800,
+                  292767600,
+                  316468600,
+                  286523600,
+                  258814500,
+                  236057300,
+                  260623000,
+                  235236700,
+                  211129400,
+                  187115200,
+                  165298300,
+                  133466400,
+                  167929200,
+                  210391800,
+                  280384000,
+                  231356300,
+                  280271700,
+                  306057700,
+                  278754300,
+                  243799300,
+                  269828100,
+                  308752000,
+                  336097800,
+                  306522600,
+                  277363800,
+                  314912400,
+                  354208100,
+                  385460400,
+                  338233800,
+                  283880200,
+                  339176200,
+                  298638500,
+                  324733100,
+                  346977400,
+                  387514100,
+                  349798000,
+                  317434900,
+                  281888100,
+                  317077600,
+                  345189900,
+                  308528300,
+                  352395500,
+                  405247600,
+                  446557700,
+                  478603300,
+                  497524100,
+                  466987600,
+                  420914100,
+                  458048500,
+                  496578100,
+                  462591600,
+                  428205000,
+                  381015700,
+                  435440100,
+                  471127000,
+                  511666400,
+                  544547700,
+                  511615800,
+                  476311700,
+                  388859000,
+                  461860900,
+                  495269700,
+                  517544300,
+                  531178700,
+                  515919300,
+                  494879200,
+                  477451600,
+                  461158600,
+                  486662200,
+                  522758800,
+                  554550700,
+                  504855200,
+                  535788900,
+                  505020100,
+                  459159500,
+                  415617300,
+                  330867300,
+                  381885600,
+                  434064000,
+                  384891300,
+                  348551300,
+                  379780500,
+                  345227000,
+                  372955400,
+                  399449700,
+                  364419500,
+                  399620000,
+                  434169100,
+                  468793600,
+                  510002000,
+                  564524500,
+                  531564800,
+                  574032800,
+                  542064400,
+                  493759700,
+                  444786200,
+                  389304600,
+                  421076700,
+                  456619100,
+                  487318000,
+                  440169400,
+                  473721400,
+                  423118900,
+                  370056200,
+                  411431200,
+                  463849700,
+                  386121000,
+                  345525800,
+                  396768700,
+                  430977200,
+                  391903300,
+                  344887300,
+                  282134500,
+                  332405600,
+                  290219800,
+                  231865300,
+                  186392200,
+                  224447800,
+                  257875600,
+                  217623800,
+                  256225200,
+                  334286100,
+                  376619300,
+                  416423400,
+                  446411700,
+                  413909100,
+                  377127200,
+                  420503100,
+                  469563700,
+                  502510700,
+                  530058900,
+                  558566100,
+                  587039300,
+                  623512800,
+                  655520800,
+                  630295500,
+                  658130800,
+                  658130800,
+                  721969000,
+                  686762300,
+                  730247000,
+                  774246200,
+                  739979900,
+                  715882300,
+                  683926000,
+                  653660600,
+                  681704300,
+                  702868400,
+                  729119100,
+                  756208300,
+                  731383300,
+                  688454300,
+                  716912900,
+                  744454100,
+                  715772000,
+                  679660800,
+                  646528600,
+                  680047400,
+                  650209400,
+                  687881200,
+                  641598900,
+                  675003000,
+                  719157600,
+                  766897000,
+                  794358900,
+                  821042600,
+                  848440200,
+                  799858700,
+                  751308600,
+                  809239200,
+                  774935500,
+                  817062000,
+                  768996600,
+                  820880200,
+                  782050800,
+                  751718700,
+                  784047700,
+                  821073200,
+                  852819500,
+                  885808500,
+                  854142000,
+                  887551800,
+                  847112500,
+                  776673700,
+                  815327500,
+                  845373200,
+                  815048300,
+                  848795700,
+                  800038100,
+                  800038100,
+                  758713500,
+                  794001900,
+                  823332800
+                ],
+                "vwap": [
+                  49.01666768391927,
+                  48.848741529422085,
+                  47.86924797918095,
+                  47.65941527374103,
+                  47.53382593890711,
+                  47.422883361979316,
+                  47.35985894123419,
+                  47.20776998639945,
+                  47.01213828773781,
+                  46.95856595074835,
+                  46.98078455565271,
+                  47.01502715160384,
+                  47.06110778138001,
+                  47.11273740260036,
+                  47.2043478254579,
+                  47.24361942545314,
+                  47.27371465322049,
+                  47.303677154232076,
+                  47.335656396787215,
+                  47.343612244616814,
+                  47.24975292985795,
+                  47.20169006965315,
+                  47.13185100221372,
+                  47.08672181201581,
+                  47.02685363108069,
+                  46.98111043729598,
+                  46.95370810969454,
+                  46.960813634864344,
+                  46.97047314917074,
+                  46.97915923658638,
+                  46.98455208345022,
+                  47.0057766479033,
+                  47.03110731232233,
+                  47.06018910189971,
+                  47.08488069260927,
+                  47.1552460672762,
+                  47.21256874349215,
+                  47.289435554158764,
+                  47.37712470885583,
+                  47.44480495274642,
+                  47.51406683516336,
+                  47.60262960510024,
+                  47.66163869670875,
+                  47.72147804953327,
+                  47.773398650645966,
+                  47.81844593238305,
+                  47.86951748452339,
+                  47.910782221359455,
+                  47.951014961341365,
+                  47.991100607919876,
+                  48.032518859235545,
+                  48.07408898545001,
+                  48.13607013309949,
+                  48.20147210855183,
+                  48.38984442590772,
+                  48.43629899884692,
+                  48.48319880691021,
+                  48.524038837372665,
+                  48.558693985699364,
+                  48.591890822789836,
+                  48.631363519719706,
+                  48.671795403251714,
+                  48.699281893183446,
+                  48.716448694391325,
+                  48.737791367504805,
+                  48.756840382673786,
+                  48.77366160333141,
+                  48.786152391515635,
+                  48.79613749698217,
+                  48.80018492463045,
+                  48.803225649017925,
+                  48.818143477246906,
+                  48.905630705457256,
+                  48.94500870403543,
+                  48.98396324350291,
+                  49.01112370747125,
+                  49.0381624844406,
+                  49.062909666178484,
+                  49.085656256651916,
+                  49.13043600929777,
+                  49.16548990086149,
+                  49.20223542394719,
+                  49.23585660173887,
+                  49.28284168472177,
+                  49.334334470862885,
+                  49.37451999423967,
+                  49.435483379656354,
+                  49.48636336760201,
+                  49.55086639967544,
+                  49.59545726216218,
+                  49.62689403604927,
+                  49.65361504283807,
+                  49.70813359298893,
+                  49.74766877893927,
+                  49.77366468520301,
+                  49.794541483663124,
+                  49.813190046661,
+                  49.83102308229079,
+                  49.84955562238968,
+                  49.86768542269262,
+                  49.89628776046521,
+                  49.92419068424252,
+                  49.949886087387824,
+                  49.96794919388103,
+                  49.9959446580747,
+                  50.03514514303307,
+                  50.07151616210329,
+                  50.11291570239675,
+                  50.147818448079526,
+                  50.17988256810622,
+                  50.22100722651704,
+                  50.27116219819139,
+                  50.30618582996737,
+                  50.35117963297322,
+                  50.3914210502472,
+                  50.42689537925387,
+                  50.46357230982324,
+                  50.54249260713407,
+                  50.61576736614767,
+                  50.654417474146676,
+                  50.680976146075466,
+                  50.69774984241061,
+                  50.71652647652342,
+                  50.73930039243794,
+                  50.75700894107803,
+                  50.77256235865404,
+                  50.79940786058727,
+                  50.846672356952006,
+                  50.889581283387855,
+                  50.94311416731509,
+                  50.976609275233336,
+                  51.00953800007785,
+                  51.048698689654024,
+                  51.08218030075028,
+                  51.1071605918943,
+                  51.12260659221535,
+                  51.14063005039957,
+                  51.15386971766685,
+                  51.162170130930775,
+                  51.17108394515889,
+                  51.17504123834134,
+                  51.179363527697845,
+                  51.18388781446371,
+                  51.187658916322704,
+                  51.1977004841512,
+                  51.210135465990895,
+                  51.226053829977154,
+                  51.25024414913938,
+                  51.291226455536304,
+                  51.31232604408254,
+                  51.349852879333426,
+                  51.3789064568082,
+                  51.414139597547475,
+                  51.43981872982146,
+                  51.45246082687865,
+                  51.45695344656546,
+                  51.46619793764145,
+                  51.47557957356824,
+                  51.48353292304275,
+                  51.49019093400772,
+                  51.49230507268618,
+                  51.48140653692087,
+                  51.47987556623633,
+                  51.486351127113856,
+                  51.4700671527814,
+                  51.45793143077197,
+                  51.44329732665226,
+                  51.43535318896545,
+                  51.42566783365312,
+                  51.40290953880419,
+                  51.36613909489515,
+                  51.343583059390646,
+                  51.32415074075204,
+                  51.28814243541396,
+                  51.259383794354655,
+                  51.23644712791262,
+                  51.21803266614179,
+                  51.19380647035757,
+                  51.16880597298012,
+                  51.12283511912928,
+                  51.10256257814673,
+                  51.08416215411042,
+                  51.07388539340089,
+                  51.06146227786625,
+                  51.042210908774145,
+                  51.01968244855893,
+                  51.00106903326013,
+                  50.993600609483586,
+                  50.986152138258575,
+                  50.98153780847625,
+                  50.97820101353787,
+                  50.98247197978367,
+                  50.98860503618904,
+                  50.99384486298429,
+                  51.000924135643594,
+                  51.012989252301146,
+                  51.04239179327336,
+                  51.05538137854246,
+                  51.07272777159309,
+                  51.087814154598476,
+                  51.099830380670575,
+                  51.10673561741612,
+                  51.1135123235642,
+                  51.117604943812985,
+                  51.1224485317837,
+                  51.12728183352638,
+                  51.13213543614912,
+                  51.138877920347504,
+                  51.14619071369032,
+                  51.153083127185624,
+                  51.159398381184054,
+                  51.16835123301778,
+                  51.1752010839024,
+                  51.17803211862966,
+                  51.17622402821132,
+                  51.173708217663645,
+                  51.169924224768046,
+                  51.16425074078845,
+                  51.155946514856744,
+                  51.15306760469319,
+                  51.151121378268556,
+                  51.150829470986764,
+                  51.15115415660557,
+                  51.15342315498217,
+                  51.15679810453004,
+                  51.15847576283125,
+                  51.157404154623535,
+                  51.15861210762071,
+                  51.159558216341985,
+                  51.1643687560516,
+                  51.169286349193264,
+                  51.18464664224268,
+                  51.196214807556785,
+                  51.205317962341546,
+                  51.21633616446675,
+                  51.23075408211536,
+                  51.24358912945211,
+                  51.260419656673754,
+                  51.27779531182062,
+                  51.2978800766527,
+                  51.3229874633164,
+                  51.3629840333409,
+                  51.38796624537067,
+                  51.408554494229094,
+                  51.42955902440342,
+                  51.454941421370364,
+                  51.48904313393713,
+                  51.508979358957134,
+                  51.533942919558974,
+                  51.5577288388113,
+                  51.5794086288581
+                ]
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_technical_indicators",
+            "args": {
+              "symbol": "JPM"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**JPM Technical Analysis** (2025-07-03 to 2026-07-02)\nPrice: $334.47\n\nSMA(20): $324.41 | SMA(50): $312.61\nRSI(14): 63.6 (Neutral)\nMACD: 6.84 | Signal: 6.62 | Histogram: 0.23\nBollinger Bands: Upper $343.12 | Mid $324.41 | Lower $305.69\nOBV Trend: Rising | VWAP (cumulative): $305.70\n\nSignals: Price above SMA(20) — short-term bullish | Golden cross pattern (SMA20 > SMA50) | MACD bullish (histogram positive) | Volume confirming price advance (OBV rising) | Price above cumulative VWAP — bullish volume-weighted bias"
+                }
+              ],
+              "details": {
+                "symbol": "JPM",
+                "range": "1y",
+                "prices": [
+                  296,
+                  291.9700012207031,
+                  282.7799987792969,
+                  283.1600036621094,
+                  288.19000244140625,
+                  286.8599853515625,
+                  288.70001220703125,
+                  286.54998779296875,
+                  285.82000732421875,
+                  289.8999938964844,
+                  291.2699890136719,
+                  290.9700012207031,
+                  291.42999267578125,
+                  296.760009765625,
+                  296.54998779296875,
+                  298.6199951171875,
+                  298.2799987792969,
+                  297.0400085449219,
+                  299.6300048828125,
+                  296.239990234375,
+                  289.3699951171875,
+                  294.260009765625,
+                  291.3699951171875,
+                  291.3500061035156,
+                  286.94000244140625,
+                  288.760009765625,
+                  289.55999755859375,
+                  292.8500061035156,
+                  290.5299987792969,
+                  294.1600036621094,
+                  290.489990234375,
+                  291.5299987792969,
+                  290.6600036621094,
+                  292.239990234375,
+                  291.4700012207031,
+                  296.239990234375,
+                  294.8999938964844,
+                  298.57000732421875,
+                  299.2799987792969,
+                  301.07000732421875,
+                  301.4200134277344,
+                  299.70001220703125,
+                  299.510009765625,
+                  303.82000732421875,
+                  294.3800048828125,
+                  292.9100036621094,
+                  297.8500061035156,
+                  300.5400085449219,
+                  305.55999755859375,
+                  306.9100036621094,
+                  308.8999938964844,
+                  309.19000244140625,
+                  311.75,
+                  313.2300109863281,
+                  314.7799987792969,
+                  312.44000244140625,
+                  312.739990234375,
+                  313.4200134277344,
+                  313.45001220703125,
+                  316.05999755859375,
+                  315.69000244140625,
+                  315.42999267578125,
+                  310.7099914550781,
+                  307.54998779296875,
+                  310.0299987792969,
+                  309.17999267578125,
+                  307.69000244140625,
+                  304.0299987792969,
+                  305.5299987792969,
+                  300.8900146484375,
+                  307.9700012207031,
+                  302.0799865722656,
+                  305.69000244140625,
+                  298.5400085449219,
+                  297.55999755859375,
+                  302.3599853515625,
+                  297.0899963378906,
+                  294.1099853515625,
+                  294.5400085449219,
+                  300.44000244140625,
+                  304.1499938964844,
+                  305.3599853515625,
+                  305.510009765625,
+                  309.44000244140625,
+                  311.1199951171875,
+                  309.3500061035156,
+                  309.25,
+                  311.67999267578125,
+                  313.4200134277344,
+                  314.2099914550781,
+                  316.8900146484375,
+                  315.6199951171875,
+                  320.4100036621094,
+                  309.4800109863281,
+                  303.6099853515625,
+                  300.3699951171875,
+                  299.4100036621094,
+                  303.2699890136719,
+                  298.3800048828125,
+                  298.0199890136719,
+                  298,
+                  303,
+                  307.6400146484375,
+                  313.0799865722656,
+                  308.9200134277344,
+                  307.8800048828125,
+                  312.1300048828125,
+                  316.1000061035156,
+                  315.0400085449219,
+                  315.2099914550781,
+                  300.510009765625,
+                  310.1099853515625,
+                  317.3800048828125,
+                  318.5199890136719,
+                  320.0199890136719,
+                  315.54998779296875,
+                  314.9800109863281,
+                  313,
+                  317.2099914550781,
+                  323.0899963378906,
+                  325.92999267578125,
+                  329.1700134277344,
+                  327.9100036621094,
+                  323.75,
+                  323.4200134277344,
+                  322.2200012207031,
+                  325.4800109863281,
+                  334.0400085449219,
+                  334.6099853515625,
+                  326.989990234375,
+                  329.7900085449219,
+                  329.19000244140625,
+                  324.489990234375,
+                  310.8999938964844,
+                  307.8699951171875,
+                  309.260009765625,
+                  312.4700012207031,
+                  302.739990234375,
+                  302.0400085449219,
+                  303.6300048828125,
+                  297.7200012207031,
+                  301.0400085449219,
+                  300.30999755859375,
+                  300.7699890136719,
+                  306.4200134277344,
+                  305.8900146484375,
+                  308.1400146484375,
+                  314.8500061035156,
+                  317.2699890136719,
+                  310.1600036621094,
+                  322.3999938964844,
+                  322.1000061035156,
+                  318.2799987792969,
+                  310.82000732421875,
+                  302.6400146484375,
+                  302.54998779296875,
+                  307.1300048828125,
+                  308.7799987792969,
+                  308.04998779296875,
+                  310.7900085449219,
+                  297.6700134277344,
+                  297.29998779296875,
+                  303.29998779296875,
+                  306.1300048828125,
+                  300.29998779296875,
+                  297.55999755859375,
+                  300.260009765625,
+                  299.3900146484375,
+                  293.54998779296875,
+                  289.4800109863281,
+                  289.9200134277344,
+                  288.7300109863281,
+                  287.5199890136719,
+                  282.8900146484375,
+                  283.44000244140625,
+                  286.1600036621094,
+                  286.8900146484375,
+                  287.739990234375,
+                  287.9700012207031,
+                  286.55999755859375,
+                  289.9100036621094,
+                  292.3999938964844,
+                  295.4200134277344,
+                  291.6600036621094,
+                  282.8399963378906,
+                  283.7699890136719,
+                  294.1600036621094,
+                  295.3800048828125,
+                  294.6000061035156,
+                  295.45001220703125,
+                  297.3999938964844,
+                  307.9700012207031,
+                  310.3299865722656,
+                  309.8699951171875,
+                  313.67999267578125,
+                  311.1199951171875,
+                  305.92999267578125,
+                  309.95001220703125,
+                  310.2900085449219,
+                  316.989990234375,
+                  313,
+                  313.0199890136719,
+                  311.69000244140625,
+                  308.2799987792969,
+                  311.6300048828125,
+                  311.45001220703125,
+                  309.25,
+                  313.2300109863281,
+                  312.4700012207031,
+                  307.6499938964844,
+                  309.3999938964844,
+                  314.8999938964844,
+                  306.2699890136719,
+                  302.1000061035156,
+                  300,
+                  304.8800048828125,
+                  300.25,
+                  299.9100036621094,
+                  297.80999755859375,
+                  300.7300109863281,
+                  295.70001220703125,
+                  301.9800109863281,
+                  303,
+                  306.3800048828125,
+                  306.739990234375,
+                  299.2799987792969,
+                  296.7300109863281,
+                  299.30999755859375,
+                  296.5799865722656,
+                  300.9599914550781,
+                  300.8500061035156,
+                  310.8900146484375,
+                  312.3699951171875,
+                  311.1099853515625,
+                  312.70001220703125,
+                  309.1400146484375,
+                  313.489990234375,
+                  320.7200012207031,
+                  319.3999938964844,
+                  331.1400146484375,
+                  333.4599914550781,
+                  325.2200012207031,
+                  331.4800109863281,
+                  334.1400146484375,
+                  333.45001220703125,
+                  335.1199951171875,
+                  329.04998779296875,
+                  329.3900146484375,
+                  327.3299865722656,
+                  334.07000732421875,
+                  334.4700012207031
+                ],
+                "dates": [
+                  "2025-07-03",
+                  "2025-07-07",
+                  "2025-07-08",
+                  "2025-07-09",
+                  "2025-07-10",
+                  "2025-07-11",
+                  "2025-07-14",
+                  "2025-07-15",
+                  "2025-07-16",
+                  "2025-07-17",
+                  "2025-07-18",
+                  "2025-07-21",
+                  "2025-07-22",
+                  "2025-07-23",
+                  "2025-07-24",
+                  "2025-07-25",
+                  "2025-07-28",
+                  "2025-07-29",
+                  "2025-07-30",
+                  "2025-07-31",
+                  "2025-08-01",
+                  "2025-08-04",
+                  "2025-08-05",
+                  "2025-08-06",
+                  "2025-08-07",
+                  "2025-08-08",
+                  "2025-08-11",
+                  "2025-08-12",
+                  "2025-08-13",
+                  "2025-08-14",
+                  "2025-08-15",
+                  "2025-08-18",
+                  "2025-08-19",
+                  "2025-08-20",
+                  "2025-08-21",
+                  "2025-08-22",
+                  "2025-08-25",
+                  "2025-08-26",
+                  "2025-08-27",
+                  "2025-08-28",
+                  "2025-08-29",
+                  "2025-09-02",
+                  "2025-09-03",
+                  "2025-09-04",
+                  "2025-09-05",
+                  "2025-09-08",
+                  "2025-09-09",
+                  "2025-09-10",
+                  "2025-09-11",
+                  "2025-09-12",
+                  "2025-09-15",
+                  "2025-09-16",
+                  "2025-09-17",
+                  "2025-09-18",
+                  "2025-09-19",
+                  "2025-09-22",
+                  "2025-09-23",
+                  "2025-09-24",
+                  "2025-09-25",
+                  "2025-09-26",
+                  "2025-09-29",
+                  "2025-09-30",
+                  "2025-10-01",
+                  "2025-10-02",
+                  "2025-10-03",
+                  "2025-10-06",
+                  "2025-10-07",
+                  "2025-10-08",
+                  "2025-10-09",
+                  "2025-10-10",
+                  "2025-10-13",
+                  "2025-10-14",
+                  "2025-10-15",
+                  "2025-10-16",
+                  "2025-10-17",
+                  "2025-10-20",
+                  "2025-10-21",
+                  "2025-10-22",
+                  "2025-10-23",
+                  "2025-10-24",
+                  "2025-10-27",
+                  "2025-10-28",
+                  "2025-10-29",
+                  "2025-10-30",
+                  "2025-10-31",
+                  "2025-11-03",
+                  "2025-11-04",
+                  "2025-11-05",
+                  "2025-11-06",
+                  "2025-11-07",
+                  "2025-11-10",
+                  "2025-11-11",
+                  "2025-11-12",
+                  "2025-11-13",
+                  "2025-11-14",
+                  "2025-11-17",
+                  "2025-11-18",
+                  "2025-11-19",
+                  "2025-11-20",
+                  "2025-11-21",
+                  "2025-11-24",
+                  "2025-11-25",
+                  "2025-11-26",
+                  "2025-11-28",
+                  "2025-12-01",
+                  "2025-12-02",
+                  "2025-12-03",
+                  "2025-12-04",
+                  "2025-12-05",
+                  "2025-12-08",
+                  "2025-12-09",
+                  "2025-12-10",
+                  "2025-12-11",
+                  "2025-12-12",
+                  "2025-12-15",
+                  "2025-12-16",
+                  "2025-12-17",
+                  "2025-12-18",
+                  "2025-12-19",
+                  "2025-12-22",
+                  "2025-12-23",
+                  "2025-12-24",
+                  "2025-12-26",
+                  "2025-12-29",
+                  "2025-12-30",
+                  "2025-12-31",
+                  "2026-01-02",
+                  "2026-01-05",
+                  "2026-01-06",
+                  "2026-01-07",
+                  "2026-01-08",
+                  "2026-01-09",
+                  "2026-01-12",
+                  "2026-01-13",
+                  "2026-01-14",
+                  "2026-01-15",
+                  "2026-01-16",
+                  "2026-01-20",
+                  "2026-01-21",
+                  "2026-01-22",
+                  "2026-01-23",
+                  "2026-01-26",
+                  "2026-01-27",
+                  "2026-01-28",
+                  "2026-01-29",
+                  "2026-01-30",
+                  "2026-02-02",
+                  "2026-02-03",
+                  "2026-02-04",
+                  "2026-02-05",
+                  "2026-02-06",
+                  "2026-02-09",
+                  "2026-02-10",
+                  "2026-02-11",
+                  "2026-02-12",
+                  "2026-02-13",
+                  "2026-02-17",
+                  "2026-02-18",
+                  "2026-02-19",
+                  "2026-02-20",
+                  "2026-02-23",
+                  "2026-02-24",
+                  "2026-02-25",
+                  "2026-02-26",
+                  "2026-02-27",
+                  "2026-03-02",
+                  "2026-03-03",
+                  "2026-03-04",
+                  "2026-03-05",
+                  "2026-03-06",
+                  "2026-03-09",
+                  "2026-03-10",
+                  "2026-03-11",
+                  "2026-03-12",
+                  "2026-03-13",
+                  "2026-03-16",
+                  "2026-03-17",
+                  "2026-03-18",
+                  "2026-03-19",
+                  "2026-03-20",
+                  "2026-03-23",
+                  "2026-03-24",
+                  "2026-03-25",
+                  "2026-03-26",
+                  "2026-03-27",
+                  "2026-03-30",
+                  "2026-03-31",
+                  "2026-04-01",
+                  "2026-04-02",
+                  "2026-04-06",
+                  "2026-04-07",
+                  "2026-04-08",
+                  "2026-04-09",
+                  "2026-04-10",
+                  "2026-04-13",
+                  "2026-04-14",
+                  "2026-04-15",
+                  "2026-04-16",
+                  "2026-04-17",
+                  "2026-04-20",
+                  "2026-04-21",
+                  "2026-04-22",
+                  "2026-04-23",
+                  "2026-04-24",
+                  "2026-04-27",
+                  "2026-04-28",
+                  "2026-04-29",
+                  "2026-04-30",
+                  "2026-05-01",
+                  "2026-05-04",
+                  "2026-05-05",
+                  "2026-05-06",
+                  "2026-05-07",
+                  "2026-05-08",
+                  "2026-05-11",
+                  "2026-05-12",
+                  "2026-05-13",
+                  "2026-05-14",
+                  "2026-05-15",
+                  "2026-05-18",
+                  "2026-05-19",
+                  "2026-05-20",
+                  "2026-05-21",
+                  "2026-05-22",
+                  "2026-05-26",
+                  "2026-05-27",
+                  "2026-05-28",
+                  "2026-05-29",
+                  "2026-06-01",
+                  "2026-06-02",
+                  "2026-06-03",
+                  "2026-06-04",
+                  "2026-06-05",
+                  "2026-06-08",
+                  "2026-06-09",
+                  "2026-06-10",
+                  "2026-06-11",
+                  "2026-06-12",
+                  "2026-06-15",
+                  "2026-06-16",
+                  "2026-06-17",
+                  "2026-06-18",
+                  "2026-06-22",
+                  "2026-06-23",
+                  "2026-06-24",
+                  "2026-06-25",
+                  "2026-06-26",
+                  "2026-06-29",
+                  "2026-06-30",
+                  "2026-07-01",
+                  "2026-07-02"
+                ],
+                "sma20": [
+                  291.83599853515625,
+                  291.50449829101564,
+                  291.6189987182617,
+                  292.0484985351562,
+                  292.45799865722654,
+                  292.39549865722654,
+                  292.49049987792966,
+                  292.5334991455078,
+                  292.84850006103517,
+                  293.08399963378906,
+                  293.2970001220703,
+                  293.2580001831055,
+                  293.28600006103517,
+                  293.24750061035155,
+                  293.02149963378906,
+                  292.76750030517576,
+                  292.6485000610352,
+                  292.47949981689453,
+                  292.5559997558594,
+                  292.5384994506836,
+                  292.7800003051758,
+                  293.38250122070315,
+                  293.6545013427734,
+                  294.06150207519534,
+                  294.6850021362305,
+                  295.05700225830077,
+                  295.264501953125,
+                  295.6790023803711,
+                  296.0635025024414,
+                  296.81500244140625,
+                  297.45250244140624,
+                  298.37300262451174,
+                  299.25600280761716,
+                  300.31050262451174,
+                  301.36000366210936,
+                  302.52550354003904,
+                  303.33550415039065,
+                  304.22750396728514,
+                  304.9700042724609,
+                  305.67850494384766,
+                  306.4280044555664,
+                  307.14150390625,
+                  307.9280029296875,
+                  308.48800201416014,
+                  308.6745010375977,
+                  309.4570007324219,
+                  310.27050018310547,
+                  310.7625,
+                  310.93699951171874,
+                  310.9354995727539,
+                  310.63450012207034,
+                  310.58800048828124,
+                  310.23249969482424,
+                  309.9294998168945,
+                  309.1949996948242,
+                  308.33399963378906,
+                  307.8299987792969,
+                  307.04749908447263,
+                  306.0819976806641,
+                  305.1364974975586,
+                  304.3554977416992,
+                  303.77849731445315,
+                  303.2749969482422,
+                  303.0149978637695,
+                  303.10949859619143,
+                  303.16399841308595,
+                  303.17249908447263,
+                  303.25049896240233,
+                  303.63299865722655,
+                  304.0274993896484,
+                  304.6934982299805,
+                  305.1394989013672,
+                  305.8164993286133,
+                  306.55249938964846,
+                  307.09949951171876,
+                  307.40199890136716,
+                  307.30249938964846,
+                  307.4184997558594,
+                  307.87649993896486,
+                  308.06849975585936,
+                  307.94749908447267,
+                  307.63999938964844,
+                  307.5220001220703,
+                  307.6285003662109,
+                  307.8104995727539,
+                  307.70050048828125,
+                  307.6270004272461,
+                  307.77100067138673,
+                  307.99200134277345,
+                  308.0730010986328,
+                  308.1230010986328,
+                  307.3040008544922,
+                  307.02850036621095,
+                  306.8770004272461,
+                  307.3289993286133,
+                  308.1494995117188,
+                  308.9084991455078,
+                  309.68699951171874,
+                  310.17350006103516,
+                  311.11499938964846,
+                  312.3684997558594,
+                  313.76499938964844,
+                  315.07350006103513,
+                  316.0869995117188,
+                  316.6205001831055,
+                  317.34550018310546,
+                  318.0625,
+                  318.7300003051758,
+                  319.6270004272461,
+                  320.6054992675781,
+                  321.19449920654296,
+                  322.6584991455078,
+                  323.6125,
+                  323.96799926757814,
+                  323.5869995117188,
+                  322.97949981689453,
+                  322.66500091552734,
+                  322.5395004272461,
+                  322.02649993896483,
+                  321.268000793457,
+                  320.2950012207031,
+                  318.8845016479492,
+                  317.4780014038086,
+                  316.09800109863284,
+                  314.9490005493164,
+                  314.09900054931643,
+                  313.2825012207031,
+                  312.4155014038086,
+                  311.4560012817383,
+                  310.58900146484376,
+                  309.7475021362305,
+                  309.3780014038086,
+                  309.02350158691405,
+                  308.71300201416017,
+                  308.70900268554686,
+                  308.4475036621094,
+                  308.11200256347655,
+                  307.84500274658205,
+                  308.1470031738281,
+                  308.44750213623047,
+                  308.8055023193359,
+                  308.8030029296875,
+                  308.61600189208986,
+                  308.76550140380857,
+                  309.03350219726565,
+                  308.72750091552734,
+                  308.31100006103514,
+                  307.91699981689453,
+                  307.1440002441406,
+                  305.95800018310547,
+                  304.9240005493164,
+                  303.3000015258789,
+                  301.63150177001955,
+                  300.09350128173827,
+                  298.6970016479492,
+                  297.7370010375977,
+                  296.91750183105466,
+                  295.90550231933594,
+                  294.85350189208987,
+                  293.84950256347656,
+                  292.6380020141602,
+                  292.25000152587893,
+                  292.0050018310547,
+                  291.61100311279296,
+                  290.8875030517578,
+                  290.0145034790039,
+                  289.3250030517578,
+                  289.020002746582,
+                  288.81950225830076,
+                  288.87200317382815,
+                  289.1705032348633,
+                  289.5445022583008,
+                  290.50650177001955,
+                  291.6470016479492,
+                  292.9960006713867,
+                  294.5080001831055,
+                  295.75599975585936,
+                  296.70799865722654,
+                  297.81849975585936,
+                  298.9345001220703,
+                  300.45599975585935,
+                  301.6104995727539,
+                  302.6414993286133,
+                  303.4549987792969,
+                  304.28599853515624,
+                  305.72549896240236,
+                  307.1095001220703,
+                  307.86399993896487,
+                  308.7565002441406,
+                  309.65,
+                  310.25999908447267,
+                  310.85999908447263,
+                  311.20649871826174,
+                  311.00349884033204,
+                  310.61499938964846,
+                  309.9309997558594,
+                  309.61900024414064,
+                  309.3350006103516,
+                  308.83300018310547,
+                  308.20899963378906,
+                  307.39600067138673,
+                  306.53100128173827,
+                  305.97900238037107,
+                  305.5445022583008,
+                  305.4495025634766,
+                  305.2050018310547,
+                  304.596501159668,
+                  303.9705017089844,
+                  303.27450103759764,
+                  302.4800003051758,
+                  302.14550018310547,
+                  301.718000793457,
+                  301.5175018310547,
+                  301.82250213623047,
+                  302.2730010986328,
+                  302.9080017089844,
+                  303.1210021972656,
+                  303.7830017089844,
+                  304.82350158691406,
+                  305.9030014038086,
+                  307.4235015869141,
+                  309.3115005493164,
+                  310.47350006103517,
+                  311.8975006103516,
+                  313.28550109863284,
+                  314.6210021972656,
+                  316.41300201416016,
+                  318.0290008544922,
+                  319.5330017089844,
+                  321.07050170898435,
+                  322.7260025024414,
+                  324.4070022583008
+                ],
+                "sma50": [
+                  293.8984008789063,
+                  294.1564007568359,
+                  294.50080078125,
+                  295.08020080566405,
+                  295.6816009521484,
+                  296.21340087890627,
+                  296.7250012207031,
+                  297.20580078125,
+                  297.74320129394533,
+                  298.2958013916016,
+                  298.8190014648437,
+                  299.3074017333984,
+                  299.7966015625,
+                  300.18220153808596,
+                  300.3980010986328,
+                  300.6676013183594,
+                  300.87880126953127,
+                  301.06700134277344,
+                  301.20680114746096,
+                  301.3248010253906,
+                  301.41780151367186,
+                  301.7898016357422,
+                  301.946201171875,
+                  302.2326013183594,
+                  302.3764013671875,
+                  302.58880126953125,
+                  302.86080078125,
+                  303.01140075683594,
+                  303.0366003417969,
+                  303.1168005371094,
+                  303.2424005126953,
+                  303.5156005859375,
+                  303.7922003173828,
+                  304.0892004394531,
+                  304.4332006835937,
+                  304.8262005615234,
+                  305.08840087890627,
+                  305.3754010009766,
+                  305.6376007080078,
+                  305.92040100097654,
+                  306.1832006835937,
+                  306.4926007080078,
+                  306.8110003662109,
+                  307.22900024414065,
+                  307.34220031738283,
+                  307.5267999267578,
+                  307.6759997558594,
+                  307.70719970703124,
+                  307.76179931640627,
+                  307.61819946289063,
+                  307.4403991699219,
+                  307.2223992919922,
+                  307.0985992431641,
+                  307.01639953613284,
+                  307.0133990478516,
+                  306.8961993408203,
+                  306.80499938964846,
+                  306.7927996826172,
+                  306.8463995361328,
+                  306.8781994628906,
+                  306.8611993408203,
+                  306.5575994873047,
+                  306.4511993408203,
+                  306.584599609375,
+                  306.8039996337891,
+                  307.00379943847656,
+                  307.13119934082033,
+                  307.27699951171877,
+                  307.45639953613284,
+                  307.68999938964845,
+                  308.1339990234375,
+                  308.4931988525391,
+                  309.0349993896484,
+                  309.4793994140625,
+                  309.98359924316406,
+                  310.50079956054685,
+                  310.8979998779297,
+                  311.46580017089843,
+                  312.26440063476565,
+                  313.06580017089846,
+                  313.5967999267578,
+                  314.1096002197266,
+                  314.5862005615234,
+                  314.96580017089843,
+                  314.995,
+                  314.93,
+                  314.9282000732422,
+                  314.99260009765624,
+                  314.8138000488281,
+                  314.58619995117186,
+                  314.3746002197266,
+                  313.9911999511719,
+                  313.69960021972656,
+                  313.29760009765624,
+                  313.12339965820314,
+                  313.1796002197266,
+                  313.29000061035157,
+                  313.4646008300781,
+                  313.696201171875,
+                  314.07400085449217,
+                  314.3168011474609,
+                  314.80480102539065,
+                  315.1868011474609,
+                  315.3996008300781,
+                  315.3544012451172,
+                  315.22880126953123,
+                  315.12220092773435,
+                  315.0222009277344,
+                  314.87580078125,
+                  314.73600036621093,
+                  314.6476007080078,
+                  314.59080078125,
+                  314.3346008300781,
+                  314.05300048828127,
+                  313.8052008056641,
+                  313.41080078125,
+                  313.0510009765625,
+                  312.75660095214846,
+                  312.48440124511717,
+                  312.011201171875,
+                  311.33900146484376,
+                  310.6188018798828,
+                  309.8100018310547,
+                  309.00220153808596,
+                  308.1850018310547,
+                  307.3854016113281,
+                  306.66420166015627,
+                  305.89240173339846,
+                  304.9664013671875,
+                  304.0336016845703,
+                  303.22500183105467,
+                  302.4274017333984,
+                  301.6916015625,
+                  301.1102020263672,
+                  300.7254022216797,
+                  300.22480224609376,
+                  299.7150018310547,
+                  299.3488018798828,
+                  299.20160217285155,
+                  299.05280212402346,
+                  298.88920227050784,
+                  298.88280212402344,
+                  299.0214019775391,
+                  299.2218017578125,
+                  299.4038018798828,
+                  299.54900146484374,
+                  299.6536010742187,
+                  299.6094006347656,
+                  299.51140075683594,
+                  299.3718011474609,
+                  299.50840087890623,
+                  299.3204010009766,
+                  299.1388006591797,
+                  299.0070007324219,
+                  298.9562005615234,
+                  299.13600036621096,
+                  299.3140008544922,
+                  299.3564007568359,
+                  299.4454010009766,
+                  299.53380126953124,
+                  299.4710009765625,
+                  299.7056005859375,
+                  300.05760070800784,
+                  300.1170007324219,
+                  300.0364007568359,
+                  300.03040100097655,
+                  300.17680114746094,
+                  300.1766009521484,
+                  300.1870007324219,
+                  300.2722009277344,
+                  300.49720092773435,
+                  300.6128009033203,
+                  300.8778009033203,
+                  301.18740112304687,
+                  301.6572009277344,
+                  302.1232006835937,
+                  302.3856005859375,
+                  302.5824005126953,
+                  302.81380065917966,
+                  302.98600036621093,
+                  303.2740002441406,
+                  303.49280029296875,
+                  303.8626007080078,
+                  304.20160034179685,
+                  304.5905999755859,
+                  305.18780029296875,
+                  305.69520080566406,
+                  306.08180053710936,
+                  306.5886004638672,
+                  307.08460021972655,
+                  307.7984002685547,
+                  308.51960021972656,
+                  308.8646002197266,
+                  309.2876007080078,
+                  309.7730010986328,
+                  310.1684014892578,
+                  310.6484014892578,
+                  311.11080139160157,
+                  311.4996014404297,
+                  311.84040100097656,
+                  312.18200134277345,
+                  312.6114013671875
+                ],
+                "rsi": [
+                  50.75485449092768,
+                  53.59451283197233,
+                  53.053381382733036,
+                  51.02973569847066,
+                  54.8993672013357,
+                  49.39728186102294,
+                  40.531916141980375,
+                  47.72370340717021,
+                  44.31289315108547,
+                  44.28931561620896,
+                  39.31880639165341,
+                  42.201745734694185,
+                  43.47299946186395,
+                  48.49066606323067,
+                  45.42835116252956,
+                  50.676958509302075,
+                  45.87319994712722,
+                  47.39497955827271,
+                  46.22420454331278,
+                  48.70252988041988,
+                  47.55236678843992,
+                  54.69092684519561,
+                  52.527977645151104,
+                  57.487055709797275,
+                  58.392588255965265,
+                  60.66728482865989,
+                  61.11493708267666,
+                  57.64300453865667,
+                  57.256049594789026,
+                  63.27806513915737,
+                  47.494903878520276,
+                  45.58803029250528,
+                  52.49112439198676,
+                  55.780922298718714,
+                  61.182895009987384,
+                  62.50932288142176,
+                  64.43836669871091,
+                  64.72324018397069,
+                  67.21955104931726,
+                  68.60283239926753,
+                  70.02923297082432,
+                  65.21249075406749,
+                  65.53973031041727,
+                  66.31331098810887,
+                  66.34919879269678,
+                  69.40329295497276,
+                  68.45480125678378,
+                  67.75404491723108,
+                  56.455846887592884,
+                  50.39676561078677,
+                  54.522011161215914,
+                  52.898206153211724,
+                  50.08245862700801,
+                  43.90076301752501,
+                  46.79901455369665,
+                  39.92738272463203,
+                  51.60435131463905,
+                  43.95041022352063,
+                  48.948297339513736,
+                  41.126342021214654,
+                  40.178616286101445,
+                  46.661886383925,
+                  41.3617090958131,
+                  38.68579325713122,
+                  39.29610152767104,
+                  47.079299721105244,
+                  51.3070884862621,
+                  52.63610145084089,
+                  52.80808834889376,
+                  57.1931497597915,
+                  58.949173356321744,
+                  56.327460570428364,
+                  56.175442744993404,
+                  59.066249265972154,
+                  61.0476368858847,
+                  61.94818829671009,
+                  64.91194292784567,
+                  62.430412296208935,
+                  67.4800022224345,
+                  50.72600010066389,
+                  44.35649731078598,
+                  41.2757355043822,
+                  40.380815305784445,
+                  45.497717895136304,
+                  40.72870796758488,
+                  40.39301383592397,
+                  40.37311673524219,
+                  47.35828527352529,
+                  52.87545086395239,
+                  58.38255619899528,
+                  53.25710306821096,
+                  52.02736655460029,
+                  56.45257483678358,
+                  60.15043228467381,
+                  58.7167639147805,
+                  58.88599681403783,
+                  42.616203492204804,
+                  51.95257528841156,
+                  57.581143682908824,
+                  58.40400614289372,
+                  59.51681382994483,
+                  54.81097344081453,
+                  54.22225274703588,
+                  52.127634402305624,
+                  56.018083958723864,
+                  60.80864457263251,
+                  62.90997384596338,
+                  65.20226361369006,
+                  63.55718065740911,
+                  58.32498196424794,
+                  57.91767860772273,
+                  56.37586914922347,
+                  59.52791858035669,
+                  66.39417760977852,
+                  66.79809805103551,
+                  56.94410467636377,
+                  59.31892858785706,
+                  58.57337558820377,
+                  52.95839757114551,
+                  40.78410400501579,
+                  38.650695394572075,
+                  40.19621110661316,
+                  43.722116987368366,
+                  36.665537892957126,
+                  36.2127317070973,
+                  38.08322746953574,
+                  34.08256999801226,
+                  38.02146926678833,
+                  37.49098019631583,
+                  38.07725709553924,
+                  44.91172222831687,
+                  44.416491228064544,
+                  47.08412628948588,
+                  54.151100499738234,
+                  56.412040755943835,
+                  48.79818067335966,
+                  59.04590554321645,
+                  58.73562762215172,
+                  54.787528131308086,
+                  48.00171293984951,
+                  41.87688419280564,
+                  41.81364895834902,
+                  46.259606540045006,
+                  47.806846427463086,
+                  47.15991012559181,
+                  49.900319956009874,
+                  39.371141614477665,
+                  39.120428198888376,
+                  45.21275446892002,
+                  47.862965056220716,
+                  43.22428721586959,
+                  41.20318059564868,
+                  43.98279294212254,
+                  43.27291718833871,
+                  38.75153553699508,
+                  35.93368157023383,
+                  36.471512675545526,
+                  35.601037770559344,
+                  34.694281709485864,
+                  31.398855161772886,
+                  32.22242214478173,
+                  36.29563835984529,
+                  37.383282187021344,
+                  38.69569435380131,
+                  39.06787440321401,
+                  37.56240529135755,
+                  43.16604244574822,
+                  46.9752873431326,
+                  51.24362886579454,
+                  46.25165793961781,
+                  37.11738139613783,
+                  38.49662526827754,
+                  51.33823849429174,
+                  52.589993796796804,
+                  51.674767507640176,
+                  52.64200141243935,
+                  54.87343031358229,
+                  64.60813182233663,
+                  66.35335428998454,
+                  65.67358247221722,
+                  68.54774715271898,
+                  64.6318668767342,
+                  57.464662719152955,
+                  61.066103130299496,
+                  61.364056726668686,
+                  66.76212173537877,
+                  61.271888932528235,
+                  61.28906400261278,
+                  59.40146418194353,
+                  54.74591489348923,
+                  58.210980018959546,
+                  57.954216941244184,
+                  54.77399783266866,
+                  59.1420919832695,
+                  57.9902878280226,
+                  51.182352646554826,
+                  53.324852876862856,
+                  59.36144233896392,
+                  48.71505669965333,
+                  44.55672676314335,
+                  42.58527500677319,
+                  48.30892207477116,
+                  43.8431441301041,
+                  43.52495482362718,
+                  41.520582807276966,
+                  45.293098821338454,
+                  40.45208142358887,
+                  47.93433452991892,
+                  49.05402077116693,
+                  52.68520588762536,
+                  53.06887043263636,
+                  44.93689658689302,
+                  42.537445036478076,
+                  45.6967995617783,
+                  43.002541525090585,
+                  48.272087943033284,
+                  48.151702402839625,
+                  58.36036922692547,
+                  59.62243288646003,
+                  58.0103676234281,
+                  59.498558503900874,
+                  54.81430487974594,
+                  59.05605822595993,
+                  64.94609109366638,
+                  63.15964540441909,
+                  70.84168344908542,
+                  72.08064408705809,
+                  62.003469326021204,
+                  65.90345895795136,
+                  67.43309430791042,
+                  66.59846262249599,
+                  67.64232948361743,
+                  60.26944063877975,
+                  60.528981743368654,
+                  58.05462181880704,
+                  63.335626486208845,
+                  63.62829293358371
+                ],
+                "macd": [
+                  {
+                    "macd": 0.10930007867631275,
+                    "signal": 0.16611470104869064,
+                    "histogram": -0.05681462237237789
+                  },
+                  {
+                    "macd": 0.08929148162167166,
+                    "signal": 0.15075005716328685,
+                    "histogram": -0.061458575541615185
+                  },
+                  {
+                    "macd": 0.4531096077364509,
+                    "signal": 0.2112219672779197,
+                    "histogram": 0.24188764045853123
+                  },
+                  {
+                    "macd": 0.6260943621230695,
+                    "signal": 0.2941964462469497,
+                    "histogram": 0.3318979158761198
+                  },
+                  {
+                    "macd": 1.0472533535315733,
+                    "signal": 0.44480782770387445,
+                    "histogram": 0.6024455258276988
+                  },
+                  {
+                    "macd": 1.4219242081338734,
+                    "signal": 0.6402311037898742,
+                    "histogram": 0.7816931043439992
+                  },
+                  {
+                    "macd": 1.842058189447016,
+                    "signal": 0.8805965209213027,
+                    "histogram": 0.9614616685257134
+                  },
+                  {
+                    "macd": 2.178151588312403,
+                    "signal": 1.1401075343995228,
+                    "histogram": 1.0380440539128801
+                  },
+                  {
+                    "macd": 2.2794423124008745,
+                    "signal": 1.3679744899997932,
+                    "histogram": 0.9114678224010813
+                  },
+                  {
+                    "macd": 2.317667701333505,
+                    "signal": 1.5579131322665358,
+                    "histogram": 0.7597545690669694
+                  },
+                  {
+                    "macd": 2.665021669401199,
+                    "signal": 1.7793348396934685,
+                    "histogram": 0.8856868297077303
+                  },
+                  {
+                    "macd": 2.1537458465568307,
+                    "signal": 1.854217041066141,
+                    "histogram": 0.2995288054906897
+                  },
+                  {
+                    "macd": 1.611364453827207,
+                    "signal": 1.8056465236183543,
+                    "histogram": -0.19428206979114737
+                  },
+                  {
+                    "macd": 1.5621329083668343,
+                    "signal": 1.7569438005680504,
+                    "histogram": -0.19481089220121617
+                  },
+                  {
+                    "macd": 1.7203461896326644,
+                    "signal": 1.7496242783809732,
+                    "histogram": -0.02927808874830884
+                  },
+                  {
+                    "macd": 2.2251523434001115,
+                    "signal": 1.8447298913848011,
+                    "histogram": 0.38042245201531033
+                  },
+                  {
+                    "macd": 2.702990673345653,
+                    "signal": 2.0163820477769714,
+                    "histogram": 0.6866086255686814
+                  },
+                  {
+                    "macd": 3.205307780479984,
+                    "signal": 2.2541671943175743,
+                    "histogram": 0.9511405861624098
+                  },
+                  {
+                    "macd": 3.58546793033139,
+                    "signal": 2.5204273415203375,
+                    "histogram": 1.0650405888110526
+                  },
+                  {
+                    "macd": 4.04667049764879,
+                    "signal": 2.825675972746028,
+                    "histogram": 1.2209945249027623
+                  },
+                  {
+                    "macd": 4.479959191776743,
+                    "signal": 3.1565326165521714,
+                    "histogram": 1.3234265752245715
+                  },
+                  {
+                    "macd": 4.8920224747431575,
+                    "signal": 3.503630588190369,
+                    "histogram": 1.3883918865527884
+                  },
+                  {
+                    "macd": 4.972448159802525,
+                    "signal": 3.7973941025128006,
+                    "histogram": 1.1750540572897243
+                  },
+                  {
+                    "macd": 5.002724310672136,
+                    "signal": 4.038460144144668,
+                    "histogram": 0.9642641665274674
+                  },
+                  {
+                    "macd": 5.023680702867409,
+                    "signal": 4.235504255889217,
+                    "histogram": 0.7881764469781922
+                  },
+                  {
+                    "macd": 4.985242671136689,
+                    "signal": 4.385451938938711,
+                    "histogram": 0.5997907321979774
+                  },
+                  {
+                    "macd": 5.106519481487794,
+                    "signal": 4.529665447448528,
+                    "histogram": 0.5768540340392665
+                  },
+                  {
+                    "macd": 5.113827691286588,
+                    "signal": 4.64649789621614,
+                    "histogram": 0.46732979507044803
+                  },
+                  {
+                    "macd": 5.040534738272356,
+                    "signal": 4.725305264627383,
+                    "histogram": 0.31522947364497345
+                  },
+                  {
+                    "macd": 4.5491451792647695,
+                    "signal": 4.69007324755486,
+                    "histogram": -0.14092806829009064
+                  },
+                  {
+                    "macd": 3.860231185010548,
+                    "signal": 4.524104835045998,
+                    "histogram": -0.6638736500354501
+                  },
+                  {
+                    "macd": 3.474328149276232,
+                    "signal": 4.314149497892045,
+                    "histogram": -0.8398213486158133
+                  },
+                  {
+                    "macd": 3.0645822281294954,
+                    "signal": 4.064236043939536,
+                    "histogram": -0.9996538158100403
+                  },
+                  {
+                    "macd": 2.589772587701191,
+                    "signal": 3.769343352691867,
+                    "histogram": -1.1795707649906761
+                  },
+                  {
+                    "macd": 1.8962915506422746,
+                    "signal": 3.394732992281949,
+                    "histogram": -1.4984414416396743
+                  },
+                  {
+                    "macd": 1.4510139113438072,
+                    "signal": 3.005989176094321,
+                    "histogram": -1.5549752647505137
+                  },
+                  {
+                    "macd": 0.7154727087326478,
+                    "signal": 2.5478858826219866,
+                    "histogram": -1.8324131738893388
+                  },
+                  {
+                    "macd": 0.6958257072239462,
+                    "signal": 2.177473847542379,
+                    "histogram": -1.4816481403184327
+                  },
+                  {
+                    "macd": 0.20264440124094563,
+                    "signal": 1.7825079582820924,
+                    "histogram": -1.5798635570411468
+                  },
+                  {
+                    "macd": 0.10191792712595316,
+                    "signal": 1.4463899520508645,
+                    "histogram": -1.3444720249249114
+                  },
+                  {
+                    "macd": -0.5485301674372067,
+                    "signal": 1.0474059281532504,
+                    "histogram": -1.5959360955904571
+                  },
+                  {
+                    "macd": -1.1300669564751615,
+                    "signal": 0.6119113512275681,
+                    "histogram": -1.7419783077027295
+                  },
+                  {
+                    "macd": -1.1899036828467615,
+                    "signal": 0.2515483444127022,
+                    "histogram": -1.4414520272594638
+                  },
+                  {
+                    "macd": -1.6436221369880855,
+                    "signal": -0.12748575186745534,
+                    "histogram": -1.5161363851206302
+                  },
+                  {
+                    "macd": -2.2180904958430574,
+                    "signal": -0.5456067006625758,
+                    "histogram": -1.6724837951804816
+                  },
+                  {
+                    "macd": -2.6085913143264747,
+                    "signal": -0.9582036233953557,
+                    "histogram": -1.650387690931119
+                  },
+                  {
+                    "macd": -2.414156928925024,
+                    "signal": -1.2493942845012893,
+                    "histogram": -1.164762644423735
+                  },
+                  {
+                    "macd": -1.9383568023059183,
+                    "signal": -1.3871867880622153,
+                    "histogram": -0.551170014243703
+                  },
+                  {
+                    "macd": -1.446965854238556,
+                    "signal": -1.3991426012974837,
+                    "histogram": -0.04782325294107226
+                  },
+                  {
+                    "macd": -1.03351554731762,
+                    "signal": -1.326017190501511,
+                    "histogram": 0.29250164318389094
+                  },
+                  {
+                    "macd": -0.38430559998317904,
+                    "signal": -1.1376748723978447,
+                    "histogram": 0.7533692724146657
+                  },
+                  {
+                    "macd": 0.26273073289081594,
+                    "signal": -0.8575937513401126,
+                    "histogram": 1.1203244842309286
+                  },
+                  {
+                    "macd": 0.6254782435061657,
+                    "signal": -0.560979352370857,
+                    "histogram": 1.1864575958770227
+                  },
+                  {
+                    "macd": 0.8945764815311463,
+                    "signal": -0.2698681855904564,
+                    "histogram": 1.1644446671216027
+                  },
+                  {
+                    "macd": 1.2890594001995623,
+                    "signal": 0.041917331567547345,
+                    "histogram": 1.247142068632015
+                  },
+                  {
+                    "macd": 1.7222421525862046,
+                    "signal": 0.37798229577127884,
+                    "histogram": 1.3442598568149258
+                  },
+                  {
+                    "macd": 2.1050218479183513,
+                    "signal": 0.7233902062006934,
+                    "histogram": 1.381631641717658
+                  },
+                  {
+                    "macd": 2.594722640621285,
+                    "signal": 1.0976566930848117,
+                    "histogram": 1.4970659475364732
+                  },
+                  {
+                    "macd": 2.8475097647119583,
+                    "signal": 1.447627307410241,
+                    "histogram": 1.3998824573017172
+                  },
+                  {
+                    "macd": 3.3952210448371147,
+                    "signal": 1.8371460548956158,
+                    "histogram": 1.558074989941499
+                  },
+                  {
+                    "macd": 2.913739343792031,
+                    "signal": 2.052464712674899,
+                    "histogram": 0.8612746311171318
+                  },
+                  {
+                    "macd": 2.035040930869002,
+                    "signal": 2.04897995631372,
+                    "histogram": -0.013939025444718034
+                  },
+                  {
+                    "macd": 1.0649498942882474,
+                    "signal": 1.8521739439086256,
+                    "histogram": -0.7872240496203782
+                  },
+                  {
+                    "macd": 0.21619036329383334,
+                    "signal": 1.5249772277856672,
+                    "histogram": -1.308786864491834
+                  },
+                  {
+                    "macd": -0.14333682369442613,
+                    "signal": 1.1913144174896486,
+                    "histogram": -1.3346512411840747
+                  },
+                  {
+                    "macd": -0.8134684042957474,
+                    "signal": 0.7903578531325695,
+                    "histogram": -1.6038262574283169
+                  },
+                  {
+                    "macd": -1.3579491888659163,
+                    "signal": 0.36069644473287227,
+                    "histogram": -1.7186456335987885
+                  },
+                  {
+                    "macd": -1.7706560589061269,
+                    "signal": -0.0655740559949276,
+                    "histogram": -1.7050820029111993
+                  },
+                  {
+                    "macd": -1.6749630817706134,
+                    "signal": -0.3874518611500648,
+                    "histogram": -1.2875112206205486
+                  },
+                  {
+                    "macd": -1.210758434489776,
+                    "signal": -0.5521131758180071,
+                    "histogram": -0.6586452586717688
+                  },
+                  {
+                    "macd": -0.39930964358558185,
+                    "signal": -0.5215524693715221,
+                    "histogram": 0.12224282578594026
+                  },
+                  {
+                    "macd": -0.09085833866788562,
+                    "signal": -0.43541364323079484,
+                    "histogram": 0.3445553045629092
+                  },
+                  {
+                    "macd": 0.06887756717037519,
+                    "signal": -0.33455540115056087,
+                    "histogram": 0.40343296832093606
+                  },
+                  {
+                    "macd": 0.53227319063717,
+                    "signal": -0.1611896827930147,
+                    "histogram": 0.6934628734301848
+                  },
+                  {
+                    "macd": 1.2059619025189932,
+                    "signal": 0.11224063426938688,
+                    "histogram": 1.0937212682496062
+                  },
+                  {
+                    "macd": 1.6354793284927496,
+                    "signal": 0.41688837311405946,
+                    "histogram": 1.2185909553786902
+                  },
+                  {
+                    "macd": 1.9669177795275345,
+                    "signal": 0.7268942543967545,
+                    "histogram": 1.24002352513078
+                  },
+                  {
+                    "macd": 1.0315286502163303,
+                    "signal": 0.7878211335606697,
+                    "histogram": 0.2437075166556606
+                  },
+                  {
+                    "macd": 1.0527286252727208,
+                    "signal": 0.84080263190308,
+                    "histogram": 0.2119259933696408
+                  },
+                  {
+                    "macd": 1.6372859629206005,
+                    "signal": 1.0000992981065842,
+                    "histogram": 0.6371866648140163
+                  },
+                  {
+                    "macd": 2.1675528565546642,
+                    "signal": 1.2335900097962003,
+                    "histogram": 0.933962846758464
+                  },
+                  {
+                    "macd": 2.677960789099302,
+                    "signal": 1.5224641656568207,
+                    "histogram": 1.1554966234424813
+                  },
+                  {
+                    "macd": 2.690753678312092,
+                    "signal": 1.7561220681878749,
+                    "histogram": 0.9346316101242169
+                  },
+                  {
+                    "macd": 2.624644502341539,
+                    "signal": 1.9298265550186078,
+                    "histogram": 0.6948179473229312
+                  },
+                  {
+                    "macd": 2.384989490892906,
+                    "signal": 2.0208591421934674,
+                    "histogram": 0.3641303486994385
+                  },
+                  {
+                    "macd": 2.505885999811028,
+                    "signal": 2.1178645137169796,
+                    "histogram": 0.3880214860940483
+                  },
+                  {
+                    "macd": 3.0411086000160594,
+                    "signal": 2.3025133309767956,
+                    "histogram": 0.7385952690392639
+                  },
+                  {
+                    "macd": 3.6523384522020024,
+                    "signal": 2.572478355221837,
+                    "histogram": 1.0798600969801653
+                  },
+                  {
+                    "macd": 4.348063342791818,
+                    "signal": 2.9275953527358336,
+                    "histogram": 1.4204679900559842
+                  },
+                  {
+                    "macd": 4.743082767588135,
+                    "signal": 3.2906928357062943,
+                    "histogram": 1.4523899318818403
+                  },
+                  {
+                    "macd": 4.666666551661024,
+                    "signal": 3.5658875788972404,
+                    "histogram": 1.1007789727637833
+                  },
+                  {
+                    "macd": 4.527291196646729,
+                    "signal": 3.7581683024471384,
+                    "histogram": 0.7691228941995907
+                  },
+                  {
+                    "macd": 4.270773449602757,
+                    "signal": 3.8606893318782625,
+                    "histogram": 0.4100841177244945
+                  },
+                  {
+                    "macd": 4.2811859829418495,
+                    "signal": 3.9447886620909802,
+                    "histogram": 0.33639732085086926
+                  },
+                  {
+                    "macd": 4.923404314500601,
+                    "signal": 4.140511792572905,
+                    "histogram": 0.7828925219276961
+                  },
+                  {
+                    "macd": 5.415927888593387,
+                    "signal": 4.395595011777002,
+                    "histogram": 1.0203328768163855
+                  },
+                  {
+                    "macd": 5.132225347396513,
+                    "signal": 4.542921078900904,
+                    "histogram": 0.5893042684956091
+                  },
+                  {
+                    "macd": 5.074827662144571,
+                    "signal": 4.649302395549638,
+                    "histogram": 0.42552526659493317
+                  },
+                  {
+                    "macd": 4.924161437098235,
+                    "signal": 4.704274203859358,
+                    "histogram": 0.21988723323887704
+                  },
+                  {
+                    "macd": 4.375072549824608,
+                    "signal": 4.638433873052408,
+                    "histogram": -0.2633613232277998
+                  },
+                  {
+                    "macd": 2.8109140550654956,
+                    "signal": 4.2729299094550255,
+                    "histogram": -1.4620158543895299
+                  },
+                  {
+                    "macd": 1.3116912399676153,
+                    "signal": 3.6806821755575436,
+                    "histogram": -2.3689909355899283
+                  },
+                  {
+                    "macd": 0.23302278140488397,
+                    "signal": 2.9911502967270116,
+                    "histogram": -2.7581275153221276
+                  },
+                  {
+                    "macd": -0.3586756701284344,
+                    "signal": 2.3211851033559223,
+                    "histogram": -2.6798607734843567
+                  },
+                  {
+                    "macd": -1.5943528185852074,
+                    "signal": 1.5380775189676965,
+                    "histogram": -3.132430337552904
+                  },
+                  {
+                    "macd": -2.600145672875726,
+                    "signal": 0.710432880599012,
+                    "histogram": -3.310578553474738
+                  },
+                  {
+                    "macd": -3.2316914129824,
+                    "signal": -0.07799197811727043,
+                    "histogram": -3.1536994348651293
+                  },
+                  {
+                    "macd": -4.161117097929662,
+                    "signal": -0.8946170020797487,
+                    "histogram": -3.266500095849913
+                  },
+                  {
+                    "macd": -4.577035587646549,
+                    "signal": -1.6311007191931088,
+                    "histogram": -2.94593486845344
+                  },
+                  {
+                    "macd": -4.9089721971586755,
+                    "signal": -2.2866750147862223,
+                    "histogram": -2.6222971823724532
+                  },
+                  {
+                    "macd": -5.076399314209937,
+                    "signal": -2.8446198746709657,
+                    "histogram": -2.231779439538971
+                  },
+                  {
+                    "macd": -4.699009503208629,
+                    "signal": -3.215497800378498,
+                    "histogram": -1.4835117028301306
+                  },
+                  {
+                    "macd": -4.392062864411173,
+                    "signal": -3.4508108131850332,
+                    "histogram": -0.9412520512261398
+                  },
+                  {
+                    "macd": -3.9220384281520637,
+                    "signal": -3.5450563361784395,
+                    "histogram": -0.3769820919736242
+                  },
+                  {
+                    "macd": -2.9738200964540056,
+                    "signal": -3.430809088233553,
+                    "histogram": 0.4569889917795473
+                  },
+                  {
+                    "macd": -2.003977238655807,
+                    "signal": -3.145442718318004,
+                    "histogram": 1.1414654796621968
+                  },
+                  {
+                    "macd": -1.7884698169880267,
+                    "signal": -2.8740481380520086,
+                    "histogram": 1.085578321063982
+                  },
+                  {
+                    "macd": -0.6228340711501232,
+                    "signal": -2.4238053246716316,
+                    "histogram": 1.8009712535215083
+                  },
+                  {
+                    "macd": 0.2735804820888461,
+                    "signal": -1.8843281633195361,
+                    "histogram": 2.1579086454083822
+                  },
+                  {
+                    "macd": 0.6680519212177387,
+                    "signal": -1.3738521464120814,
+                    "histogram": 2.04190406762982
+                  },
+                  {
+                    "macd": 0.3743985802872203,
+                    "signal": -1.024202001072221,
+                    "histogram": 1.3986005813594413
+                  },
+                  {
+                    "macd": -0.5124733798236321,
+                    "signal": -0.9218562768225033,
+                    "histogram": 0.4093828969988712
+                  },
+                  {
+                    "macd": -1.2086575606336964,
+                    "signal": -0.9792165335847419,
+                    "histogram": -0.22944102704895453
+                  },
+                  {
+                    "macd": -1.3749696431539178,
+                    "signal": -1.0583671554985772,
+                    "histogram": -0.3166024876553406
+                  },
+                  {
+                    "macd": -1.3579785178516204,
+                    "signal": -1.118289427969186,
+                    "histogram": -0.23968908988243443
+                  },
+                  {
+                    "macd": -1.3874253386141504,
+                    "signal": -1.172116610098179,
+                    "histogram": -0.21530872851597138
+                  },
+                  {
+                    "macd": -1.1761079406099952,
+                    "signal": -1.1729148762005424,
+                    "histogram": -0.0031930644094528837
+                  },
+                  {
+                    "macd": -2.043752234250121,
+                    "signal": -1.347082347810458,
+                    "histogram": -0.696669886439663
+                  },
+                  {
+                    "macd": -2.7297576176901543,
+                    "signal": -1.6236174017863974,
+                    "histogram": -1.106140215903757
+                  },
+                  {
+                    "macd": -2.7574853953974525,
+                    "signal": -1.8503910005086084,
+                    "histogram": -0.9070943948888441
+                  },
+                  {
+                    "macd": -2.5220287537230206,
+                    "signal": -1.984718551151491,
+                    "histogram": -0.5373102025715295
+                  },
+                  {
+                    "macd": -2.7738856968576897,
+                    "signal": -2.1425519802927306,
+                    "histogram": -0.6313337165649591
+                  },
+                  {
+                    "macd": -3.158172999242595,
+                    "signal": -2.3456761840827034,
+                    "histogram": -0.8124968151598915
+                  },
+                  {
+                    "macd": -3.2078766299035806,
+                    "signal": -2.518116273246879,
+                    "histogram": -0.6897603566567017
+                  },
+                  {
+                    "macd": -3.2796625421354975,
+                    "signal": -2.670425527024603,
+                    "histogram": -0.6092370151108946
+                  },
+                  {
+                    "macd": -3.7644010824442375,
+                    "signal": -2.88922063810853,
+                    "histogram": -0.8751804443357076
+                  },
+                  {
+                    "macd": -4.425953346948688,
+                    "signal": -3.1965671798765616,
+                    "histogram": -1.2293861670721267
+                  },
+                  {
+                    "macd": -4.858725401055722,
+                    "signal": -3.5289988241123935,
+                    "histogram": -1.3297265769433282
+                  },
+                  {
+                    "macd": -5.237350704857931,
+                    "signal": -3.870669200261501,
+                    "histogram": -1.3666815045964302
+                  },
+                  {
+                    "macd": -5.570835522409368,
+                    "signal": -4.2107024646910745,
+                    "histogram": -1.3601330577182935
+                  },
+                  {
+                    "macd": -6.137970180425157,
+                    "signal": -4.596156007837891,
+                    "histogram": -1.5418141725872658
+                  },
+                  {
+                    "macd": -6.4684844027314625,
+                    "signal": -4.970621686816605,
+                    "histogram": -1.4978627159148576
+                  },
+                  {
+                    "macd": -6.4367392156763685,
+                    "signal": -5.263845192588558,
+                    "histogram": -1.1728940230878102
+                  },
+                  {
+                    "macd": -6.28027998228589,
+                    "signal": -5.467132150528025,
+                    "histogram": -0.8131478317578651
+                  },
+                  {
+                    "macd": -6.018323499329313,
+                    "signal": -5.5773704202882834,
+                    "histogram": -0.4409530790410292
+                  },
+                  {
+                    "macd": -5.726153600675275,
+                    "signal": -5.607127056365682,
+                    "histogram": -0.11902654430959281
+                  },
+                  {
+                    "macd": -5.544469173343316,
+                    "signal": -5.594595479761209,
+                    "histogram": 0.050126306417893396
+                  },
+                  {
+                    "macd": -5.071702036283227,
+                    "signal": -5.490016791065614,
+                    "histogram": 0.41831475478238644
+                  },
+                  {
+                    "macd": -4.444871559362525,
+                    "signal": -5.280987744724996,
+                    "histogram": 0.8361161853624708
+                  },
+                  {
+                    "macd": -3.662198014446176,
+                    "signal": -4.957229798669232,
+                    "histogram": 1.295031784223056
+                  },
+                  {
+                    "macd": -3.3072015942972257,
+                    "signal": -4.6272241577948305,
+                    "histogram": 1.3200225634976048
+                  },
+                  {
+                    "macd": -3.6949719166902923,
+                    "signal": -4.440773709573923,
+                    "histogram": 0.7458017928836309
+                  },
+                  {
+                    "macd": -3.8824851818454817,
+                    "signal": -4.3291160040282355,
+                    "histogram": 0.44663082218275374
+                  },
+                  {
+                    "macd": -3.1563193614296665,
+                    "signal": -4.094556675508522,
+                    "histogram": 0.9382373140788554
+                  },
+                  {
+                    "macd": -2.4540945402338252,
+                    "signal": -3.766464248453583,
+                    "histogram": 1.3123697082197578
+                  },
+                  {
+                    "macd": -1.9381736337680309,
+                    "signal": -3.400806125516473,
+                    "histogram": 1.4626324917484421
+                  },
+                  {
+                    "macd": -1.44406789384891,
+                    "signal": -3.009458479182961,
+                    "histogram": 1.5653905853340508
+                  },
+                  {
+                    "macd": -0.8849373030857919,
+                    "signal": -2.584554243963527,
+                    "histogram": 1.699616940877735
+                  },
+                  {
+                    "macd": 0.40640419762729607,
+                    "signal": -1.9863625556453626,
+                    "histogram": 2.3927667532726584
+                  },
+                  {
+                    "macd": 1.6017685444915628,
+                    "signal": -1.2687363356179775,
+                    "histogram": 2.8705048801095403
+                  },
+                  {
+                    "macd": 2.4833593150542583,
+                    "signal": -0.5183172054835303,
+                    "histogram": 3.0016765205377887
+                  },
+                  {
+                    "macd": 3.4496953728467474,
+                    "signal": 0.2752853101825253,
+                    "histogram": 3.174410062664222
+                  },
+                  {
+                    "macd": 3.9632671755844058,
+                    "signal": 1.0128816832629015,
+                    "histogram": 2.9503854923215043
+                  },
+                  {
+                    "macd": 3.906455519433848,
+                    "signal": 1.591596450497091,
+                    "histogram": 2.314859068936757
+                  },
+                  {
+                    "macd": 4.138112269735359,
+                    "signal": 2.100899614344745,
+                    "histogram": 2.037212655390614
+                  },
+                  {
+                    "macd": 4.299573964079855,
+                    "signal": 2.540634484291767,
+                    "histogram": 1.7589394797880877
+                  },
+                  {
+                    "macd": 4.911548771467665,
+                    "signal": 3.0148173417269466,
+                    "histogram": 1.896731429740718
+                  },
+                  {
+                    "macd": 5.016754328115212,
+                    "signal": 3.4152047390046,
+                    "histogram": 1.6015495891106122
+                  },
+                  {
+                    "macd": 5.0436039097346,
+                    "signal": 3.7408845731506,
+                    "histogram": 1.3027193365839995
+                  },
+                  {
+                    "macd": 4.901067144159015,
+                    "signal": 3.972921087352283,
+                    "histogram": 0.9281460568067317
+                  },
+                  {
+                    "macd": 4.4615173388912694,
+                    "signal": 4.07064033766008,
+                    "histogram": 0.39087700123118907
+                  },
+                  {
+                    "macd": 4.333534162521573,
+                    "signal": 4.12321910263238,
+                    "histogram": 0.21031505988919363
+                  },
+                  {
+                    "macd": 4.169519048351674,
+                    "signal": 4.132479091776239,
+                    "histogram": 0.03703995657543491
+                  },
+                  {
+                    "macd": 3.8180017424057837,
+                    "signal": 4.069583621902148,
+                    "histogram": -0.25158187949636446
+                  },
+                  {
+                    "macd": 3.8165802082532423,
+                    "signal": 4.018982939172368,
+                    "histogram": -0.20240273091912542
+                  },
+                  {
+                    "macd": 3.711345119471275,
+                    "signal": 3.9574553752321497,
+                    "histogram": -0.24611025576087453
+                  },
+                  {
+                    "macd": 3.202099435793059,
+                    "signal": 3.806384187344332,
+                    "histogram": -0.604284751551273
+                  },
+                  {
+                    "macd": 2.906227752731297,
+                    "signal": 3.6263529004217254,
+                    "histogram": -0.7201251476904282
+                  },
+                  {
+                    "macd": 3.0800464881930907,
+                    "signal": 3.5170916179759986,
+                    "histogram": -0.4370451297829079
+                  },
+                  {
+                    "macd": 2.4926955753169864,
+                    "signal": 3.3122124094441965,
+                    "histogram": -0.8195168341272101
+                  },
+                  {
+                    "macd": 1.671465362135791,
+                    "signal": 2.9840629999825157,
+                    "histogram": -1.3125976378467246
+                  },
+                  {
+                    "macd": 0.8414814847232606,
+                    "signal": 2.555546696930665,
+                    "histogram": -1.7140652122074043
+                  },
+                  {
+                    "macd": 0.5709078223056281,
+                    "signal": 2.1586189220056577,
+                    "histogram": -1.5877110997000297
+                  },
+                  {
+                    "macd": -0.016931280750895894,
+                    "signal": 1.723508881454347,
+                    "histogram": -1.740440162205243
+                  },
+                  {
+                    "macd": -0.5044182484958242,
+                    "signal": 1.277923455464313,
+                    "histogram": -1.7823417039601372
+                  },
+                  {
+                    "macd": -1.0481259807872902,
+                    "signal": 0.8127135682139925,
+                    "histogram": -1.8608395490012828
+                  },
+                  {
+                    "macd": -1.2292278226119606,
+                    "signal": 0.4043252900488019,
+                    "histogram": -1.6335531126607625
+                  },
+                  {
+                    "macd": -1.7583618996251857,
+                    "signal": -0.02821214788599563,
+                    "histogram": -1.7301497517391902
+                  },
+                  {
+                    "macd": -1.6519187593397646,
+                    "signal": -0.35295347017674944,
+                    "histogram": -1.2989652891630152
+                  },
+                  {
+                    "macd": -1.4683312066370036,
+                    "signal": -0.5760290174688003,
+                    "histogram": -0.8923021891682033
+                  },
+                  {
+                    "macd": -1.0381316666411635,
+                    "signal": -0.668449547303273,
+                    "histogram": -0.3696821193378905
+                  },
+                  {
+                    "macd": -0.6605334045066797,
+                    "signal": -0.6668663187439543,
+                    "histogram": 0.006332914237274556
+                  },
+                  {
+                    "macd": -0.9522658974901788,
+                    "signal": -0.7239462344931992,
+                    "histogram": -0.2283196629969796
+                  },
+                  {
+                    "macd": -1.3733970376144384,
+                    "signal": -0.853836395117447,
+                    "histogram": -0.5195606424969914
+                  },
+                  {
+                    "macd": -1.4818809446237537,
+                    "signal": -0.9794453050187084,
+                    "histogram": -0.5024356396050453
+                  },
+                  {
+                    "macd": -1.7677665807099174,
+                    "signal": -1.1371095601569503,
+                    "histogram": -0.6306570205529671
+                  },
+                  {
+                    "macd": -1.6222034664139642,
+                    "signal": -1.234128341408353,
+                    "histogram": -0.38807512500561114
+                  },
+                  {
+                    "macd": -1.4984454024444744,
+                    "signal": -1.2869917536155775,
+                    "histogram": -0.21145364882889695
+                  },
+                  {
+                    "macd": -0.5834952928740904,
+                    "signal": -1.14629246146728,
+                    "histogram": 0.5627971685931896
+                  },
+                  {
+                    "macd": 0.25805660008416,
+                    "signal": -0.8654226491569921,
+                    "histogram": 1.123479249241152
+                  },
+                  {
+                    "macd": 0.8139377132627033,
+                    "signal": -0.529550576673053,
+                    "histogram": 1.3434882899357563
+                  },
+                  {
+                    "macd": 1.3670212096279215,
+                    "signal": -0.15023621941285814,
+                    "histogram": 1.5172574290407796
+                  },
+                  {
+                    "macd": 1.5007817367541065,
+                    "signal": 0.1799673718205348,
+                    "histogram": 1.3208143649335717
+                  },
+                  {
+                    "macd": 1.935483544215458,
+                    "signal": 0.5310706062995195,
+                    "histogram": 1.4044129379159385
+                  },
+                  {
+                    "macd": 2.830758104022266,
+                    "signal": 0.9910081058440687,
+                    "histogram": 1.839749998178197
+                  },
+                  {
+                    "macd": 3.3946249600127203,
+                    "signal": 1.4717314766777991,
+                    "histogram": 1.9228934833349212
+                  },
+                  {
+                    "macd": 4.73424167400708,
+                    "signal": 2.124233516143655,
+                    "histogram": 2.610008157863425
+                  },
+                  {
+                    "macd": 5.914916831381333,
+                    "signal": 2.882370179191191,
+                    "histogram": 3.0325466521901423
+                  },
+                  {
+                    "macd": 6.115219607420897,
+                    "signal": 3.5289400648371325,
+                    "histogram": 2.586279542583765
+                  },
+                  {
+                    "macd": 6.701836867873055,
+                    "signal": 4.163519425444317,
+                    "histogram": 2.5383174424287382
+                  },
+                  {
+                    "macd": 7.297257100613592,
+                    "signal": 4.7902669604781725,
+                    "histogram": 2.5069901401354198
+                  },
+                  {
+                    "macd": 7.625551879080319,
+                    "signal": 5.357323944198602,
+                    "histogram": 2.2682279348817174
+                  },
+                  {
+                    "macd": 7.929080021662571,
+                    "signal": 5.871675159691396,
+                    "histogram": 2.0574048619711753
+                  },
+                  {
+                    "macd": 7.592309976207844,
+                    "signal": 6.215802122994686,
+                    "histogram": 1.376507853213158
+                  },
+                  {
+                    "macd": 7.269061399422128,
+                    "signal": 6.426453978280175,
+                    "histogram": 0.8426074211419534
+                  },
+                  {
+                    "macd": 6.768632936896267,
+                    "signal": 6.494889770003394,
+                    "histogram": 0.27374316689287337
+                  },
+                  {
+                    "macd": 6.837089410151236,
+                    "signal": 6.563329698032963,
+                    "histogram": 0.2737597121182729
+                  },
+                  {
+                    "macd": 6.844716195353783,
+                    "signal": 6.619606997497128,
+                    "histogram": 0.22510919785665529
+                  }
+                ],
+                "bb": [
+                  {
+                    "upper": 302.1596156267931,
+                    "middle": 291.83599853515625,
+                    "lower": 281.5123814435194
+                  },
+                  {
+                    "upper": 301.6969441770097,
+                    "middle": 291.50449829101564,
+                    "lower": 281.3120524050216
+                  },
+                  {
+                    "upper": 301.8810034858201,
+                    "middle": 291.6189987182617,
+                    "lower": 281.3569939507033
+                  },
+                  {
+                    "upper": 301.4802363417858,
+                    "middle": 292.0484985351562,
+                    "lower": 282.61676072852663
+                  },
+                  {
+                    "upper": 300.9775894201024,
+                    "middle": 292.45799865722654,
+                    "lower": 283.9384078943507
+                  },
+                  {
+                    "upper": 301.0565782593772,
+                    "middle": 292.39549865722654,
+                    "lower": 283.7344190550759
+                  },
+                  {
+                    "upper": 300.94586346158496,
+                    "middle": 292.49049987792966,
+                    "lower": 284.03513629427437
+                  },
+                  {
+                    "upper": 300.919784795057,
+                    "middle": 292.5334991455078,
+                    "lower": 284.14721349595857
+                  },
+                  {
+                    "upper": 300.77266805511533,
+                    "middle": 292.84850006103517,
+                    "lower": 284.924332066955
+                  },
+                  {
+                    "upper": 300.4165125599095,
+                    "middle": 293.08399963378906,
+                    "lower": 285.7514867076686
+                  },
+                  {
+                    "upper": 300.49340529454673,
+                    "middle": 293.2970001220703,
+                    "lower": 286.10059494959387
+                  },
+                  {
+                    "upper": 300.50619095878864,
+                    "middle": 293.2580001831055,
+                    "lower": 286.0098094074223
+                  },
+                  {
+                    "upper": 300.5028791280533,
+                    "middle": 293.28600006103517,
+                    "lower": 286.06912099401706
+                  },
+                  {
+                    "upper": 300.5116339634614,
+                    "middle": 293.24750061035155,
+                    "lower": 285.9833672572417
+                  },
+                  {
+                    "upper": 300.113664248665,
+                    "middle": 293.02149963378906,
+                    "lower": 285.92933501891315
+                  },
+                  {
+                    "upper": 299.6980212102753,
+                    "middle": 292.76750030517576,
+                    "lower": 285.83697940007625
+                  },
+                  {
+                    "upper": 299.24674027645267,
+                    "middle": 292.6485000610352,
+                    "lower": 286.0502598456177
+                  },
+                  {
+                    "upper": 298.6515026478831,
+                    "middle": 292.47949981689453,
+                    "lower": 286.30749698590597
+                  },
+                  {
+                    "upper": 298.9847957823916,
+                    "middle": 292.5559997558594,
+                    "lower": 286.12720372932716
+                  },
+                  {
+                    "upper": 298.8916338089541,
+                    "middle": 292.5384994506836,
+                    "lower": 286.1853650924131
+                  },
+                  {
+                    "upper": 299.9873676496535,
+                    "middle": 292.7800003051758,
+                    "lower": 285.5726329606981
+                  },
+                  {
+                    "upper": 301.32595468255295,
+                    "middle": 293.38250122070315,
+                    "lower": 285.43904775885335
+                  },
+                  {
+                    "upper": 302.0587087056448,
+                    "middle": 293.6545013427734,
+                    "lower": 285.25029397990204
+                  },
+                  {
+                    "upper": 302.7667708850853,
+                    "middle": 294.06150207519534,
+                    "lower": 285.3562332653054
+                  },
+                  {
+                    "upper": 304.26633495615465,
+                    "middle": 294.6850021362305,
+                    "lower": 285.1036693163063
+                  },
+                  {
+                    "upper": 303.9603725669663,
+                    "middle": 295.05700225830077,
+                    "lower": 286.1536319496352
+                  },
+                  {
+                    "upper": 303.7550423401478,
+                    "middle": 295.264501953125,
+                    "lower": 286.7739615661022
+                  },
+                  {
+                    "upper": 303.81722859446774,
+                    "middle": 295.6790023803711,
+                    "lower": 287.5407761662745
+                  },
+                  {
+                    "upper": 304.3559446479006,
+                    "middle": 296.0635025024414,
+                    "lower": 287.77106035698216
+                  },
+                  {
+                    "upper": 305.6704154234318,
+                    "middle": 296.81500244140625,
+                    "lower": 287.9595894593807
+                  },
+                  {
+                    "upper": 307.238447480482,
+                    "middle": 297.45250244140624,
+                    "lower": 287.66655740233045
+                  },
+                  {
+                    "upper": 308.8079983042247,
+                    "middle": 298.37300262451174,
+                    "lower": 287.93800694479876
+                  },
+                  {
+                    "upper": 310.20161993159815,
+                    "middle": 299.25600280761716,
+                    "lower": 288.3103856836362
+                  },
+                  {
+                    "upper": 311.79093849063645,
+                    "middle": 300.31050262451174,
+                    "lower": 288.83006675838703
+                  },
+                  {
+                    "upper": 313.51527836813176,
+                    "middle": 301.36000366210936,
+                    "lower": 289.20472895608697
+                  },
+                  {
+                    "upper": 315.1260577916549,
+                    "middle": 302.52550354003904,
+                    "lower": 289.9249492884232
+                  },
+                  {
+                    "upper": 316.2934162384834,
+                    "middle": 303.33550415039065,
+                    "lower": 290.3775920622979
+                  },
+                  {
+                    "upper": 317.1960095111557,
+                    "middle": 304.22750396728514,
+                    "lower": 291.2589984234146
+                  },
+                  {
+                    "upper": 318.2544275422715,
+                    "middle": 304.9700042724609,
+                    "lower": 291.68558100265034
+                  },
+                  {
+                    "upper": 319.18312945612826,
+                    "middle": 305.67850494384766,
+                    "lower": 292.17388043156706
+                  },
+                  {
+                    "upper": 320.4791721246751,
+                    "middle": 306.4280044555664,
+                    "lower": 292.3768367864577
+                  },
+                  {
+                    "upper": 321.54774954874387,
+                    "middle": 307.14150390625,
+                    "lower": 292.7352582637562
+                  },
+                  {
+                    "upper": 322.3408527565268,
+                    "middle": 307.9280029296875,
+                    "lower": 293.5151531028483
+                  },
+                  {
+                    "upper": 322.41104817804325,
+                    "middle": 308.48800201416014,
+                    "lower": 294.56495585027704
+                  },
+                  {
+                    "upper": 322.44149149264683,
+                    "middle": 308.6745010375977,
+                    "lower": 294.9075105825485
+                  },
+                  {
+                    "upper": 321.5640959191928,
+                    "middle": 309.4570007324219,
+                    "lower": 297.3499055456509
+                  },
+                  {
+                    "upper": 319.71451165706,
+                    "middle": 310.27050018310547,
+                    "lower": 300.82648870915096
+                  },
+                  {
+                    "upper": 318.4240374777942,
+                    "middle": 310.7625,
+                    "lower": 303.1009625222058
+                  },
+                  {
+                    "upper": 317.77387046507226,
+                    "middle": 310.93699951171874,
+                    "lower": 304.1001285583652
+                  },
+                  {
+                    "upper": 317.7771000300184,
+                    "middle": 310.9354995727539,
+                    "lower": 304.09389911548936
+                  },
+                  {
+                    "upper": 318.59606555527535,
+                    "middle": 310.63450012207034,
+                    "lower": 302.6729346888653
+                  },
+                  {
+                    "upper": 318.60024635278097,
+                    "middle": 310.58800048828124,
+                    "lower": 302.5757546237815
+                  },
+                  {
+                    "upper": 319.0516232900467,
+                    "middle": 310.23249969482424,
+                    "lower": 301.4133760996018
+                  },
+                  {
+                    "upper": 318.9337210551764,
+                    "middle": 309.9294998168945,
+                    "lower": 300.9252785786126
+                  },
+                  {
+                    "upper": 319.3282847436916,
+                    "middle": 309.1949996948242,
+                    "lower": 299.06171464595684
+                  },
+                  {
+                    "upper": 319.31372610800025,
+                    "middle": 308.33399963378906,
+                    "lower": 297.3542731595779
+                  },
+                  {
+                    "upper": 318.934243171456,
+                    "middle": 307.8299987792969,
+                    "lower": 296.7257543871378
+                  },
+                  {
+                    "upper": 318.8416903539786,
+                    "middle": 307.04749908447263,
+                    "lower": 295.25330781496666
+                  },
+                  {
+                    "upper": 318.7598618685112,
+                    "middle": 306.0819976806641,
+                    "lower": 293.4041334928169
+                  },
+                  {
+                    "upper": 318.2870994993779,
+                    "middle": 305.1364974975586,
+                    "lower": 291.98589549573927
+                  },
+                  {
+                    "upper": 316.6455479035761,
+                    "middle": 304.3554977416992,
+                    "lower": 292.0654475798223
+                  },
+                  {
+                    "upper": 314.91527701137744,
+                    "middle": 303.77849731445315,
+                    "lower": 292.64171761752885
+                  },
+                  {
+                    "upper": 313.09144047907455,
+                    "middle": 303.2749969482422,
+                    "lower": 293.4585534174098
+                  },
+                  {
+                    "upper": 312.29052444147663,
+                    "middle": 303.0149978637695,
+                    "lower": 293.7394712860624
+                  },
+                  {
+                    "upper": 312.6038433220259,
+                    "middle": 303.10949859619143,
+                    "lower": 293.61515387035695
+                  },
+                  {
+                    "upper": 312.8276233643411,
+                    "middle": 303.16399841308595,
+                    "lower": 293.5003734618308
+                  },
+                  {
+                    "upper": 312.8575524652403,
+                    "middle": 303.17249908447263,
+                    "lower": 293.48744570370496
+                  },
+                  {
+                    "upper": 313.1034964364788,
+                    "middle": 303.25049896240233,
+                    "lower": 293.3975014883259
+                  },
+                  {
+                    "upper": 314.14899048005833,
+                    "middle": 303.63299865722655,
+                    "lower": 293.1170068343948
+                  },
+                  {
+                    "upper": 315.3589145897609,
+                    "middle": 304.0274993896484,
+                    "lower": 292.69608418953595
+                  },
+                  {
+                    "upper": 316.75146735617614,
+                    "middle": 304.6934982299805,
+                    "lower": 292.63552910378485
+                  },
+                  {
+                    "upper": 318.26210768286614,
+                    "middle": 305.1394989013672,
+                    "lower": 292.0168901198682
+                  },
+                  {
+                    "upper": 319.61742610785126,
+                    "middle": 305.8164993286133,
+                    "lower": 292.01557254937535
+                  },
+                  {
+                    "upper": 321.7475534882811,
+                    "middle": 306.55249938964846,
+                    "lower": 291.35744529101584
+                  },
+                  {
+                    "upper": 321.88350760994996,
+                    "middle": 307.09949951171876,
+                    "lower": 292.31549141348756
+                  },
+                  {
+                    "upper": 321.62999223274267,
+                    "middle": 307.40199890136716,
+                    "lower": 293.17400556999166
+                  },
+                  {
+                    "upper": 321.696999344256,
+                    "middle": 307.30249938964846,
+                    "lower": 292.9079994350409
+                  },
+                  {
+                    "upper": 321.51626761636714,
+                    "middle": 307.4184997558594,
+                    "lower": 293.3207318953516
+                  },
+                  {
+                    "upper": 320.75775450222847,
+                    "middle": 307.87649993896486,
+                    "lower": 294.99524537570124
+                  },
+                  {
+                    "upper": 320.2440304027954,
+                    "middle": 308.06849975585936,
+                    "lower": 295.89296910892335
+                  },
+                  {
+                    "upper": 320.467111748466,
+                    "middle": 307.94749908447267,
+                    "lower": 295.42788642047935
+                  },
+                  {
+                    "upper": 320.80316069245526,
+                    "middle": 307.63999938964844,
+                    "lower": 294.4768380868416
+                  },
+                  {
+                    "upper": 320.806553040386,
+                    "middle": 307.5220001220703,
+                    "lower": 294.23744720375464
+                  },
+                  {
+                    "upper": 320.8809394427856,
+                    "middle": 307.6285003662109,
+                    "lower": 294.37606128963625
+                  },
+                  {
+                    "upper": 321.2560222123119,
+                    "middle": 307.8104995727539,
+                    "lower": 294.36497693319586
+                  },
+                  {
+                    "upper": 321.07171329429406,
+                    "middle": 307.70050048828125,
+                    "lower": 294.32928768226844
+                  },
+                  {
+                    "upper": 320.9772810789173,
+                    "middle": 307.6270004272461,
+                    "lower": 294.2767197755749
+                  },
+                  {
+                    "upper": 321.24971105108824,
+                    "middle": 307.77100067138673,
+                    "lower": 294.2922902916852
+                  },
+                  {
+                    "upper": 321.85918169468573,
+                    "middle": 307.99200134277345,
+                    "lower": 294.12482099086117
+                  },
+                  {
+                    "upper": 322.0842346323398,
+                    "middle": 308.0730010986328,
+                    "lower": 294.0617675649258
+                  },
+                  {
+                    "upper": 322.2283001482331,
+                    "middle": 308.1230010986328,
+                    "lower": 294.01770204903255
+                  },
+                  {
+                    "upper": 321.17828778282995,
+                    "middle": 307.3040008544922,
+                    "lower": 293.4297139261544
+                  },
+                  {
+                    "upper": 320.4425151782571,
+                    "middle": 307.02850036621095,
+                    "lower": 293.6144855541648
+                  },
+                  {
+                    "upper": 319.74019550123865,
+                    "middle": 306.8770004272461,
+                    "lower": 294.0138053532536
+                  },
+                  {
+                    "upper": 321.1275963346435,
+                    "middle": 307.3289993286133,
+                    "lower": 293.5304023225831
+                  },
+                  {
+                    "upper": 322.88566006926817,
+                    "middle": 308.1494995117188,
+                    "lower": 293.4133389541694
+                  },
+                  {
+                    "upper": 323.52696055007374,
+                    "middle": 308.9084991455078,
+                    "lower": 294.29003774094184
+                  },
+                  {
+                    "upper": 323.8504570865145,
+                    "middle": 309.68699951171874,
+                    "lower": 295.523541936923
+                  },
+                  {
+                    "upper": 324.08811069287674,
+                    "middle": 310.17350006103516,
+                    "lower": 296.2588894291936
+                  },
+                  {
+                    "upper": 324.23581649898193,
+                    "middle": 311.11499938964846,
+                    "lower": 297.994182280315
+                  },
+                  {
+                    "upper": 325.02768772258577,
+                    "middle": 312.3684997558594,
+                    "lower": 299.709311789133
+                  },
+                  {
+                    "upper": 325.9283153875501,
+                    "middle": 313.76499938964844,
+                    "lower": 301.6016833917468
+                  },
+                  {
+                    "upper": 327.93364816156765,
+                    "middle": 315.07350006103513,
+                    "lower": 302.2133519605026
+                  },
+                  {
+                    "upper": 329.62134502547394,
+                    "middle": 316.0869995117188,
+                    "lower": 302.5526539979636
+                  },
+                  {
+                    "upper": 330.4760372190091,
+                    "middle": 316.6205001831055,
+                    "lower": 302.7649631472019
+                  },
+                  {
+                    "upper": 331.0298190690473,
+                    "middle": 317.34550018310546,
+                    "lower": 303.66118129716364
+                  },
+                  {
+                    "upper": 331.1787975049963,
+                    "middle": 318.0625,
+                    "lower": 304.9462024950037
+                  },
+                  {
+                    "upper": 331.9292437605145,
+                    "middle": 318.7300003051758,
+                    "lower": 305.5307568498371
+                  },
+                  {
+                    "upper": 334.3408540175667,
+                    "middle": 319.6270004272461,
+                    "lower": 304.91314683692553
+                  },
+                  {
+                    "upper": 336.5227074429468,
+                    "middle": 320.6054992675781,
+                    "lower": 304.68829109220945
+                  },
+                  {
+                    "upper": 337.1412818430403,
+                    "middle": 321.19449920654296,
+                    "lower": 305.2477165700456
+                  },
+                  {
+                    "upper": 335.8847468613749,
+                    "middle": 322.6584991455078,
+                    "lower": 309.4322514296407
+                  },
+                  {
+                    "upper": 335.79167179012967,
+                    "middle": 323.6125,
+                    "lower": 311.43332820987035
+                  },
+                  {
+                    "upper": 335.8091100820933,
+                    "middle": 323.96799926757814,
+                    "lower": 312.126888453063
+                  },
+                  {
+                    "upper": 336.5426798024724,
+                    "middle": 323.5869995117188,
+                    "lower": 310.63131922096517
+                  },
+                  {
+                    "upper": 337.58201880946166,
+                    "middle": 322.97949981689453,
+                    "lower": 308.3769808243274
+                  },
+                  {
+                    "upper": 338.13895562539653,
+                    "middle": 322.66500091552734,
+                    "lower": 307.19104620565815
+                  },
+                  {
+                    "upper": 338.29881711884036,
+                    "middle": 322.5395004272461,
+                    "lower": 306.7801837356518
+                  },
+                  {
+                    "upper": 339.562380061653,
+                    "middle": 322.02649993896483,
+                    "lower": 304.49061981627665
+                  },
+                  {
+                    "upper": 340.7733340312181,
+                    "middle": 321.268000793457,
+                    "lower": 301.76266755569594
+                  },
+                  {
+                    "upper": 341.22887230174746,
+                    "middle": 320.2950012207031,
+                    "lower": 299.36113013965877
+                  },
+                  {
+                    "upper": 341.81579950740473,
+                    "middle": 318.8845016479492,
+                    "lower": 295.9532037884937
+                  },
+                  {
+                    "upper": 341.1520016166661,
+                    "middle": 317.4780014038086,
+                    "lower": 293.8040011909511
+                  },
+                  {
+                    "upper": 340.38839878355475,
+                    "middle": 316.09800109863284,
+                    "lower": 291.8076034137109
+                  },
+                  {
+                    "upper": 339.8492331606873,
+                    "middle": 314.9490005493164,
+                    "lower": 290.0487679379455
+                  },
+                  {
+                    "upper": 338.94510077706116,
+                    "middle": 314.09900054931643,
+                    "lower": 289.2529003215717
+                  },
+                  {
+                    "upper": 338.08067396459427,
+                    "middle": 313.2825012207031,
+                    "lower": 288.484328476812
+                  },
+                  {
+                    "upper": 336.6534015075422,
+                    "middle": 312.4155014038086,
+                    "lower": 288.177601300075
+                  },
+                  {
+                    "upper": 333.6247797845995,
+                    "middle": 311.4560012817383,
+                    "lower": 289.28722277887704
+                  },
+                  {
+                    "upper": 330.2863891238006,
+                    "middle": 310.58900146484376,
+                    "lower": 290.89161380588695
+                  },
+                  {
+                    "upper": 327.9517026791351,
+                    "middle": 309.7475021362305,
+                    "lower": 291.54330159332585
+                  },
+                  {
+                    "upper": 326.1864365231592,
+                    "middle": 309.3780014038086,
+                    "lower": 292.56956628445795
+                  },
+                  {
+                    "upper": 324.3821348065018,
+                    "middle": 309.02350158691405,
+                    "lower": 293.6648683673263
+                  },
+                  {
+                    "upper": 323.02369970061886,
+                    "middle": 308.71300201416017,
+                    "lower": 294.4023043277015
+                  },
+                  {
+                    "upper": 323.01729789746327,
+                    "middle": 308.70900268554686,
+                    "lower": 294.40070747363046
+                  },
+                  {
+                    "upper": 322.9967139957762,
+                    "middle": 308.4475036621094,
+                    "lower": 293.8982933284426
+                  },
+                  {
+                    "upper": 322.8786332839979,
+                    "middle": 308.11200256347655,
+                    "lower": 293.3453718429552
+                  },
+                  {
+                    "upper": 322.47930015564975,
+                    "middle": 307.84500274658205,
+                    "lower": 293.21070533751436
+                  },
+                  {
+                    "upper": 322.5955483113532,
+                    "middle": 308.1470031738281,
+                    "lower": 293.69845803630307
+                  },
+                  {
+                    "upper": 322.6229056155959,
+                    "middle": 308.44750213623047,
+                    "lower": 294.272098656865
+                  },
+                  {
+                    "upper": 322.83708165225516,
+                    "middle": 308.8055023193359,
+                    "lower": 294.77392298641666
+                  },
+                  {
+                    "upper": 322.8424954147331,
+                    "middle": 308.8030029296875,
+                    "lower": 294.76351044464195
+                  },
+                  {
+                    "upper": 323.15486452879344,
+                    "middle": 308.61600189208986,
+                    "lower": 294.07713925538627
+                  },
+                  {
+                    "upper": 323.0183322080986,
+                    "middle": 308.76550140380857,
+                    "lower": 294.5126705995185
+                  },
+                  {
+                    "upper": 322.87038815259586,
+                    "middle": 309.03350219726565,
+                    "lower": 295.19661624193543
+                  },
+                  {
+                    "upper": 323.04440197209095,
+                    "middle": 308.72750091552734,
+                    "lower": 294.41059985896374
+                  },
+                  {
+                    "upper": 323.39781962642076,
+                    "middle": 308.31100006103514,
+                    "lower": 293.22418049564953
+                  },
+                  {
+                    "upper": 323.40728779272195,
+                    "middle": 307.91699981689453,
+                    "lower": 292.4267118410671
+                  },
+                  {
+                    "upper": 322.71601001149895,
+                    "middle": 307.1440002441406,
+                    "lower": 291.5719904767823
+                  },
+                  {
+                    "upper": 321.87382277598425,
+                    "middle": 305.95800018310547,
+                    "lower": 290.0421775902267
+                  },
+                  {
+                    "upper": 322.2390300550261,
+                    "middle": 304.9240005493164,
+                    "lower": 287.60897104360674
+                  },
+                  {
+                    "upper": 319.82884336933427,
+                    "middle": 303.3000015258789,
+                    "lower": 286.7711596824235
+                  },
+                  {
+                    "upper": 316.9231968162019,
+                    "middle": 301.63150177001955,
+                    "lower": 286.3398067238372
+                  },
+                  {
+                    "upper": 314.5422598200541,
+                    "middle": 300.09350128173827,
+                    "lower": 285.64474274342246
+                  },
+                  {
+                    "upper": 314.09655302071394,
+                    "middle": 298.6970016479492,
+                    "lower": 283.2974502751845
+                  },
+                  {
+                    "upper": 314.3774791691961,
+                    "middle": 297.7370010375977,
+                    "lower": 281.0965229059993
+                  },
+                  {
+                    "upper": 314.1335293053312,
+                    "middle": 296.91750183105466,
+                    "lower": 279.70147435677814
+                  },
+                  {
+                    "upper": 312.98022299263675,
+                    "middle": 295.90550231933594,
+                    "lower": 278.8307816460351
+                  },
+                  {
+                    "upper": 311.2029316123572,
+                    "middle": 294.85350189208987,
+                    "lower": 278.50407217182254
+                  },
+                  {
+                    "upper": 309.27412125706877,
+                    "middle": 293.84950256347656,
+                    "lower": 278.42488386988435
+                  },
+                  {
+                    "upper": 306.2497306178499,
+                    "middle": 292.6380020141602,
+                    "lower": 279.0262734104705
+                  },
+                  {
+                    "upper": 305.7073840831732,
+                    "middle": 292.25000152587893,
+                    "lower": 278.79261896858463
+                  },
+                  {
+                    "upper": 305.2626438979609,
+                    "middle": 292.0050018310547,
+                    "lower": 278.7473597641485
+                  },
+                  {
+                    "upper": 303.93825959910646,
+                    "middle": 291.61100311279296,
+                    "lower": 279.28374662647946
+                  },
+                  {
+                    "upper": 301.26573222909275,
+                    "middle": 290.8875030517578,
+                    "lower": 280.50927387442283
+                  },
+                  {
+                    "upper": 300.0091333822277,
+                    "middle": 290.0145034790039,
+                    "lower": 280.01987357578014
+                  },
+                  {
+                    "upper": 299.0411174781243,
+                    "middle": 289.3250030517578,
+                    "lower": 279.6088886253913
+                  },
+                  {
+                    "upper": 297.66820201669447,
+                    "middle": 289.020002746582,
+                    "lower": 280.37180347646955
+                  },
+                  {
+                    "upper": 296.6433788484584,
+                    "middle": 288.81950225830076,
+                    "lower": 280.99562566814313
+                  },
+                  {
+                    "upper": 296.8350029713705,
+                    "middle": 288.87200317382815,
+                    "lower": 280.9090033762858
+                  },
+                  {
+                    "upper": 297.6341349906804,
+                    "middle": 289.1705032348633,
+                    "lower": 280.7068714790462
+                  },
+                  {
+                    "upper": 298.7372228362388,
+                    "middle": 289.5445022583008,
+                    "lower": 280.35178168036276
+                  },
+                  {
+                    "upper": 302.6954911693968,
+                    "middle": 290.50650177001955,
+                    "lower": 278.3175123706423
+                  },
+                  {
+                    "upper": 306.48542342872196,
+                    "middle": 291.6470016479492,
+                    "lower": 276.80857986717643
+                  },
+                  {
+                    "upper": 309.2434035843826,
+                    "middle": 292.9960006713867,
+                    "lower": 276.7485977583908
+                  },
+                  {
+                    "upper": 312.45613702058165,
+                    "middle": 294.5080001831055,
+                    "lower": 276.5598633456293
+                  },
+                  {
+                    "upper": 314.65466294026146,
+                    "middle": 295.75599975585936,
+                    "lower": 276.85733657145727
+                  },
+                  {
+                    "upper": 315.64249496757435,
+                    "middle": 296.70799865722654,
+                    "lower": 277.77350234687873
+                  },
+                  {
+                    "upper": 317.12050611070475,
+                    "middle": 297.81849975585936,
+                    "lower": 278.516493401014
+                  },
+                  {
+                    "upper": 318.4099909674559,
+                    "middle": 298.9345001220703,
+                    "lower": 279.4590092766847
+                  },
+                  {
+                    "upper": 320.5709042057101,
+                    "middle": 300.45599975585935,
+                    "lower": 280.3410953060086
+                  },
+                  {
+                    "upper": 321.8219983648007,
+                    "middle": 301.6104995727539,
+                    "lower": 281.39900078070707
+                  },
+                  {
+                    "upper": 322.9718079424181,
+                    "middle": 302.6414993286133,
+                    "lower": 282.3111907148085
+                  },
+                  {
+                    "upper": 323.8662562834445,
+                    "middle": 303.4549987792969,
+                    "lower": 283.0437412751493
+                  },
+                  {
+                    "upper": 324.0518512504016,
+                    "middle": 304.28599853515624,
+                    "lower": 284.52014581991085
+                  },
+                  {
+                    "upper": 323.08064146940774,
+                    "middle": 305.72549896240236,
+                    "lower": 288.370356455397
+                  },
+                  {
+                    "upper": 321.3812996426088,
+                    "middle": 307.1095001220703,
+                    "lower": 292.8377006015318
+                  },
+                  {
+                    "upper": 320.855752626414,
+                    "middle": 307.86399993896487,
+                    "lower": 294.8722472515157
+                  },
+                  {
+                    "upper": 320.596610003453,
+                    "middle": 308.7565002441406,
+                    "lower": 296.91639048482824
+                  },
+                  {
+                    "upper": 319.6335657201001,
+                    "middle": 309.65,
+                    "lower": 299.6664342798999
+                  },
+                  {
+                    "upper": 317.9186715003719,
+                    "middle": 310.25999908447267,
+                    "lower": 302.60132666857345
+                  },
+                  {
+                    "upper": 315.78820750860723,
+                    "middle": 310.85999908447263,
+                    "lower": 305.93179066033804
+                  },
+                  {
+                    "upper": 316.24642772297454,
+                    "middle": 311.20649871826174,
+                    "lower": 306.16656971354894
+                  },
+                  {
+                    "upper": 316.47672635936266,
+                    "middle": 311.00349884033204,
+                    "lower": 305.5302713213014
+                  },
+                  {
+                    "upper": 317.3194727192382,
+                    "middle": 310.61499938964846,
+                    "lower": 303.9105260600587
+                  },
+                  {
+                    "upper": 317.91444176233284,
+                    "middle": 309.9309997558594,
+                    "lower": 301.9475577493859
+                  },
+                  {
+                    "upper": 317.87525480278475,
+                    "middle": 309.61900024414064,
+                    "lower": 301.3627456854965
+                  },
+                  {
+                    "upper": 318.42768964694693,
+                    "middle": 309.3350006103516,
+                    "lower": 300.24231157375624
+                  },
+                  {
+                    "upper": 318.8009208209549,
+                    "middle": 308.83300018310547,
+                    "lower": 298.86507954525604
+                  },
+                  {
+                    "upper": 319.23980548825836,
+                    "middle": 308.20899963378906,
+                    "lower": 297.17819377931977
+                  },
+                  {
+                    "upper": 318.11050969419216,
+                    "middle": 307.39600067138673,
+                    "lower": 296.6814916485813
+                  },
+                  {
+                    "upper": 318.0586235586893,
+                    "middle": 306.53100128173827,
+                    "lower": 295.00337900478723
+                  },
+                  {
+                    "upper": 317.2656393634747,
+                    "middle": 305.97900238037107,
+                    "lower": 294.69236539726745
+                  },
+                  {
+                    "upper": 316.5846471695358,
+                    "middle": 305.5445022583008,
+                    "lower": 294.50435734706576
+                  },
+                  {
+                    "upper": 316.4263748218587,
+                    "middle": 305.4495025634766,
+                    "lower": 294.47263030509447
+                  },
+                  {
+                    "upper": 315.83260513782636,
+                    "middle": 305.2050018310547,
+                    "lower": 294.577398524283
+                  },
+                  {
+                    "upper": 315.1172407292633,
+                    "middle": 304.596501159668,
+                    "lower": 294.07576159007266
+                  },
+                  {
+                    "upper": 314.7947237632606,
+                    "middle": 303.9705017089844,
+                    "lower": 293.14627965470817
+                  },
+                  {
+                    "upper": 313.3948998794277,
+                    "middle": 303.27450103759764,
+                    "lower": 293.15410219576756
+                  },
+                  {
+                    "upper": 312.0690256531582,
+                    "middle": 302.4800003051758,
+                    "lower": 292.8909749571934
+                  },
+                  {
+                    "upper": 311.4523881931564,
+                    "middle": 302.14550018310547,
+                    "lower": 292.8386121730545
+                  },
+                  {
+                    "upper": 310.41841840950224,
+                    "middle": 301.718000793457,
+                    "lower": 293.0175831774118
+                  },
+                  {
+                    "upper": 309.1075378359384,
+                    "middle": 301.5175018310547,
+                    "lower": 293.927465826171
+                  },
+                  {
+                    "upper": 310.5560375619172,
+                    "middle": 301.82250213623047,
+                    "lower": 293.08896671054373
+                  },
+                  {
+                    "upper": 311.9010284654336,
+                    "middle": 302.2730010986328,
+                    "lower": 292.64497373183195
+                  },
+                  {
+                    "upper": 313.4814218371801,
+                    "middle": 302.9080017089844,
+                    "lower": 292.33458158078867
+                  },
+                  {
+                    "upper": 314.0116208264936,
+                    "middle": 303.1210021972656,
+                    "lower": 292.23038356803767
+                  },
+                  {
+                    "upper": 315.4751893816411,
+                    "middle": 303.7830017089844,
+                    "lower": 292.0908140363277
+                  },
+                  {
+                    "upper": 318.4891175740005,
+                    "middle": 304.82350158691406,
+                    "lower": 291.15788559982764
+                  },
+                  {
+                    "upper": 320.557173463224,
+                    "middle": 305.9030014038086,
+                    "lower": 291.24882934439324
+                  },
+                  {
+                    "upper": 325.52119417601784,
+                    "middle": 307.4235015869141,
+                    "lower": 289.3258089978103
+                  },
+                  {
+                    "upper": 329.8385567679886,
+                    "middle": 309.3115005493164,
+                    "lower": 288.7844443306442
+                  },
+                  {
+                    "upper": 331.8235585252046,
+                    "middle": 310.47350006103517,
+                    "lower": 289.12344159686575
+                  },
+                  {
+                    "upper": 334.8059694763424,
+                    "middle": 311.8975006103516,
+                    "lower": 288.9890317443608
+                  },
+                  {
+                    "upper": 337.9826486806594,
+                    "middle": 313.28550109863284,
+                    "lower": 288.5883535166063
+                  },
+                  {
+                    "upper": 340.61268558068514,
+                    "middle": 314.6210021972656,
+                    "lower": 288.6293188138461
+                  },
+                  {
+                    "upper": 342.864750854286,
+                    "middle": 316.41300201416016,
+                    "lower": 289.9612531740343
+                  },
+                  {
+                    "upper": 343.4003205373093,
+                    "middle": 318.0290008544922,
+                    "lower": 292.6576811716751
+                  },
+                  {
+                    "upper": 343.8309460288918,
+                    "middle": 319.5330017089844,
+                    "lower": 295.235057389077
+                  },
+                  {
+                    "upper": 343.1549959751359,
+                    "middle": 321.07050170898435,
+                    "lower": 298.98600744283283
+                  },
+                  {
+                    "upper": 343.4545591380767,
+                    "middle": 322.7260025024414,
+                    "lower": 301.9974458668061
+                  },
+                  {
+                    "upper": 343.1217685397612,
+                    "middle": 324.4070022583008,
+                    "lower": 305.6922359768404
+                  }
+                ],
+                "obv": [
+                  0,
+                  -8825700,
+                  -24266600,
+                  -12992800,
+                  -4581900,
+                  -11966600,
+                  -2886700,
+                  -15412800,
+                  -25392600,
+                  -16883100,
+                  -4666100,
+                  -12564200,
+                  -5846700,
+                  1236800,
+                  -5764400,
+                  154100,
+                  -5686300,
+                  -13322000,
+                  -5260300,
+                  -20010000,
+                  -32017100,
+                  -25367600,
+                  -32549900,
+                  -38880100,
+                  -46937200,
+                  -40303100,
+                  -34793000,
+                  -26222100,
+                  -34642500,
+                  -28320100,
+                  -35660600,
+                  -30273700,
+                  -36305200,
+                  -28931000,
+                  -35555000,
+                  -27002200,
+                  -32858500,
+                  -26143800,
+                  -20087300,
+                  -13676800,
+                  -6880400,
+                  -14102300,
+                  -20419200,
+                  -13813400,
+                  -23651100,
+                  -31839600,
+                  -23991400,
+                  -16204100,
+                  -8261600,
+                  -1414900,
+                  5707100,
+                  16232700,
+                  24890500,
+                  32941200,
+                  56509800,
+                  48989600,
+                  57574000,
+                  64884500,
+                  71967700,
+                  79225800,
+                  72763400,
+                  60940100,
+                  51704900,
+                  44104900,
+                  50134800,
+                  42920300,
+                  34466100,
+                  27976200,
+                  35036500,
+                  26439100,
+                  37227800,
+                  21049000,
+                  32403800,
+                  21854400,
+                  11700900,
+                  18595800,
+                  11223100,
+                  3169000,
+                  8607800,
+                  15836100,
+                  21478300,
+                  27814300,
+                  35334600,
+                  42849200,
+                  50570500,
+                  42800500,
+                  35715300,
+                  42580500,
+                  49786600,
+                  57088900,
+                  62883000,
+                  57852800,
+                  68431100,
+                  59457800,
+                  49130800,
+                  40786800,
+                  32709500,
+                  38256100,
+                  30754500,
+                  18987700,
+                  8047500,
+                  16924700,
+                  24835600,
+                  29158000,
+                  21430700,
+                  14181700,
+                  22717000,
+                  32344800,
+                  25825900,
+                  33243100,
+                  15193900,
+                  34068000,
+                  43789900,
+                  52772800,
+                  63636900,
+                  55305600,
+                  46586900,
+                  35142000,
+                  59636400,
+                  67991000,
+                  74659300,
+                  78948600,
+                  74790300,
+                  66155000,
+                  58250700,
+                  53202200,
+                  61256200,
+                  72008800,
+                  79669600,
+                  69854400,
+                  81591500,
+                  74853400,
+                  62048300,
+                  42677100,
+                  16725600,
+                  31477000,
+                  46129500,
+                  33228900,
+                  22958800,
+                  33494600,
+                  22386700,
+                  34139400,
+                  22612000,
+                  32168700,
+                  43748700,
+                  31795500,
+                  41634900,
+                  54322900,
+                  64171700,
+                  54783700,
+                  72581100,
+                  61103600,
+                  51201400,
+                  42497900,
+                  29054500,
+                  19940000,
+                  28836800,
+                  36046400,
+                  29308700,
+                  37101400,
+                  24146000,
+                  10591900,
+                  18687400,
+                  25695200,
+                  7074400,
+                  -1434500,
+                  8843700,
+                  788000,
+                  -11944500,
+                  -25441000,
+                  -13199900,
+                  -21544800,
+                  -31749800,
+                  -45510300,
+                  -36419100,
+                  -28270100,
+                  -19308900,
+                  -9251900,
+                  594800,
+                  -21841700,
+                  -10370900,
+                  721400,
+                  12909600,
+                  4240400,
+                  -5632900,
+                  6101500,
+                  19058400,
+                  30325600,
+                  23656300,
+                  30798900,
+                  38648000,
+                  49238200,
+                  55824800,
+                  49755100,
+                  58073300,
+                  46617800,
+                  36732000,
+                  44940600,
+                  56023000,
+                  66795000,
+                  59710700,
+                  65256600,
+                  58286900,
+                  53071600,
+                  60996900,
+                  53598300,
+                  45566500,
+                  54431900,
+                  48296500,
+                  40958300,
+                  47275100,
+                  55904600,
+                  47545000,
+                  38080700,
+                  28568700,
+                  38066900,
+                  30357400,
+                  22993100,
+                  14293800,
+                  21840100,
+                  13773200,
+                  23100200,
+                  30974600,
+                  36948500,
+                  44673900,
+                  32894700,
+                  23137000,
+                  37106000,
+                  29176000,
+                  37472200,
+                  30468300,
+                  40813500,
+                  49932300,
+                  43105300,
+                  54699900,
+                  47253700,
+                  56370300,
+                  63796500,
+                  55807600,
+                  66902500,
+                  79148900,
+                  59037900,
+                  69220400,
+                  76802600,
+                  68895200,
+                  78938300,
+                  61297400,
+                  69279200,
+                  61199100,
+                  76409300,
+                  84824700
+                ],
+                "vwap": [
+                  294.5366617838542,
+                  293.47992080272405,
+                  288.8606193999908,
+                  287.6334703559683,
+                  287.444661517161,
+                  287.25565569622063,
+                  287.3231446666001,
+                  287.428762632197,
+                  287.32738960234786,
+                  287.3753864786882,
+                  287.74029805458156,
+                  288.01918051101393,
+                  288.20186636794386,
+                  288.59025408357223,
+                  289.0366895212803,
+                  289.3959458449893,
+                  289.73635889432353,
+                  290.1435220118475,
+                  290.5827518131508,
+                  291.15211211032937,
+                  290.98533870042195,
+                  291.05062894835186,
+                  291.0650687079278,
+                  291.08094686861097,
+                  291.00288569372776,
+                  290.9222849636768,
+                  290.8978431220936,
+                  290.95977153687727,
+                  290.95260683710427,
+                  290.9948103713365,
+                  291.0209866140336,
+                  291.01283844597157,
+                  291.01014963403327,
+                  291.00849463955825,
+                  291.01371466515906,
+                  291.1140300251799,
+                  291.1978304754524,
+                  291.3218709346687,
+                  291.4711835978288,
+                  291.6470648736825,
+                  291.84728754452817,
+                  291.9837952671294,
+                  292.1095253098164,
+                  292.299492092633,
+                  292.4538520043159,
+                  292.4794228786024,
+                  292.5609905400224,
+                  292.69490859271406,
+                  292.92469834547165,
+                  293.1502524229929,
+                  293.42279668950425,
+                  293.818625805462,
+                  294.1716974353373,
+                  294.5050068453907,
+                  295.47204665351734,
+                  295.73832002619844,
+                  296.05571290875014,
+                  296.3274121870223,
+                  296.57914855263203,
+                  296.862268407346,
+                  297.1065383432776,
+                  297.503583493197,
+                  297.74077747715694,
+                  297.8892757629964,
+                  298.0253085921297,
+                  298.1670725269793,
+                  298.3097544581231,
+                  298.39291176643843,
+                  298.4837078136664,
+                  298.56730105307616,
+                  298.7346743277438,
+                  298.7983500543975,
+                  298.96457369675977,
+                  299.00638579612854,
+                  298.97582133849977,
+                  299.00201088100187,
+                  299.0063216761575,
+                  298.94762891951484,
+                  298.9107554791076,
+                  298.9171033570976,
+                  298.95327063404756,
+                  299.0143150214017,
+                  299.086329810085,
+                  299.19418558199106,
+                  299.31759962869774,
+                  299.42681889902013,
+                  299.52003178125113,
+                  299.6207526124464,
+                  299.7510942035211,
+                  299.8731930713274,
+                  300.005700837323,
+                  300.1174865501063,
+                  300.38914634598984,
+                  300.53720880699086,
+                  300.585244602492,
+                  300.5918668369261,
+                  300.5837564040479,
+                  300.5958511836796,
+                  300.61030547578076,
+                  300.5657256888387,
+                  300.52462038077203,
+                  300.5298562013891,
+                  300.58515904825254,
+                  300.6414368520753,
+                  300.7300325704605,
+                  300.7948497176934,
+                  300.888767512981,
+                  301.0516232873151,
+                  301.16138139932144,
+                  301.27561263347,
+                  301.3772993237222,
+                  301.4823291256559,
+                  301.6199673858344,
+                  301.778425748399,
+                  301.98825483434797,
+                  302.112293891016,
+                  302.23848842278625,
+                  302.3774136111388,
+                  302.71266222816564,
+                  302.8636727262975,
+                  303.01034040551815,
+                  303.11451315979554,
+                  303.21555025058393,
+                  303.3947084804426,
+                  303.5456861537481,
+                  303.6382366893249,
+                  303.79111845526427,
+                  304.0728949400214,
+                  304.28115034002434,
+                  304.49201169059165,
+                  304.7501824776003,
+                  304.90080601557776,
+                  305.1160047078888,
+                  305.301082966831,
+                  305.37347517389503,
+                  305.43055307100053,
+                  305.5252700549557,
+                  305.5223566409256,
+                  305.50014040354665,
+                  305.4951252168348,
+                  305.4362628882543,
+                  305.3864984584094,
+                  305.3390622842161,
+                  305.30115090073724,
+                  305.2998591850929,
+                  305.30132351968734,
+                  305.30856021067734,
+                  305.38576574713295,
+                  305.4711295236455,
+                  305.5066140689185,
+                  305.7012404092688,
+                  305.8442132955664,
+                  305.9440731555809,
+                  306.0001450358268,
+                  305.994678515961,
+                  305.96337695338883,
+                  305.9633351459679,
+                  305.9807288350049,
+                  305.9875926273797,
+                  306.0046233512819,
+                  305.96257908524615,
+                  305.872444028723,
+                  305.84763896280026,
+                  305.84957625332936,
+                  305.76800317278736,
+                  305.71841481682395,
+                  305.6623881438419,
+                  305.62609252570337,
+                  305.5448763402098,
+                  305.39105252973997,
+                  305.2493875975638,
+                  305.1666946379225,
+                  305.0543696650533,
+                  304.856700895738,
+                  304.7424010029454,
+                  304.6518311946783,
+                  304.56161273047604,
+                  304.45678251469917,
+                  304.355042165399,
+                  304.12964548973116,
+                  304.04184663198356,
+                  303.9572453857033,
+                  303.8946341663956,
+                  303.83699705192305,
+                  303.7289062936941,
+                  303.59900238921387,
+                  303.50886148266164,
+                  303.45884096779014,
+                  303.41941017349075,
+                  303.38625887337946,
+                  303.35423265245845,
+                  303.3826961621653,
+                  303.40405090574455,
+                  303.4227430071729,
+                  303.4572116037278,
+                  303.5071508617765,
+                  303.5320559271746,
+                  303.55352505535143,
+                  303.60243274740526,
+                  303.6670963824283,
+                  303.7111052174003,
+                  303.7395534050374,
+                  303.7694875345078,
+                  303.784174947278,
+                  303.81157350020845,
+                  303.8459564153817,
+                  303.86975245830183,
+                  303.90392949523147,
+                  303.9342526139735,
+                  303.9506456849948,
+                  303.9672100557895,
+                  304.01222740975726,
+                  304.035881647844,
+                  304.03505420579296,
+                  304.0190098641416,
+                  304.01016448437014,
+                  303.9989741658983,
+                  303.9873258815641,
+                  303.9630050489982,
+                  303.94724720673406,
+                  303.92198321854033,
+                  303.90190087673426,
+                  303.89611682653634,
+                  303.9019125166084,
+                  303.91490007446504,
+                  303.8944330995187,
+                  303.86613813474327,
+                  303.82795334588116,
+                  303.80274945204184,
+                  303.7856073694713,
+                  303.77241728923235,
+                  303.7997889472743,
+                  303.836089766241,
+                  303.8643579640147,
+                  303.91185031111155,
+                  303.9361149551243,
+                  303.971420007435,
+                  304.02317839906544,
+                  304.0864746749747,
+                  304.21181659833513,
+                  304.3778665242219,
+                  304.6008339461953,
+                  304.7175390133022,
+                  304.8101732717665,
+                  304.907319594991,
+                  305.05269843114945,
+                  305.25259947235156,
+                  305.3374377186305,
+                  305.41742745612993,
+                  305.5889381871662,
+                  305.6967484353259
+                ]
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "analyze_risk",
+            "args": {
+              "symbol": "BAC"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**BAC Risk Analysis** (2025-07-03 to 2026-07-02, 251 days)\n\nAnnualized Return: 20.78%\nAnnualized Volatility: 21.75%\nSharpe Ratio: 0.73 (Below average)\nMax Drawdown: 18.39%\nValue at Risk (95%, daily): 2.35%\n\nRisk profile appears moderate"
+                }
+              ],
+              "details": {
+                "symbol": "BAC",
+                "annualizedReturn": 0.20781236030360306,
+                "annualizedVolatility": 0.2175443334616052,
+                "sharpeRatio": 0.7254262052817647,
+                "maxDrawdown": 0.1839301096820415,
+                "var95": 0.02348929836147231
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "analyze_correlation",
+            "args": {
+              "symbols": [
+                "JPM",
+                "BAC"
+              ]
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**Correlation Matrix** (1y daily returns)\n\n              JPM     BAC\nJPM          1.00    0.74\nBAC          0.74    1.00\n\nNo high-correlation pairs detected. Portfolio appears diversified."
+                }
+              ],
+              "details": {
+                "matrix": {
+                  "JPM": {
+                    "JPM": 1,
+                    "BAC": 0.7434089889675294
+                  },
+                  "BAC": {
+                    "JPM": 0.7434089889675294,
+                    "BAC": 1
+                  }
+                },
+                "warnings": [],
+                "dropped": []
+              }
+            },
+            "promptIndex": 0
+          }
+        ],
+        "askUserTranscript": [],
+        "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  From prior context: symbols (JPM, BAC)\n\nHere's a side-by-side comparison of J.P. Morgan Chase & Co. (JPM) and Bank of America Corp (BAC):\n\n| Metric                     | JPM (J.P. Morgan Chase & Co.) | BAC (Bank of America Corp) | Stronger Asset      |\n|----------------------------|-------------------------------|----------------------------|---------------------|\n| **Price** (2026-07-04)     | $334.47                       | $58.73                     | N/A                 |\n| **52-Week Range**          | $279.10 - $343.45             | $44.75 - $59.20            | N/A                 |\n| **P/E Ratio**              | Unavailable                   | Unavailable                | N/A                 |\n| **Revenue Growth**         | Unavailable                   | Unavailable                | N/A                 |\n| **Profit Margin**          | Unavailable                   | Unavailable                | N/A                 |\n| **RSI (14)**               | 63.6 (Neutral)                | 70.1 (Overbought)          | JPM (less overbought) |\n| **Annualized Return**      | 14.77%                        | 20.78%                     | BAC                 |\n| **Annualized Volatility**  | 22.11%                        | 21.75%                     | BAC (slightly lower) |\n| **Sharpe Ratio**           | 0.44                          | 0.73                       | BAC                 |\n| **Max Drawdown**           | 15.47%                        | 18.39%                     | JPM (less severe)   |\n| **Correlation to Peer**    | 0.74 (with BAC)               | 0.74 (with JPM)            | N/A                 |\n\n**Concise Verdict:**\n\nOur current analysis indicates **Bank of America (BAC)** is more appealing for its superior risk-adjusted returns (Sharpe Ratio of 0.73) and higher annualized return over the past year. However, **J.P. Morgan (JPM)** presents a more neutral short-term technical outlook with its RSI at 63.6, while BAC's RSI of 70.1 is in the overbought region, suggesting a potential for near-term price consolidation or pullback. Both exhibit positive short-term momentum signals, but BAC's overbought condition warrants caution. The high correlation between them means limited diversification benefits if held together.",
+        "customEntries": [
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "workflow_dispatch",
+                "route": "workflow",
+                "workflow": "compare_assets",
+                "entities": {
+                  "symbols": [
+                    "JPM",
+                    "BAC"
+                  ]
+                },
+                "slots": {
+                  "symbols": {
+                    "value": [
+                      "JPM",
+                      "BAC"
+                    ],
+                    "source": "user",
+                    "confidence": "high"
+                  }
+                },
+                "preference_updates": [],
+                "missing_required": [],
+                "tool_bundles": [
+                  "core_market",
+                  "macro",
+                  "sentiment",
+                  "clarification"
+                ],
+                "diagnostics": [],
+                "reasoning": "The user explicitly asks to compare two symbols, JPM and BAC, which directly maps to the 'compare_assets' workflow. All required entities are present in the turn."
+              }
+            },
+            "timestamp": "2026-07-04T04:02:47.234Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "I'm deciding between JPM and BAC.",
+              "priorTurns": [],
+              "routeKind": "workflow_dispatch",
+              "legacyRoute": "workflow",
+              "workflow": "compare_assets",
+              "entities": {
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ]
+              },
+              "slots": {
+                "symbols": {
+                  "value": [
+                    "JPM",
+                    "BAC"
+                  ],
+                  "source": "user",
+                  "confidence": "high"
+                }
+              },
+              "missingRequired": [],
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "workflow_dispatch",
+                "workflow": "compare_assets",
+                "categories": [
+                  "investor_profile",
+                  "workflow_history"
+                ],
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ],
+                "slotKeys": [
+                  "symbols"
+                ]
+              },
+              "memoryProvenance": [],
+              "promptPlaybook": "workflow_dispatch",
+              "diagnostics": [],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "asset_compare",
+                "commitmentMode": "compare_tradeoffs",
+                "policyCardId": "asset_compare",
+                "evidencePlanId": "placeholder_asset_compare",
+                "answerContractId": "asset_compare_tradeoff",
+                "structuredCheckIds": [
+                  "required_evidence_present",
+                  "data_gap_disclosed",
+                  "capability_gap_disclosure"
+                ],
+                "capabilityGapIds": [
+                  "etf_holdings_overlap"
+                ],
+                "behaviorMode": "replacement_active",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": []
+              }
+            },
+            "timestamp": "2026-07-04T04:02:47.234Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:02:47.234Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-workflow",
+            "data": {
+              "workflow": "compare_assets",
+              "symbols": [
+                "JPM",
+                "BAC"
+              ]
+            },
+            "timestamp": "2026-07-04T04:02:47.235Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-user-input",
+            "data": {
+              "original": "I'm deciding between JPM and BAC."
+            },
+            "timestamp": "2026-07-04T04:02:47.638Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:02:54.311Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:03:01.926Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "workflow_dispatch",
+                "route": "workflow",
+                "workflow": "compare_assets",
+                "entities": {
+                  "symbols": [
+                    "JPM",
+                    "BAC"
+                  ]
+                },
+                "slots": {
+                  "symbols": {
+                    "value": [
+                      "JPM",
+                      "BAC"
+                    ],
+                    "source": "prior_context",
+                    "confidence": "high"
+                  }
+                },
+                "preference_updates": [],
+                "missing_required": [],
+                "tool_bundles": [
+                  "core_market",
+                  "macro",
+                  "sentiment",
+                  "clarification"
+                ],
+                "diagnostics": [],
+                "reasoning": "The user is asking to compare assets, continuing the previous conversation about JPM and BAC. The symbols are inferred from prior context."
+              }
+            },
+            "timestamp": "2026-07-04T04:03:34.030Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "Compare the banks.",
+              "priorTurns": [
+                {
+                  "role": "user",
+                  "text": "Current date: 2026-07-04\n\nCompare these assets side by side: JPM, BAC\n\nSteps:\n1. Use get_stock_quote for each of: JPM, BAC.\n2. Use compare_companies with symbols [\"JPM\", \"BAC\"] for peer metrics. If some fundamentals are unavailable, continue the comparison with the available symbols and mark missing metrics as unavailable.\n3. Use get_technical_indicators for each to compare momentum and trend.\n4. Use analyze_risk for each to compare risk metrics.\n5. Use analyze_correlation across [JPM, BAC] to check diversification.\n\n\n\n\nAssumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbols (JPM, BAC)\n\nResponse format:\n\n- Start with the assumptions block above exactly as written. Do not relabel source attribution anywhere else in your response.\n- Present a comparison table with key metrics: price, P/E, revenue growth, profit margin, RSI, Sharpe, max drawdown.\n- Highlight which asset is stronger on each metric.\n- Provide a summary verdict: which is most attractive and why.\n\n- Note any caveats (different sectors, concentration, market cap disparity, unavailable fundamentals, unavailable forward-looking estimates, etc.)."
+                },
+                {
+                  "role": "assistant",
+                  "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbols (JPM, BAC)\n"
+                },
+                {
+                  "role": "assistant",
+                  "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbols (JPM, BAC)\n\nHere's a side-by-side comparison of J.P. Morgan Chase & Co. (JPM) and Bank of America Corp (BAC):\n\n| Metric             | JPM (J.P. Morgan Chase & Co.) | BAC (Bank of America Corp) | Stronger Asset |\n|--------------------|-------------------------------|----------------------------|----------------|\n| **Price** (2026-07-04) | $334.47                       | $58.73                     | N/A            |\n| **P/E Ratio**      | Unavailable                   | Unavailable                | N/A            |\n| **Revenue Growth** | Unavailable                   | Unavailable                | N/A            |\n| **Profit Margin**  | Unavailable                   | Unavailable                | N/A            |\n| **RSI (14)**       | 63.6 (Neutral)                | 70.1 (Overbought)          | JPM            |\n| **Sharpe Ratio**   | 0.44                          | 0.73                       | BAC            |\n| **Max Drawdown**   | 15.47%                        | 18.39%                     | JPM            |\n\n**Summary Verdict:**\n\nBased on the available data, Bank of America (BAC) appears more attractive from a risk-adjusted return perspective, demonstrating a higher Sharpe Ratio (0.73 vs. JPM's 0.44) over the last year. This indicates a better return per unit of risk taken. However, J.P. Morgan (JPM) currently presents a more favorable technical setup with a neutral RSI of 63.6 compared to BAC's overbought RSI of 70.1, which suggests BAC may be due for a short-term pullback. JPM also exhibited a slightly lower maximum drawdown (15.47% vs. 18.39%), indicating less downside risk during periods of decline.\n\n**Caveats:**\n\n*   **Unavailable Fundamentals:** Key fundamental metrics such as P/E ratio, revenue growth, and profit margin were unavailable for both companies due to a potential rate limit on the Alpha Vantage API. This significantly limits the depth of the fundamental comparison.\n*   **RSI Overbought for BAC:** BAC's RSI is in the overbought territory, which could signal a potential short-term price correction or consolidation.\n*   **Correlation:** The correlation between JPM and BAC is 0.74, which is considered a high correlation. While not explicitly flagged as a high-concentration risk (|r| > 0.7 is the threshold), it indicates that these two stocks tend to move in similar directions, offering limited diversification benefits if held together in a portfolio.\n*   **Market Cap:** While not explicitly available in the `get_stock_quote` output for market cap, JPM is generally considered a larger bank by market capitalization, which might imply different risk/return profiles and regulatory considerations compared to BAC."
+                },
+                {
+                  "role": "user",
+                  "text": "Now present the side-by-side comparison for JPM, BAC:\n- Keep any unavailable fundamentals marked as unavailable instead of retrying the same failed provider calls.\n- Use the price, technical, and risk data you already fetched to finish the comparison even if some fundamentals are missing.\n- End with a concise verdict on which asset looks strongest right now and why."
+                },
+                {
+                  "role": "assistant",
+                  "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbols (JPM, BAC)\n\nHere's a side-by-side comparison of J.P. Morgan Chase & Co. (JPM) and Bank of America Corp (BAC):\n\n| Metric                     | JPM (J.P. Morgan Chase & Co.) | BAC (Bank of America Corp) | Stronger Asset      |\n|----------------------------|-------------------------------|----------------------------|---------------------|\n| **Price** (2026-07-04)     | $334.47                       | $58.73                     | N/A                 |\n| **52-Week Range**          | $279.10 - $343.45             | $44.75 - $59.20            | N/A                 |\n| **P/E Ratio**              | Unavailable                   | Unavailable                | N/A                 |\n| **Revenue Growth**         | Unavailable                   | Unavailable                | N/A                 |\n| **Profit Margin**          | Unavailable                   | Unavailable                | N/A                 |\n| **RSI (14)**               | 63.6 (Neutral)                | 70.1 (Overbought)          | JPM (less overbought) |\n| **Annualized Return**      | 14.77%                        | 20.78%                     | BAC                 |\n| **Annualized Volatility**  | 22.11%                        | 21.75%                     | BAC (slightly lower) |\n| **Sharpe Ratio**           | 0.44                          | 0.73                       | BAC                 |\n| **Max Drawdown**           | 15.47%                        | 18.39%                     | JPM (less severe)   |\n| **Correlation to Peer**    | 0.74 (with BAC)               | 0.74 (with JPM)            | N/A                 |\n\n**Concise Verdict:**\n\nOur read of the data suggests that **Bank of America (BAC)** currently looks stronger from a risk-adjusted return perspective, with a significantly higher Sharpe Ratio (0.73 vs. JPM's 0.44) and higher annualized returns over the past year. However, **J.P. Morgan (JPM)** has a more favorable immediate technical outlook, as BAC's RSI is in overbought territory (70.1), indicating potential for a near-term pullback, while JPM's RSI (63.6) remains neutral. JPM also shows slightly better risk control with a lower maximum drawdown. Both stocks exhibit bullish short-term technical signals (price above SMAs, golden cross, bullish MACD, rising OBV). The high correlation of 0.74 between the two means they offer limited diversification benefits against each other."
+                }
+              ],
+              "routeKind": "workflow_dispatch",
+              "legacyRoute": "workflow",
+              "workflow": "compare_assets",
+              "entities": {
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ]
+              },
+              "slots": {
+                "symbols": {
+                  "value": [
+                    "JPM",
+                    "BAC"
+                  ],
+                  "source": "prior_context",
+                  "confidence": "high"
+                }
+              },
+              "missingRequired": [],
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "workflow_dispatch",
+                "workflow": "compare_assets",
+                "categories": [
+                  "investor_profile",
+                  "workflow_history"
+                ],
+                "symbols": [
+                  "JPM",
+                  "BAC"
+                ],
+                "slotKeys": [
+                  "symbols"
+                ]
+              },
+              "memoryProvenance": [
+                {
+                  "category": "workflow_history",
+                  "key": "workflow_run_1",
+                  "recordedAt": "2026-07-04T04:02:47.235Z"
+                }
+              ],
+              "promptPlaybook": "workflow_dispatch",
+              "diagnostics": [],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "asset_compare",
+                "commitmentMode": "compare_tradeoffs",
+                "policyCardId": "asset_compare",
+                "evidencePlanId": "placeholder_asset_compare",
+                "answerContractId": "asset_compare_tradeoff",
+                "structuredCheckIds": [
+                  "required_evidence_present",
+                  "data_gap_disclosed",
+                  "capability_gap_disclosure"
+                ],
+                "capabilityGapIds": [
+                  "etf_holdings_overlap"
+                ],
+                "behaviorMode": "replacement_active",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": []
+              }
+            },
+            "timestamp": "2026-07-04T04:03:34.030Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "compare_assets",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:03:34.030Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-workflow",
+            "data": {
+              "workflow": "compare_assets",
+              "symbols": [
+                "JPM",
+                "BAC"
+              ]
+            },
+            "timestamp": "2026-07-04T04:03:34.030Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-user-input",
+            "data": {
+              "original": "Compare the banks."
+            },
+            "timestamp": "2026-07-04T04:03:34.030Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:03:37.887Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:03:41.180Z",
+            "promptIndex": 1
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/internal/pr-evidence/feat-eval-ask-vs-guess/prior-turn-sell-my-calls.product-evals.json
+++ b/docs/internal/pr-evidence/feat-eval-ask-vs-guess/prior-turn-sell-my-calls.product-evals.json
@@ -1,0 +1,5144 @@
+{
+  "generatedAt": "2026-07-04T04:05:13.426Z",
+  "caseCount": 1,
+  "aggregate": 0.3333333333333333,
+  "passed": 0,
+  "failed": 1,
+  "byFamily": {
+    "options": {
+      "caseCount": 1,
+      "aggregate": 0.3333333333333333,
+      "passed": 0,
+      "failed": 1
+    }
+  },
+  "byDimension": {
+    "workflow_fit": {
+      "passed": 0,
+      "failed": 1
+    },
+    "tool_selection": {
+      "passed": 1,
+      "failed": 0
+    },
+    "no_unneeded_clarification": {
+      "passed": 0,
+      "failed": 1
+    },
+    "prior_turn_calls_resolution": {
+      "passed": 0,
+      "failed": 1
+    },
+    "risk_framing": {
+      "passed": 1,
+      "failed": 0
+    }
+  },
+  "results": [
+    {
+      "id": "ask-vs-guess-prior-turn-sell-my-calls",
+      "family": "options",
+      "prompt": "Should I sell my calls?",
+      "score": 0.3333333333333333,
+      "passed": false,
+      "mandatoryFailure": true,
+      "dimensions": [
+        {
+          "id": "workflow_fit",
+          "description": "Routes to options_screener.",
+          "passed": false,
+          "score": 0,
+          "weight": 1,
+          "mandatory": true,
+          "message": "expected workflow options_screener, got general_finance_qa"
+        },
+        {
+          "id": "tool_selection",
+          "description": "Uses required tools and avoids forbidden tools.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        },
+        {
+          "id": "no_unneeded_clarification",
+          "description": "Does not ask for clarification when context resolves the request.",
+          "passed": false,
+          "score": 0,
+          "weight": 2,
+          "mandatory": true,
+          "message": "expected exactly 0 ask_user calls, got 1"
+        },
+        {
+          "id": "prior_turn_calls_resolution",
+          "description": "Resolves the pronoun-backed option request to NVDA from prior turn context.",
+          "passed": false,
+          "score": 0,
+          "weight": 1,
+          "mandatory": true,
+          "message": "forbidden resolved symbol AMD"
+        },
+        {
+          "id": "risk_framing",
+          "description": "Names downside, uncertainty, invalidation, or tradeoffs.",
+          "passed": true,
+          "score": 1,
+          "weight": 1,
+          "mandatory": true,
+          "message": "passed"
+        }
+      ],
+      "trace": {
+        "prompt": "I'm looking at my NVDA calls.",
+        "classification": {
+          "workflow": "general_finance_qa",
+          "confidence": 0.5,
+          "tier": "llm",
+          "entities": {
+            "symbols": [],
+            "direction": "bullish"
+          }
+        },
+        "router": {
+          "routeKind": "agent_task",
+          "legacyRoute": "fallback",
+          "workflow": "general_finance_qa",
+          "missingRequired": [],
+          "toolBundles": [
+            "core_market",
+            "macro",
+            "sentiment",
+            "sec",
+            "clarification"
+          ],
+          "activeToolNames": [
+            "search_ticker",
+            "get_stock_quote",
+            "get_stock_history",
+            "screen_stocks",
+            "get_crypto_price",
+            "get_crypto_history",
+            "get_company_overview",
+            "get_financials",
+            "get_earnings",
+            "compare_companies",
+            "compute_dcf",
+            "get_technical_indicators",
+            "backtest_strategy",
+            "analyze_risk",
+            "analyze_correlation",
+            "analyze_holdings_overlap",
+            "track_portfolio",
+            "manage_watchlist",
+            "manage_alerts",
+            "daily_watchlist_report",
+            "manage_notifications",
+            "search_web",
+            "get_economic_data",
+            "get_fear_greed",
+            "get_reddit_sentiment",
+            "get_twitter_sentiment",
+            "get_web_sentiment",
+            "get_sentiment_trend",
+            "get_sentiment_summary",
+            "get_sec_filings",
+            "ask_user"
+          ],
+          "memoryCategories": [
+            "investor_profile",
+            "workflow_history"
+          ],
+          "memoryProvenance": [],
+          "diagnostics": [],
+          "toolScopeViolations": [
+            {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            },
+            {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            }
+          ],
+          "toolScope": [
+            {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "options_screener",
+              "toolBundles": [
+                "core_market",
+                "options",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_option_chain",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_fear_greed",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            {
+              "mode": "observe",
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "enforced": false
+            }
+          ]
+        },
+        "planning": {
+          "version": "planning-v1",
+          "taskFamily": "general_fallback",
+          "commitmentMode": "framework",
+          "policyCardId": "general_fallback",
+          "evidencePlanId": "placeholder_general_fallback",
+          "answerContractId": "general_fallback",
+          "structuredCheckIds": [
+            "data_gap_disclosed"
+          ],
+          "workspacePlaceholderIds": [],
+          "artifactPlaceholderIds": [],
+          "artifactContractIds": [],
+          "capabilityGapIds": [],
+          "evidenceRecords": [
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "NVDA"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 0,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_option_chain",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_option_chain"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_option_chain",
+                "args": {
+                  "symbol": "NVDA",
+                  "type": "call"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 1,
+                "toolName": "get_option_chain"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_option_chain",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_option_chain"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_option_chain",
+                "args": {
+                  "symbol": "NVDA",
+                  "expiration": "2026-07-31",
+                  "type": "call"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 2,
+                "toolName": "get_option_chain"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:ask_user",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "ask_user"
+              },
+              "entityScope": {},
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "ask_user",
+                "args": {
+                  "question_type": "select",
+                  "question": "Which calls are you referring to?",
+                  "options": [
+                    "NVDA Jan 16 2026 200 Call",
+                    "AMD Jan 16 2026 150 Call",
+                    "Both"
+                  ]
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 3,
+                "toolName": "ask_user"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "AMD"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "AMD"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 4,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_stock_quote",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_stock_quote"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_stock_quote",
+                "args": {
+                  "symbol": "NVDA"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 5,
+                "toolName": "get_stock_quote"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_option_chain",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_option_chain"
+              },
+              "entityScope": {
+                "symbols": [
+                  "AMD"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_option_chain",
+                "args": {
+                  "symbol": "AMD",
+                  "expiration": "2026-01-16",
+                  "type": "call"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 6,
+                "toolName": "get_option_chain"
+              },
+              "gaps": [],
+              "caveats": []
+            },
+            {
+              "id": "tool_result:get_option_chain",
+              "evidenceType": "tool_result",
+              "source": {
+                "toolName": "get_option_chain"
+              },
+              "entityScope": {
+                "symbols": [
+                  "NVDA"
+                ]
+              },
+              "observedAt": "1970-01-01T00:00:00.000Z",
+              "providerStatus": "available",
+              "normalizedFacts": {
+                "toolName": "get_option_chain",
+                "args": {
+                  "type": "call",
+                  "symbol": "NVDA",
+                  "expiration": "2026-01-16"
+                },
+                "isError": false,
+                "providerStatus": "available"
+              },
+              "rawTracePointer": {
+                "traceId": "eval-trace",
+                "toolCallIndex": 7,
+                "toolName": "get_option_chain"
+              },
+              "gaps": [],
+              "caveats": []
+            }
+          ],
+          "structuredCheckResults": [
+            {
+              "checkId": "required_evidence_present",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "freshness_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "data_gap_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            },
+            {
+              "checkId": "required_final_fields_present",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "source_coverage_disclosed",
+              "passed": true,
+              "observedOnly": true
+            },
+            {
+              "checkId": "capability_gap_disclosure",
+              "passed": true,
+              "observedOnly": true
+            }
+          ],
+          "structuredCheckFailures": [
+            {
+              "checkId": "commitment_mode_respected",
+              "passed": false,
+              "observedOnly": true,
+              "failureReason": "Expected framework metadata and fields: framework_or_checklist"
+            }
+          ],
+          "retryEligibility": {
+            "eligible": true,
+            "activeRetryAllowed": false,
+            "reasons": [
+              "commitment_mode_respected: Expected framework metadata and fields: framework_or_checklist"
+            ]
+          },
+          "parityStatus": "legacy_active",
+          "regressionClassification": "none"
+        },
+        "toolCalls": [
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "NVDA"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "NVDA: $194.83 (-1.39%)\nOpen: $197.14 | High: $200.06 | Low: $192.35\nVolume: 129,935,067 | Market Cap: N/A\n52W Range: $157.34 - $236.54"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "price": 194.83,
+                "change": -2.75,
+                "changePercent": -1.3918412794817288,
+                "open": 197.13999938964844,
+                "high": 200.055,
+                "low": 192.35,
+                "previousClose": 197.58,
+                "volume": 129935067,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 236.54,
+                "week52Low": 157.34,
+                "timestamp": 1783137833343,
+                "currency": "USD"
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_option_chain",
+            "args": {
+              "symbol": "NVDA",
+              "type": "call"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**NVDA Options Chain** — Expiry: 2026-07-06\nUnderlying: $194.83\nQuote status: closed / live_quotes\nOption bid/ask and last prices are quoted per share; multiply by 100 for one standard contract premium.\n⚠ Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens. do not treat zero bid/ask as confirmed live illiquidity without broker verification; do not stop at the stale quote caveat. Disclose the gap, avoid naming tradable live premiums, and finish the strategy explanation with mechanics, assignment outcomes, labeled hypotheticals, and what live broker quotes would change.\nAvailable expirations: 2026-07-06, 2026-07-08, 2026-07-10, 2026-07-17, 2026-07-24, 2026-07-31, 2026-08-07, 2026-08-21, 2026-09-18, 2026-10-16, 2026-11-20, 2026-12-18, 2027-01-15, 2027-03-19, 2027-06-17, 2027-09-17, 2027-12-17, 2028-01-21, 2028-06-16, 2028-12-15\n\n**CALLS** (41 contracts, volume: 308,164)\nStrike | Bid/Ask (per share) | Last (per share) | Vol | OI | IV | Delta | Gamma | Theta | Vega | Rho\n $200.00 | $0.33/$0.36 | $0.35 | 83170 | 12655 | 27.2% | 0.111 | 0.048 | -0.188 | 0.037 | 0.002\n $195.00 | $1.70/$1.83 | $1.71 | 52502 | 4597 | 27.1% | 0.495 | 0.088 | -0.349 | 0.067 | 0.007\n $197.50 | $0.80/$0.88 | $0.82 | 36339 | 2727 | 27.2% | 0.253 | 0.075 | -0.295 | 0.057 | 0.004\n $202.50 | $0.13/$0.14 | $0.13 | 25652 | 8378 | 27.9% | 0.044 | 0.025 | -0.101 | 0.019 | 0.001\n $205.00 | $0.06/$0.07 | $0.07 | 24413 | 13703 | 30.5% | 0.021 | 0.013 | -0.061 | 0.011 | 0.000\n $212.50 | $0.01/$0.02 | $0.02 | 23404 | 1739 | 39.8% | 0.005 | 0.003 | -0.022 | 0.003 | 0.000\n*$192.50 | $3.15/$3.40 | $3.45 | 13378 | 638 | 28.9% | 0.732 | 0.072 | -0.333 | 0.059 | 0.010\n $207.50 | $0.02/$0.03 | $0.02 | 10606 | 3957 | 31.8% | 0.009 | 0.006 | -0.030 | 0.005 | 0.000\n $210.00 | $0.01/$0.02 | $0.02 | 9390 | 8991 | 35.2% | 0.005 | 0.003 | -0.022 | 0.003 | 0.000\n*$190.00 | $5.00/$5.55 | $5.52 | 7072 | 361 | 34.5% | 0.841 | 0.047 | -0.313 | 0.046 | 0.012\n\nPut/Call Ratio: 0.54"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "underlyingPrice": 194.83,
+                "expirationDate": "2026-07-06",
+                "expirationDates": [
+                  "2026-07-06",
+                  "2026-07-08",
+                  "2026-07-10",
+                  "2026-07-17",
+                  "2026-07-24",
+                  "2026-07-31",
+                  "2026-08-07",
+                  "2026-08-21",
+                  "2026-09-18",
+                  "2026-10-16",
+                  "2026-11-20",
+                  "2026-12-18",
+                  "2027-01-15",
+                  "2027-03-19",
+                  "2027-06-17",
+                  "2027-09-17",
+                  "2027-12-17",
+                  "2028-01-21",
+                  "2028-06-16",
+                  "2028-12-15"
+                ],
+                "calls": [
+                  {
+                    "contractSymbol": "NVDA260706C00135000",
+                    "type": "call",
+                    "strike": 135,
+                    "expiration": "2026-07-06",
+                    "bid": 55.1,
+                    "ask": 64,
+                    "lastPrice": 59.74,
+                    "volume": 2,
+                    "openInterest": 1,
+                    "impliedVolatility": 3.8310551098632812,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9200386637576083,
+                      "gamma": 0.002742489354612443,
+                      "theta": -2.1088864127786398,
+                      "vega": 0.029562800033574067,
+                      "rho": 0.008593005262718794
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00150000",
+                    "type": "call",
+                    "strike": 150,
+                    "expiration": "2026-07-06",
+                    "bid": 40.1,
+                    "ask": 49,
+                    "lastPrice": 43.43,
+                    "volume": 2,
+                    "openInterest": 1,
+                    "impliedVolatility": 3.0068384204101566,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8977899757210585,
+                      "gamma": 0.004125483567852026,
+                      "theta": -1.956797642312513,
+                      "vega": 0.034903354515537034,
+                      "rho": 0.009374449897168999
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00155000",
+                    "type": "call",
+                    "strike": 155,
+                    "expiration": "2026-07-06",
+                    "bid": 35.15,
+                    "ask": 44,
+                    "lastPrice": 38.98,
+                    "volume": 37,
+                    "openInterest": 4,
+                    "impliedVolatility": 2.7441437646484372,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.887989900641685,
+                      "gamma": 0.004796829783832699,
+                      "theta": -1.8960048267380376,
+                      "vega": 0.03703764662859169,
+                      "rho": 0.009599457534249962
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00160000",
+                    "type": "call",
+                    "strike": 160,
+                    "expiration": "2026-07-06",
+                    "bid": 30.15,
+                    "ask": 39,
+                    "lastPrice": 34.65,
+                    "volume": 5,
+                    "openInterest": 8,
+                    "impliedVolatility": 2.484867069091797,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8764473187853983,
+                      "gamma": 0.005635110139134201,
+                      "theta": -1.8273539737324707,
+                      "vega": 0.03939923463412148,
+                      "rho": 0.009798786209507908
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00165000",
+                    "type": "call",
+                    "strike": 165,
+                    "expiration": "2026-07-06",
+                    "bid": 26.85,
+                    "ask": 32.55,
+                    "lastPrice": 29,
+                    "volume": 201,
+                    "openInterest": 2,
+                    "impliedVolatility": 1.8940434985351562,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8908530225433746,
+                      "gamma": 0.006835166231740695,
+                      "theta": -1.2943870842956802,
+                      "vega": 0.03642681883315737,
+                      "rho": 0.010478669564692726
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00170000",
+                    "type": "call",
+                    "strike": 170,
+                    "expiration": "2026-07-06",
+                    "bid": 21.85,
+                    "ask": 27.45,
+                    "lastPrice": 24.1,
+                    "volume": 124,
+                    "openInterest": 24,
+                    "impliedVolatility": 1.6376971240234375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8786242561330775,
+                      "gamma": 0.008456067446306942,
+                      "theta": -1.1990295923669871,
+                      "vega": 0.03896585773432434,
+                      "rho": 0.010675906206376228
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00175000",
+                    "type": "call",
+                    "strike": 175,
+                    "expiration": "2026-07-06",
+                    "bid": 15.8,
+                    "ask": 23.8,
+                    "lastPrice": 18.46,
+                    "volume": 23,
+                    "openInterest": 37,
+                    "impliedVolatility": 1.6782242651367185,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8271146753764039,
+                      "gamma": 0.010144312932165517,
+                      "theta": -1.5044704923847922,
+                      "vega": 0.0479021327526001,
+                      "rho": 0.010193537070301224
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00177500",
+                    "type": "call",
+                    "strike": 177.5,
+                    "expiration": "2026-07-06",
+                    "bid": 13.8,
+                    "ask": 19.15,
+                    "lastPrice": 18,
+                    "volume": 7,
+                    "openInterest": 15,
+                    "impliedVolatility": 1.1167036352539061,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8747046395319171,
+                      "gamma": 0.012648306370968624,
+                      "theta": -0.8409042623248593,
+                      "vega": 0.03974225654633944,
+                      "rho": 0.011226711762676554
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00180000",
+                    "type": "call",
+                    "strike": 180,
+                    "expiration": "2026-07-06",
+                    "bid": 13.5,
+                    "ask": 16.85,
+                    "lastPrice": 14.35,
+                    "volume": 1212,
+                    "openInterest": 214,
+                    "impliedVolatility": 0.6064492480468751,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9527850353472254,
+                      "gamma": 0.01180631866321472,
+                      "theta": -0.2491381981189943,
+                      "vega": 0.020146108977250554,
+                      "rho": 0.012637682305647418
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00182500",
+                    "type": "call",
+                    "strike": 182.5,
+                    "expiration": "2026-07-06",
+                    "bid": 10.65,
+                    "ask": 14,
+                    "lastPrice": 12.51,
+                    "volume": 3881,
+                    "openInterest": 116,
+                    "impliedVolatility": 0.8642591699218749,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8526689672141411,
+                      "gamma": 0.018009956568832655,
+                      "theta": -0.720358162486664,
+                      "vega": 0.043796446793598266,
+                      "rho": 0.011285247961391066
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00185000",
+                    "type": "call",
+                    "strike": 185,
+                    "expiration": "2026-07-06",
+                    "bid": 9.1,
+                    "ask": 10.15,
+                    "lastPrice": 9.95,
+                    "volume": 5824,
+                    "openInterest": 566,
+                    "impliedVolatility": 0.43066975585937506,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.939417604804542,
+                      "gamma": 0.020013178220000143,
+                      "theta": -0.21670025446835867,
+                      "vega": 0.024251726002930924,
+                      "rho": 0.012815946380235895
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00187500",
+                    "type": "call",
+                    "strike": 187.5,
+                    "expiration": "2026-07-06",
+                    "bid": 6.95,
+                    "ask": 7.8,
+                    "lastPrice": 7.66,
+                    "volume": 5975,
+                    "openInterest": 810,
+                    "impliedVolatility": 0.387701435546875,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9039805358299963,
+                      "gamma": 0.030699386620672307,
+                      "theta": -0.2630075085765278,
+                      "vega": 0.03348955087417447,
+                      "rho": 0.012479097532640107
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00190000",
+                    "type": "call",
+                    "strike": 190,
+                    "expiration": "2026-07-06",
+                    "bid": 5,
+                    "ask": 5.55,
+                    "lastPrice": 5.52,
+                    "volume": 7072,
+                    "openInterest": 361,
+                    "impliedVolatility": 0.34497725341796875,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8410721816323831,
+                      "gamma": 0.047115720337636134,
+                      "theta": -0.31325388736451154,
+                      "vega": 0.04573392881002885,
+                      "rho": 0.011736225330174068
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00192500",
+                    "type": "call",
+                    "strike": 192.5,
+                    "expiration": "2026-07-06",
+                    "bid": 3.15,
+                    "ask": 3.4,
+                    "lastPrice": 3.45,
+                    "volume": 13378,
+                    "openInterest": 638,
+                    "impliedVolatility": 0.2890696093749999,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.7322014258199219,
+                      "gamma": 0.07221369042881114,
+                      "theta": -0.33283428508083346,
+                      "vega": 0.05873597622722669,
+                      "rho": 0.010315360418856067
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00195000",
+                    "type": "call",
+                    "strike": 195,
+                    "expiration": "2026-07-06",
+                    "bid": 1.7,
+                    "ask": 1.83,
+                    "lastPrice": 1.71,
+                    "volume": 52502,
+                    "openInterest": 4597,
+                    "impliedVolatility": 0.27149166015625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.49451176619653975,
+                      "gamma": 0.08759750539073503,
+                      "theta": -0.3485917415845329,
+                      "vega": 0.06691607320639532,
+                      "rho": 0.006958330909602601
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00197500",
+                    "type": "call",
+                    "strike": 197.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.8,
+                    "ask": 0.88,
+                    "lastPrice": 0.82,
+                    "volume": 36339,
+                    "openInterest": 2727,
+                    "impliedVolatility": 0.27173579833984374,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.25252639098916174,
+                      "gamma": 0.07506137691462766,
+                      "theta": -0.29481771876489477,
+                      "vega": 0.0573912387298279,
+                      "rho": 0.0035791604531177053
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00200000",
+                    "type": "call",
+                    "strike": 200,
+                    "expiration": "2026-07-06",
+                    "bid": 0.33,
+                    "ask": 0.36,
+                    "lastPrice": 0.35,
+                    "volume": 83170,
+                    "openInterest": 12655,
+                    "impliedVolatility": 0.27197993652343744,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.11140214959347172,
+                      "gamma": 0.048229289277856476,
+                      "theta": -0.1884437769760242,
+                      "vega": 0.03690880175802001,
+                      "rho": 0.0015861208726561484
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00202500",
+                    "type": "call",
+                    "strike": 202.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.13,
+                    "ask": 0.14,
+                    "lastPrice": 0.13,
+                    "volume": 25652,
+                    "openInterest": 8378,
+                    "impliedVolatility": 0.27930408203124996,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.04449921884392416,
+                      "gamma": 0.024507189681601167,
+                      "theta": -0.10058528668915957,
+                      "vega": 0.01925985490635898,
+                      "rho": 0.0006351279655189776
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00205000",
+                    "type": "call",
+                    "strike": 205,
+                    "expiration": "2026-07-06",
+                    "bid": 0.06,
+                    "ask": 0.07,
+                    "lastPrice": 0.07,
+                    "volume": 24413,
+                    "openInterest": 13703,
+                    "impliedVolatility": 0.304694453125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.02129135447494679,
+                      "gamma": 0.01253856577373132,
+                      "theta": -0.061091191664526395,
+                      "vega": 0.010749657482388155,
+                      "rho": 0.0003040425445608901
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00207500",
+                    "type": "call",
+                    "strike": 207.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.02,
+                    "ask": 0.03,
+                    "lastPrice": 0.02,
+                    "volume": 10606,
+                    "openInterest": 3957,
+                    "impliedVolatility": 0.31836619140624994,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.008689638466562066,
+                      "gamma": 0.005663572420468651,
+                      "theta": -0.030078758194373844,
+                      "vega": 0.0050734059767220474,
+                      "rho": 0.00012420184580455988
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00210000",
+                    "type": "call",
+                    "strike": 210,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.02,
+                    "volume": 9390,
+                    "openInterest": 8991,
+                    "impliedVolatility": 0.35156898437499995,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.005339691148952719,
+                      "gamma": 0.0033657897371875164,
+                      "theta": -0.02177299418676083,
+                      "vega": 0.003329505619037914,
+                      "rho": 0.00007628888793380439
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00212500",
+                    "type": "call",
+                    "strike": 212.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.02,
+                    "volume": 23404,
+                    "openInterest": 1739,
+                    "impliedVolatility": 0.398443515625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0045959158207697914,
+                      "gamma": 0.0026046592173676352,
+                      "theta": -0.02162291906313674,
+                      "vega": 0.0029201145578646058,
+                      "rho": 0.00006558225392580239
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00215000",
+                    "type": "call",
+                    "strike": 215,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.02,
+                    "volume": 2873,
+                    "openInterest": 5550,
+                    "impliedVolatility": 0.445318046875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.00412328082346014,
+                      "gamma": 0.0021186410240478146,
+                      "theta": -0.021955345071857306,
+                      "vega": 0.0026546660086733953,
+                      "rho": 0.00005876482872445143
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00217500",
+                    "type": "call",
+                    "strike": 217.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1164,
+                    "openInterest": 588,
+                    "impliedVolatility": 0.45313046875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.00193649808045393,
+                      "gamma": 0.0010637422693034941,
+                      "theta": -0.011408255248621076,
+                      "vega": 0.0013562567048273075,
+                      "rho": 0.00002762028655824613
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00220000",
+                    "type": "call",
+                    "strike": 220,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 451,
+                    "openInterest": 3075,
+                    "impliedVolatility": 0.500005,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0019373782962756603,
+                      "gamma": 0.0009644113603848499,
+                      "theta": -0.0125881792064459,
+                      "vega": 0.0013568095156528972,
+                      "rho": 0.00002759743263307031
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00222500",
+                    "type": "call",
+                    "strike": 222.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 486,
+                    "impliedVolatility": 0.500005,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0008292431306610171,
+                      "gamma": 0.00044771109086560703,
+                      "theta": -0.005842017179060601,
+                      "vega": 0.0006298750650421488,
+                      "rho": 0.000011824272834724625
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00225000",
+                    "type": "call",
+                    "strike": 225,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 3,
+                    "openInterest": 895,
+                    "impliedVolatility": 0.5468795312500001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0009117086332298685,
+                      "gamma": 0.00044623974972390077,
+                      "theta": -0.006963688492568821,
+                      "vega": 0.0006866606148699431,
+                      "rho": 0.000012983282210486118
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00227500",
+                    "type": "call",
+                    "strike": 227.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 115,
+                    "openInterest": 318,
+                    "impliedVolatility": 0.57812921875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0007561889785502318,
+                      "gamma": 0.00035598068934131156,
+                      "theta": -0.006206675107438947,
+                      "vega": 0.0005790733453516528,
+                      "rho": 0.000010762504873099265
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00230000",
+                    "type": "call",
+                    "strike": 230,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 120,
+                    "openInterest": 1282,
+                    "impliedVolatility": 0.6250037500000001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0008419352167056138,
+                      "gamma": 0.00036316137750751887,
+                      "theta": -0.007398672448672645,
+                      "vega": 0.0006386523194568733,
+                      "rho": 0.000011967113713496951
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00232500",
+                    "type": "call",
+                    "strike": 232.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.02,
+                    "volume": 51,
+                    "openInterest": 194,
+                    "impliedVolatility": 0.6562534375000001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0007272649121773389,
+                      "gamma": 0.00030263501303755703,
+                      "theta": -0.006796305468973532,
+                      "vega": 0.0005588213357034239,
+                      "rho": 0.000010331142971002233
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00235000",
+                    "type": "call",
+                    "strike": 235,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 2,
+                    "openInterest": 256,
+                    "impliedVolatility": 0.6875031250000001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0006402067192646244,
+                      "gamma": 0.00025710347473498674,
+                      "theta": -0.006335763800588449,
+                      "vega": 0.0004973531107563358,
+                      "rho": 0.00000908897975549859
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00237500",
+                    "type": "call",
+                    "strike": 237.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.03,
+                    "volume": 2,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.7187528125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0005730500612022293,
+                      "gamma": 0.00022219694760678774,
+                      "theta": -0.0059838114038092294,
+                      "vega": 0.0004493656398881337,
+                      "rho": 0.000008130577393166557
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00240000",
+                    "type": "call",
+                    "strike": 240,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 3,
+                    "openInterest": 1162,
+                    "impliedVolatility": 0.7500025,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0005205620891592933,
+                      "gamma": 0.0001949843520817688,
+                      "theta": -0.005716780055675431,
+                      "vega": 0.00041147616797441484,
+                      "rho": 0.000007381259551122064
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00245000",
+                    "type": "call",
+                    "strike": 245,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 5,
+                    "openInterest": 32,
+                    "impliedVolatility": 0.8125018749999999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0004461163686841352,
+                      "gamma": 0.0001561972035194052,
+                      "theta": -0.005373477354742546,
+                      "vega": 0.0003570917708319539,
+                      "rho": 0.000006317588365136758
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00250000",
+                    "type": "call",
+                    "strike": 250,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 51,
+                    "impliedVolatility": 0.8906260937499999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0004899790799655634,
+                      "gamma": 0.00015532072238679578,
+                      "theta": -0.0064191229687406174,
+                      "vega": 0.0003892306510922799,
+                      "rho": 0.000006924710307223941
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00255000",
+                    "type": "call",
+                    "strike": 255,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 2,
+                    "openInterest": 86,
+                    "impliedVolatility": 0.9687503125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0005397150410063056,
+                      "gamma": 0.00015604342662241843,
+                      "theta": -0.00762885806627451,
+                      "vega": 0.0004253432548898323,
+                      "rho": 0.000007611941213673264
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00260000",
+                    "type": "call",
+                    "strike": 260,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 22,
+                    "impliedVolatility": 1.000005,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0003492429347187742,
+                      "gamma": 0.0001012926046129724,
+                      "theta": -0.005276194751190292,
+                      "vega": 0.0002850113308128741,
+                      "rho": 0.00000492582143360025
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00265000",
+                    "type": "call",
+                    "strike": 265,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 2,
+                    "impliedVolatility": 1.0625046875000002,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.00033858242197087884,
+                      "gamma": 0.00009264633213995312,
+                      "theta": -0.005447307863945864,
+                      "vega": 0.0002769754655166482,
+                      "rho": 0.000004768766923050881
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00270000",
+                    "type": "call",
+                    "strike": 270,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 150,
+                    "openInterest": 353,
+                    "impliedVolatility": 1.125004375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0003341017440517402,
+                      "gamma": 0.00008643023874724814,
+                      "theta": -0.005696727586525214,
+                      "vega": 0.00027359120987016444,
+                      "rho": 0.000004698937772523528
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00275000",
+                    "type": "call",
+                    "strike": 275,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.03,
+                    "volume": 0,
+                    "openInterest": 4,
+                    "impliedVolatility": 1.1875040625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0003344855116563794,
+                      "gamma": 0.00008196811463552274,
+                      "theta": -0.006019089083941832,
+                      "vega": 0.00027388122764342783,
+                      "rho": 0.000004697498567677091
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706C00280000",
+                    "type": "call",
+                    "strike": 280,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 0,
+                    "openInterest": 31,
+                    "impliedVolatility": 1.2500037499999999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.000338873418785135,
+                      "gamma": 0.00007881194446612415,
+                      "theta": -0.006412076444353489,
+                      "vega": 0.00027719511628830607,
+                      "rho": 0.0000047520916116878856
+                    }
+                  }
+                ],
+                "puts": [
+                  {
+                    "contractSymbol": "NVDA260706P00110000",
+                    "type": "put",
+                    "strike": 110,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 2,
+                    "openInterest": 23,
+                    "impliedVolatility": 1.96875015625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00019801385278195305,
+                      "gamma": 0.000030431406126026357,
+                      "theta": -0.006127734331706768,
+                      "vega": 0.00016857564946505,
+                      "rho": -0.0000029950656512434046
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00115000",
+                    "type": "put",
+                    "strike": 115,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.08,
+                    "volume": 2,
+                    "openInterest": 2,
+                    "impliedVolatility": 1.8125009374999999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00019850330889115142,
+                      "gamma": 0.00003313063698021551,
+                      "theta": -0.005653933024847542,
+                      "vega": 0.00016896246687344546,
+                      "rho": -0.0000029912617783766287
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00120000",
+                    "type": "put",
+                    "strike": 120,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 3,
+                    "impliedVolatility": 1.6875015625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0002370228407375663,
+                      "gamma": 0.000041947092468272836,
+                      "theta": -0.006204666074567183,
+                      "vega": 0.00019917199017475132,
+                      "rho": -0.0000035628613568950633
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00125000",
+                    "type": "put",
+                    "strike": 125,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 26,
+                    "openInterest": 81,
+                    "impliedVolatility": 1.5625021874999998,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00027619867967154654,
+                      "gamma": 0.000052194855235898555,
+                      "theta": -0.006618444087825716,
+                      "vega": 0.00022947244728875076,
+                      "rho": -0.000004140953277158169
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00130000",
+                    "type": "put",
+                    "strike": 130,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.02,
+                    "volume": 10,
+                    "openInterest": 100,
+                    "impliedVolatility": 1.4375028125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00031376036013552877,
+                      "gamma": 0.00006382991260942098,
+                      "theta": -0.00684985105725644,
+                      "vega": 0.00025817558444467194,
+                      "rho": -0.000004691342243925397
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00135000",
+                    "type": "put",
+                    "strike": 135,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 4,
+                    "openInterest": 56,
+                    "impliedVolatility": 1.3125034374999998,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0003466787475527866,
+                      "gamma": 0.00007665266775295862,
+                      "theta": -0.00685665604432255,
+                      "vega": 0.0002830804906696192,
+                      "rho": -0.000005168912442070943
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00140000",
+                    "type": "put",
+                    "strike": 140,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 4,
+                    "openInterest": 130,
+                    "impliedVolatility": 1.1875040625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00037107095829735925,
+                      "gamma": 0.00009020316255111051,
+                      "theta": -0.006604058108699414,
+                      "vega": 0.0003013971104089708,
+                      "rho": -0.000005516413005922874
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00145000",
+                    "type": "put",
+                    "strike": 145,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.01,
+                    "lastPrice": 0.01,
+                    "volume": 9,
+                    "openInterest": 3914,
+                    "impliedVolatility": 1.0625046875000002,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00038217281380226176,
+                      "gamma": 0.00010359151209601871,
+                      "theta": -0.006070527806308163,
+                      "vega": 0.0003096971744442639,
+                      "rho": -0.000005664281774784846
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00150000",
+                    "type": "put",
+                    "strike": 150,
+                    "expiration": "2026-07-06",
+                    "bid": 0,
+                    "ask": 0.02,
+                    "lastPrice": 0.01,
+                    "volume": 158,
+                    "openInterest": 1098,
+                    "impliedVolatility": 1.015629921875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.000875778820398021,
+                      "gamma": 0.00023165055476070286,
+                      "theta": -0.012400905071970982,
+                      "vega": 0.000661989418922019,
+                      "rho": -0.000012987506609701929
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00155000",
+                    "type": "put",
+                    "strike": 155,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.02,
+                    "volume": 25,
+                    "openInterest": 264,
+                    "impliedVolatility": 0.929688203125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0013695691532206178,
+                      "gamma": 0.00037960363860666565,
+                      "theta": -0.017023095091449104,
+                      "vega": 0.000993001495912427,
+                      "rho": -0.00002028417376012795
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00160000",
+                    "type": "put",
+                    "strike": 160,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.01,
+                    "volume": 686,
+                    "openInterest": 213,
+                    "impliedVolatility": 0.8125018749999999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.00158686477536929,
+                      "gamma": 0.0004960456127016088,
+                      "theta": -0.016984517257688736,
+                      "vega": 0.0011340395491205627,
+                      "rho": -0.00002343423844238238
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00165000",
+                    "type": "put",
+                    "strike": 165,
+                    "expiration": "2026-07-06",
+                    "bid": 0.01,
+                    "ask": 0.02,
+                    "lastPrice": 0.01,
+                    "volume": 1028,
+                    "openInterest": 3897,
+                    "impliedVolatility": 0.6953155468750001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0018209507832100957,
+                      "gamma": 0.0006559963641957304,
+                      "theta": -0.016441723656097647,
+                      "vega": 0.001283410500822113,
+                      "rho": -0.00002681073913663678
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00170000",
+                    "type": "put",
+                    "strike": 170,
+                    "expiration": "2026-07-06",
+                    "bid": 0.02,
+                    "ask": 0.03,
+                    "lastPrice": 0.02,
+                    "volume": 8626,
+                    "openInterest": 1941,
+                    "impliedVolatility": 0.6171913281250001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0034762937478287625,
+                      "gamma": 0.0013150434987215375,
+                      "theta": -0.025953159476657515,
+                      "vega": 0.0022837162903978246,
+                      "rho": -0.0000511307743717582
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00175000",
+                    "type": "put",
+                    "strike": 175,
+                    "expiration": "2026-07-06",
+                    "bid": 0.04,
+                    "ask": 0.05,
+                    "lastPrice": 0.05,
+                    "volume": 3913,
+                    "openInterest": 1303,
+                    "impliedVolatility": 0.5390671093750001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.007150506682451763,
+                      "gamma": 0.0028284520275527877,
+                      "theta": -0.04254471773927704,
+                      "vega": 0.004290163738035081,
+                      "rho": -0.00010507304746092166
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00177500",
+                    "type": "put",
+                    "strike": 177.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.06,
+                    "ask": 0.07,
+                    "lastPrice": 0.07,
+                    "volume": 3777,
+                    "openInterest": 431,
+                    "impliedVolatility": 0.5039112109375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.011102858196690324,
+                      "gamma": 0.004409189279244364,
+                      "theta": -0.057916322160622084,
+                      "vega": 0.006251654654281455,
+                      "rho": -0.00016312075850853812
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00180000",
+                    "type": "put",
+                    "strike": 180,
+                    "expiration": "2026-07-06",
+                    "bid": 0.08,
+                    "ask": 0.09,
+                    "lastPrice": 0.09,
+                    "volume": 6047,
+                    "openInterest": 3601,
+                    "impliedVolatility": 0.46289599609375004,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.016634717553619116,
+                      "gamma": 0.006736862619849841,
+                      "theta": -0.0746093921265537,
+                      "vega": 0.008774519256204821,
+                      "rho": -0.00024427993497982845
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00182500",
+                    "type": "put",
+                    "strike": 182.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.12,
+                    "ask": 0.13,
+                    "lastPrice": 0.12,
+                    "volume": 2604,
+                    "openInterest": 1877,
+                    "impliedVolatility": 0.422857333984375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.026099609298833815,
+                      "gamma": 0.010654207194229893,
+                      "theta": -0.09835178107614419,
+                      "vega": 0.012676437560861085,
+                      "rho": -0.0003831510834359607
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00185000",
+                    "type": "put",
+                    "strike": 185,
+                    "expiration": "2026-07-06",
+                    "bid": 0.19,
+                    "ask": 0.2,
+                    "lastPrice": 0.19,
+                    "volume": 9498,
+                    "openInterest": 11281,
+                    "impliedVolatility": 0.3842835009765625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.04320085658291806,
+                      "gamma": 0.017414059713435816,
+                      "theta": -0.13254680269773475,
+                      "vega": 0.018829291717741253,
+                      "rho": -0.0006341637738162973
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00187500",
+                    "type": "put",
+                    "strike": 187.5,
+                    "expiration": "2026-07-06",
+                    "bid": 0.33,
+                    "ask": 0.36,
+                    "lastPrice": 0.34,
+                    "volume": 7659,
+                    "openInterest": 2983,
+                    "impliedVolatility": 0.35742830078125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.08064936572054848,
+                      "gamma": 0.029570509559079663,
+                      "theta": -0.19424774180661536,
+                      "vega": 0.029739246508350733,
+                      "rho": -0.0011851867811662079
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00190000",
+                    "type": "put",
+                    "strike": 190,
+                    "expiration": "2026-07-06",
+                    "bid": 0.61,
+                    "ask": 0.66,
+                    "lastPrice": 0.65,
+                    "volume": 17715,
+                    "openInterest": 5334,
+                    "impliedVolatility": 0.33301448242187504,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.15157543245469585,
+                      "gamma": 0.047513194045583504,
+                      "theta": -0.26986204108231876,
+                      "vega": 0.04452045184464587,
+                      "rho": -0.002231862082541472
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00192500",
+                    "type": "put",
+                    "strike": 192.5,
+                    "expiration": "2026-07-06",
+                    "bid": 1.17,
+                    "ask": 1.27,
+                    "lastPrice": 1.18,
+                    "volume": 24372,
+                    "openInterest": 4889,
+                    "impliedVolatility": 0.3205634350585937,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.2852453529075387,
+                      "gamma": 0.06664608604447299,
+                      "theta": -0.34832075247705147,
+                      "vega": 0.06011333859467759,
+                      "rho": -0.004218131726614598
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00195000",
+                    "type": "put",
+                    "strike": 195,
+                    "expiration": "2026-07-06",
+                    "bid": 2.2,
+                    "ask": 2.3,
+                    "lastPrice": 2.3,
+                    "volume": 35206,
+                    "openInterest": 6642,
+                    "impliedVolatility": 0.3139717041015625,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.5028360326674002,
+                      "gamma": 0.07574830799129645,
+                      "theta": -0.374450405432811,
+                      "vega": 0.06691841754536224,
+                      "rho": -0.007482372281318975
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00197500",
+                    "type": "put",
+                    "strike": 197.5,
+                    "expiration": "2026-07-06",
+                    "bid": 3.55,
+                    "ask": 3.9,
+                    "lastPrice": 3.45,
+                    "volume": 10762,
+                    "openInterest": 2232,
+                    "impliedVolatility": 0.3276434423828125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.711790478765107,
+                      "gamma": 0.06544238169522647,
+                      "theta": -0.34576656674570794,
+                      "vega": 0.06033131517431614,
+                      "rho": -0.010570466910063374
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00200000",
+                    "type": "put",
+                    "strike": 200,
+                    "expiration": "2026-07-06",
+                    "bid": 5.55,
+                    "ask": 5.95,
+                    "lastPrice": 5.61,
+                    "volume": 5361,
+                    "openInterest": 1291,
+                    "impliedVolatility": 0.3618227880859375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8259408900609063,
+                      "gamma": 0.047223325366692416,
+                      "theta": -0.29862624089319,
+                      "vega": 0.0480767052890389,
+                      "rho": -0.012359907620930652
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00202500",
+                    "type": "put",
+                    "strike": 202.5,
+                    "expiration": "2026-07-06",
+                    "bid": 7.65,
+                    "ask": 8.6,
+                    "lastPrice": 7.85,
+                    "volume": 4709,
+                    "openInterest": 347,
+                    "impliedVolatility": 0.4885305053710938,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8449032114940438,
+                      "gamma": 0.032815532860440255,
+                      "theta": -0.38353629624738,
+                      "vega": 0.04510797845032116,
+                      "rho": -0.01282715613976481
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00205000",
+                    "type": "put",
+                    "strike": 205,
+                    "expiration": "2026-07-06",
+                    "bid": 10,
+                    "ask": 11.85,
+                    "lastPrice": 10.32,
+                    "volume": 11996,
+                    "openInterest": 1209,
+                    "impliedVolatility": 0.5400436621093752,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.883235310848649,
+                      "gamma": 0.025027147521053405,
+                      "theta": -0.3544973174307048,
+                      "vega": 0.03802966003686335,
+                      "rho": -0.013551255837595238
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00207500",
+                    "type": "put",
+                    "strike": 207.5,
+                    "expiration": "2026-07-06",
+                    "bid": 11,
+                    "ask": 14.6,
+                    "lastPrice": 12.8,
+                    "volume": 4499,
+                    "openInterest": 266,
+                    "impliedVolatility": 0.8740246972656249,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8209992559673863,
+                      "gamma": 0.01984285006734818,
+                      "theta": -0.764326636953252,
+                      "vega": 0.04879889314222388,
+                      "rho": -0.01292211104058505
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00210000",
+                    "type": "put",
+                    "strike": 210,
+                    "expiration": "2026-07-06",
+                    "bid": 15,
+                    "ask": 17.05,
+                    "lastPrice": 15.14,
+                    "volume": 4149,
+                    "openInterest": 531,
+                    "impliedVolatility": 0.72851833984375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.900807692311945,
+                      "gamma": 0.016694238201415273,
+                      "theta": -0.4345149825217958,
+                      "vega": 0.03422073326145792,
+                      "rho": -0.014179663032229206
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00212500",
+                    "type": "put",
+                    "strike": 212.5,
+                    "expiration": "2026-07-06",
+                    "bid": 15.95,
+                    "ask": 19.6,
+                    "lastPrice": 18.95,
+                    "volume": 1195,
+                    "openInterest": 7,
+                    "impliedVolatility": 0.50586431640625,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9811117619223118,
+                      "gamma": 0.0068465490986356166,
+                      "theta": -0.06249831028902344,
+                      "vega": 0.009745137883490611,
+                      "rho": -0.01547810278340879
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00215000",
+                    "type": "put",
+                    "strike": 215,
+                    "expiration": "2026-07-06",
+                    "bid": 18.45,
+                    "ask": 22.2,
+                    "lastPrice": 21.5,
+                    "volume": 1001,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.6005899316406251,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9766150327358576,
+                      "gamma": 0.006865194176147281,
+                      "theta": -0.09993409315269236,
+                      "vega": 0.011601471799179973,
+                      "rho": -0.015600956343498713
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00217500",
+                    "type": "put",
+                    "strike": 217.5,
+                    "expiration": "2026-07-06",
+                    "bid": 20.95,
+                    "ask": 24.45,
+                    "lastPrice": 24.01,
+                    "volume": 411,
+                    "openInterest": 5,
+                    "impliedVolatility": 0.51562984375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9946471248508625,
+                      "gamma": 0.0022998203933772376,
+                      "theta": -0.0021521457249970392,
+                      "vega": 0.0033366771115845993,
+                      "rho": -0.016040334340523085
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00220000",
+                    "type": "put",
+                    "strike": 220,
+                    "expiration": "2026-07-06",
+                    "bid": 23.65,
+                    "ask": 27.2,
+                    "lastPrice": 27.19,
+                    "volume": 330,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.77929908203125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9706399636210682,
+                      "gamma": 0.006351560813920841,
+                      "theta": -0.17120984350712198,
+                      "vega": 0.013927297135323558,
+                      "rho": -0.01589026467015982
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00222500",
+                    "type": "put",
+                    "strike": 222.5,
+                    "expiration": "2026-07-06",
+                    "bid": 26.1,
+                    "ask": 29.6,
+                    "lastPrice": 29.73,
+                    "volume": 52,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.7861349511718749,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9792207242189472,
+                      "gamma": 0.0047641184860267765,
+                      "theta": -0.12316731178118104,
+                      "vega": 0.010538089318131685,
+                      "rho": -0.01619533379461271
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00225000",
+                    "type": "put",
+                    "strike": 225,
+                    "expiration": "2026-07-06",
+                    "bid": 27.9,
+                    "ask": 32.85,
+                    "lastPrice": 30.66,
+                    "volume": 42,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.85937640625,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9782793980235995,
+                      "gamma": 0.004518515922129382,
+                      "theta": -0.1432719384371001,
+                      "vega": 0.010926006613802044,
+                      "rho": -0.01636824216889324
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00230000",
+                    "type": "put",
+                    "strike": 230,
+                    "expiration": "2026-07-06",
+                    "bid": 32.7,
+                    "ask": 37.55,
+                    "lastPrice": 17.85,
+                    "volume": 0,
+                    "openInterest": 0,
+                    "impliedVolatility": 1.7094741088867185,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8809214245174299,
+                      "gamma": 0.008004701929365294,
+                      "theta": -1.1877648179058948,
+                      "vega": 0.03850258676344327,
+                      "rho": -0.015468706657641577
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260706P00232500",
+                    "type": "put",
+                    "strike": 232.5,
+                    "expiration": "2026-07-06",
+                    "bid": 36.25,
+                    "ask": 40,
+                    "lastPrice": 39.24,
+                    "volume": 12,
+                    "openInterest": 0,
+                    "impliedVolatility": 1.173832255859375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9652343449034804,
+                      "gamma": 0.004818485435761312,
+                      "theta": -0.31428046779599306,
+                      "vega": 0.01591471280965352,
+                      "rho": -0.016748652583496688
+                    }
+                  }
+                ],
+                "totalCallVolume": 308164,
+                "totalPutVolume": 165891,
+                "putCallRatio": 0.5383205046663465,
+                "quoteStatus": {
+                  "marketSession": "closed",
+                  "bidAskState": "live_quotes",
+                  "zeroBidAskContracts": 0,
+                  "totalContracts": 77,
+                  "warning": "Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens."
+                },
+                "fetchedAt": "2026-07-04T04:03:56.255Z"
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "get_option_chain",
+            "args": {
+              "symbol": "NVDA",
+              "expiration": "2026-07-31",
+              "type": "call"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**NVDA Options Chain** — Expiry: 2026-07-31\nUnderlying: $194.83\nQuote status: closed / live_quotes\nOption bid/ask and last prices are quoted per share; multiply by 100 for one standard contract premium.\n⚠ Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens. do not treat zero bid/ask as confirmed live illiquidity without broker verification; do not stop at the stale quote caveat. Disclose the gap, avoid naming tradable live premiums, and finish the strategy explanation with mechanics, assignment outcomes, labeled hypotheticals, and what live broker quotes would change.\nAvailable expirations: 2026-07-06, 2026-07-08, 2026-07-10, 2026-07-17, 2026-07-24, 2026-07-31, 2026-08-07, 2026-08-21, 2026-09-18, 2026-10-16, 2026-11-20, 2026-12-18, 2027-01-15, 2027-03-19, 2027-06-17, 2027-09-17, 2027-12-17, 2028-01-21, 2028-06-16, 2028-12-15\n\n**CALLS** (61 contracts, volume: 30,536)\nStrike | Bid/Ask (per share) | Last (per share) | Vol | OI | IV | Delta | Gamma | Theta | Vega | Rho\n $220.00 | $1.41/$1.47 | $1.48 | 4791 | 7319 | 39.1% | 0.122 | 0.011 | -0.091 | 0.125 | 0.017\n $210.00 | $3.10/$3.20 | $3.15 | 4045 | 4856 | 39.3% | 0.236 | 0.016 | -0.132 | 0.178 | 0.032\n $230.00 | $0.66/$0.69 | $0.69 | 3372 | 8983 | 40.0% | 0.062 | 0.007 | -0.058 | 0.079 | 0.009\n $250.00 | $0.18/$0.21 | $0.19 | 3197 | 6971 | 44.3% | 0.019 | 0.003 | -0.026 | 0.032 | 0.003\n $205.00 | $4.40/$4.55 | $4.60 | 2875 | 5680 | 39.4% | 0.318 | 0.018 | -0.150 | 0.199 | 0.043\n $200.00 | $6.20/$6.35 | $6.40 | 2729 | 8008 | 39.9% | 0.421 | 0.018 | -0.162 | 0.212 | 0.056\n $225.00 | $0.95/$1.00 | $1.01 | 2184 | 7063 | 39.4% | 0.086 | 0.009 | -0.073 | 0.100 | 0.012\n $215.00 | $2.10/$2.16 | $2.19 | 2155 | 3482 | 38.9% | 0.170 | 0.014 | -0.111 | 0.152 | 0.023\n $195.00 | $8.50/$8.75 | $8.69 | 1411 | 2861 | 41.0% | 0.545 | 0.018 | -0.171 | 0.213 | 0.071\n $265.00 | $0.08/$0.15 | $0.10 | 605 | 1140 | 50.3% | 0.013 | 0.002 | -0.021 | 0.022 | 0.002\n\nPut/Call Ratio: 0.33"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "underlyingPrice": 194.83,
+                "expirationDate": "2026-07-31",
+                "expirationDates": [
+                  "2026-07-06",
+                  "2026-07-08",
+                  "2026-07-10",
+                  "2026-07-17",
+                  "2026-07-24",
+                  "2026-07-31",
+                  "2026-08-07",
+                  "2026-08-21",
+                  "2026-09-18",
+                  "2026-10-16",
+                  "2026-11-20",
+                  "2026-12-18",
+                  "2027-01-15",
+                  "2027-03-19",
+                  "2027-06-17",
+                  "2027-09-17",
+                  "2027-12-17",
+                  "2028-01-21",
+                  "2028-06-16",
+                  "2028-12-15"
+                ],
+                "calls": [
+                  {
+                    "contractSymbol": "NVDA260731C00050000",
+                    "type": "call",
+                    "strike": 50,
+                    "expiration": "2026-07-31",
+                    "bid": 140.35,
+                    "ask": 149.6,
+                    "lastPrice": 144.38,
+                    "volume": 1,
+                    "openInterest": 3,
+                    "impliedVolatility": 2.042973642578125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9974633646873057,
+                      "gamma": 0.00009385590229154514,
+                      "theta": -0.027109665007893805,
+                      "vega": 0.005524719526989063,
+                      "rho": 0.037349179229966
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00075000",
+                    "type": "call",
+                    "strike": 75,
+                    "expiration": "2026-07-31",
+                    "bid": 115.45,
+                    "ask": 124.7,
+                    "lastPrice": 125,
+                    "volume": 1,
+                    "openInterest": 8,
+                    "impliedVolatility": 1.5605490722656248,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9945758751911592,
+                      "gamma": 0.00024022145443272923,
+                      "theta": -0.0404838972741899,
+                      "vega": 0.0108012770124266,
+                      "rho": 0.05576665978234455
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00080000",
+                    "type": "call",
+                    "strike": 80,
+                    "expiration": "2026-07-31",
+                    "bid": 110.5,
+                    "ask": 119.75,
+                    "lastPrice": 113.86,
+                    "volume": 1,
+                    "openInterest": 3,
+                    "impliedVolatility": 1.5009790576171875,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9933089550327674,
+                      "gamma": 0.0002997287938894895,
+                      "theta": -0.04582000498857143,
+                      "vega": 0.012962506322171543,
+                      "rho": 0.05932936365678259
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00085000",
+                    "type": "call",
+                    "strike": 85,
+                    "expiration": "2026-07-31",
+                    "bid": 105.5,
+                    "ask": 114.75,
+                    "lastPrice": 109,
+                    "volume": 3,
+                    "openInterest": 15,
+                    "impliedVolatility": 1.40625296875,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9928582416445563,
+                      "gamma": 0.0003384677316028842,
+                      "theta": -0.04618177547036036,
+                      "vega": 0.01371407769021785,
+                      "rho": 0.0630438557033528
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00090000",
+                    "type": "call",
+                    "strike": 90,
+                    "expiration": "2026-07-31",
+                    "bid": 100.55,
+                    "ask": 109.8,
+                    "lastPrice": 103.18,
+                    "volume": 10,
+                    "openInterest": 13,
+                    "impliedVolatility": 1.3486360693359374,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9913845173728506,
+                      "gamma": 0.000414745169526976,
+                      "theta": -0.05123945900108728,
+                      "vega": 0.01611617555719402,
+                      "rho": 0.06657512457072294
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00095000",
+                    "type": "call",
+                    "strike": 95,
+                    "expiration": "2026-07-31",
+                    "bid": 95.55,
+                    "ask": 104.8,
+                    "lastPrice": 99.47,
+                    "volume": 2,
+                    "openInterest": 2,
+                    "impliedVolatility": 1.26172244140625,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9908292900711873,
+                      "gamma": 0.000467657196451611,
+                      "theta": -0.051394316421126,
+                      "vega": 0.01700111213021405,
+                      "rho": 0.07027491670764528
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00100000",
+                    "type": "call",
+                    "strike": 100,
+                    "expiration": "2026-07-31",
+                    "bid": 90.55,
+                    "ask": 99.85,
+                    "lastPrice": 94.4,
+                    "volume": 1,
+                    "openInterest": 19,
+                    "impliedVolatility": 1.193363408203125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9896459245159986,
+                      "gamma": 0.0005483417310816961,
+                      "theta": -0.05393583688431787,
+                      "vega": 0.018854277644462295,
+                      "rho": 0.07386456794949377
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00105000",
+                    "type": "call",
+                    "strike": 105,
+                    "expiration": "2026-07-31",
+                    "bid": 85.6,
+                    "ask": 94.85,
+                    "lastPrice": 88.45,
+                    "volume": 2,
+                    "openInterest": 43,
+                    "impliedVolatility": 1.1259809326171877,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9883902269428435,
+                      "gamma": 0.0006403850592021896,
+                      "theta": -0.056193817362176345,
+                      "vega": 0.02077581691267773,
+                      "rho": 0.07744460833514609
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00110000",
+                    "type": "call",
+                    "strike": 110,
+                    "expiration": "2026-07-31",
+                    "bid": 80.6,
+                    "ask": 89.9,
+                    "lastPrice": 87.78,
+                    "volume": 26,
+                    "openInterest": 66,
+                    "impliedVolatility": 1.0615281298828125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9869474634638162,
+                      "gamma": 0.0007497665238291643,
+                      "theta": -0.058548819855336484,
+                      "vega": 0.022932079321816318,
+                      "rho": 0.08099520976963957
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00115000",
+                    "type": "call",
+                    "strike": 115,
+                    "expiration": "2026-07-31",
+                    "bid": 75.65,
+                    "ask": 84.95,
+                    "lastPrice": 80.63,
+                    "volume": 1,
+                    "openInterest": 62,
+                    "impliedVolatility": 1.0068409033203123,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.984810802316401,
+                      "gamma": 0.0008974448585083444,
+                      "theta": -0.06254299815775366,
+                      "vega": 0.026034815646392446,
+                      "rho": 0.08442870662170227
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00120000",
+                    "type": "call",
+                    "strike": 120,
+                    "expiration": "2026-07-31",
+                    "bid": 70.7,
+                    "ask": 79.95,
+                    "lastPrice": 71.94,
+                    "volume": 1,
+                    "openInterest": 55,
+                    "impliedVolatility": 0.9438482177734374,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9830620185479331,
+                      "gamma": 0.0010480659248489775,
+                      "theta": -0.064418694407035,
+                      "vega": 0.028502085837380474,
+                      "rho": 0.08793489710470778
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00125000",
+                    "type": "call",
+                    "strike": 125,
+                    "expiration": "2026-07-31",
+                    "bid": 65.7,
+                    "ask": 75,
+                    "lastPrice": 72.3,
+                    "volume": 30,
+                    "openInterest": 66,
+                    "impliedVolatility": 0.8818371191406249,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9811484661149179,
+                      "gamma": 0.0012253798550207963,
+                      "theta": -0.0660471875186297,
+                      "vega": 0.03113472214362272,
+                      "rho": 0.09141745540571597
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00130000",
+                    "type": "call",
+                    "strike": 130,
+                    "expiration": "2026-07-31",
+                    "bid": 60.75,
+                    "ask": 70,
+                    "lastPrice": 63.77,
+                    "volume": 29,
+                    "openInterest": 62,
+                    "impliedVolatility": 0.8217791259765624,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9789364897850411,
+                      "gamma": 0.001440098371270335,
+                      "theta": -0.0676880532080825,
+                      "vega": 0.034098332949931656,
+                      "rho": 0.0948542334851325
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00135000",
+                    "type": "call",
+                    "strike": 135,
+                    "expiration": "2026-07-31",
+                    "bid": 55.8,
+                    "ask": 65,
+                    "lastPrice": 58.87,
+                    "volume": 28,
+                    "openInterest": 68,
+                    "impliedVolatility": 0.7622094091796876,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9765031264883207,
+                      "gamma": 0.001697009764713714,
+                      "theta": -0.06899790405532553,
+                      "vega": 0.03726872447760375,
+                      "rho": 0.09825952412800686
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00140000",
+                    "type": "call",
+                    "strike": 140,
+                    "expiration": "2026-07-31",
+                    "bid": 52.45,
+                    "ask": 57.9,
+                    "lastPrice": 55.8,
+                    "volume": 11,
+                    "openInterest": 80,
+                    "impliedVolatility": 0.6367223828125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9824345380505615,
+                      "gamma": 0.0016010656610448849,
+                      "theta": -0.05235152447028108,
+                      "vega": 0.02937278607926643,
+                      "rho": 0.10306265919642753
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00145000",
+                    "type": "call",
+                    "strike": 145,
+                    "expiration": "2026-07-31",
+                    "bid": 47.65,
+                    "ask": 53.05,
+                    "lastPrice": 48.99,
+                    "volume": 148,
+                    "openInterest": 171,
+                    "impliedVolatility": 0.624027197265625,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.974021436753607,
+                      "gamma": 0.0022476954882340566,
+                      "theta": -0.06454995091036875,
+                      "vega": 0.04041353817879439,
+                      "rho": 0.10548716393790793
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00150000",
+                    "type": "call",
+                    "strike": 150,
+                    "expiration": "2026-07-31",
+                    "bid": 43.2,
+                    "ask": 48.15,
+                    "lastPrice": 43.4,
+                    "volume": 151,
+                    "openInterest": 56,
+                    "impliedVolatility": 0.6250037500000001,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9597866973275704,
+                      "gamma": 0.003166752769749386,
+                      "theta": -0.08362356045500337,
+                      "vega": 0.05702728088396099,
+                      "rho": 0.1069450334542415
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00155000",
+                    "type": "call",
+                    "strike": 155,
+                    "expiration": "2026-07-31",
+                    "bid": 38.75,
+                    "ask": 42.4,
+                    "lastPrice": 40,
+                    "volume": 1,
+                    "openInterest": 53,
+                    "impliedVolatility": 0.5454147021484376,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.959415440609974,
+                      "gamma": 0.003654652411913394,
+                      "theta": -0.07651619240608366,
+                      "vega": 0.057432642802621024,
+                      "rho": 0.11073886357061476
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00160000",
+                    "type": "call",
+                    "strike": 160,
+                    "expiration": "2026-07-31",
+                    "bid": 35.7,
+                    "ask": 36.4,
+                    "lastPrice": 39.37,
+                    "volume": 155,
+                    "openInterest": 264,
+                    "impliedVolatility": 0.5473678076171876,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.9372370173652329,
+                      "gamma": 0.005049143436583427,
+                      "theta": -0.09867751105745734,
+                      "vega": 0.07963112334655512,
+                      "rho": 0.11090819916583049
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00165000",
+                    "type": "call",
+                    "strike": 165,
+                    "expiration": "2026-07-31",
+                    "bid": 31,
+                    "ask": 31.7,
+                    "lastPrice": 30.2,
+                    "volume": 24,
+                    "openInterest": 152,
+                    "impliedVolatility": 0.5130663928222656,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.919287037316699,
+                      "gamma": 0.006441097677782089,
+                      "theta": -0.1083437019171401,
+                      "vega": 0.09521806151099658,
+                      "rho": 0.11181292472842735
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00170000",
+                    "type": "call",
+                    "strike": 170,
+                    "expiration": "2026-07-31",
+                    "bid": 26.1,
+                    "ask": 27.05,
+                    "lastPrice": 25.77,
+                    "volume": 68,
+                    "openInterest": 388,
+                    "impliedVolatility": 0.504765694580078,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8859621833779066,
+                      "gamma": 0.008243113345811345,
+                      "theta": -0.12908339869846025,
+                      "vega": 0.1198855900654043,
+                      "rho": 0.11012449002566868
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00175000",
+                    "type": "call",
+                    "strike": 175,
+                    "expiration": "2026-07-31",
+                    "bid": 22.3,
+                    "ask": 22.75,
+                    "lastPrice": 21,
+                    "volume": 37,
+                    "openInterest": 583,
+                    "impliedVolatility": 0.48071808349609374,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8490286866490263,
+                      "gamma": 0.010262166532604786,
+                      "theta": -0.14277813456946276,
+                      "vega": 0.14213970178444327,
+                      "rho": 0.10785866311089089
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00180000",
+                    "type": "call",
+                    "strike": 180,
+                    "expiration": "2026-07-31",
+                    "bid": 17.8,
+                    "ask": 18.65,
+                    "lastPrice": 18.1,
+                    "volume": 141,
+                    "openInterest": 374,
+                    "impliedVolatility": 0.4563042651367188,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.8008807580489582,
+                      "gamma": 0.012543401602203335,
+                      "theta": -0.15451972932469457,
+                      "vega": 0.16491332111224186,
+                      "rho": 0.10370490991212673
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00185000",
+                    "type": "call",
+                    "strike": 185,
+                    "expiration": "2026-07-31",
+                    "bid": 14.6,
+                    "ask": 14.95,
+                    "lastPrice": 14.7,
+                    "volume": 161,
+                    "openInterest": 923,
+                    "impliedVolatility": 0.43933666137695315,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.7353565973301581,
+                      "gamma": 0.014780696765187668,
+                      "theta": -0.16576238632304283,
+                      "vega": 0.18710191605298424,
+                      "rho": 0.09650096011063618
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00190000",
+                    "type": "call",
+                    "strike": 190,
+                    "expiration": "2026-07-31",
+                    "bid": 11.25,
+                    "ask": 11.65,
+                    "lastPrice": 11.55,
+                    "volume": 422,
+                    "openInterest": 2058,
+                    "impliedVolatility": 0.4249325085449219,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": 0.6511914341598732,
+                      "gamma": 0.016693477926702324,
+                      "theta": -0.1722421084112266,
+                      "vega": 0.20438671647391413,
+                      "rho": 0.085907548488884
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00195000",
+                    "type": "call",
+                    "strike": 195,
+                    "expiration": "2026-07-31",
+                    "bid": 8.5,
+                    "ask": 8.75,
+                    "lastPrice": 8.69,
+                    "volume": 1411,
+                    "openInterest": 2861,
+                    "impliedVolatility": 0.41040628662109374,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.544835098062967,
+                      "gamma": 0.01804800451173572,
+                      "theta": -0.17091983067980882,
+                      "vega": 0.21341703299830514,
+                      "rho": 0.0712093382036561
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00200000",
+                    "type": "call",
+                    "strike": 200,
+                    "expiration": "2026-07-31",
+                    "bid": 6.2,
+                    "ask": 6.35,
+                    "lastPrice": 6.4,
+                    "volume": 2729,
+                    "openInterest": 8008,
+                    "impliedVolatility": 0.3986876538085938,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.4212237094039692,
+                      "gamma": 0.018435974325929166,
+                      "theta": -0.16245812256925038,
+                      "vega": 0.21177991224696865,
+                      "rho": 0.05585860610958057
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00205000",
+                    "type": "call",
+                    "strike": 205,
+                    "expiration": "2026-07-31",
+                    "bid": 4.4,
+                    "ask": 4.55,
+                    "lastPrice": 4.6,
+                    "volume": 2875,
+                    "openInterest": 5680,
+                    "impliedVolatility": 0.39441523559570313,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.31802679573590215,
+                      "gamma": 0.017537737173245832,
+                      "theta": -0.149589191705007,
+                      "vega": 0.19930267248862804,
+                      "rho": 0.04281065188904575
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00210000",
+                    "type": "call",
+                    "strike": 210,
+                    "expiration": "2026-07-31",
+                    "bid": 3.1,
+                    "ask": 3.2,
+                    "lastPrice": 3.15,
+                    "volume": 4045,
+                    "openInterest": 4856,
+                    "impliedVolatility": 0.39282833740234374,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.2359476499595149,
+                      "gamma": 0.01576871119412889,
+                      "theta": -0.13232732300642727,
+                      "vega": 0.17847808204411691,
+                      "rho": 0.03212829333936166
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00215000",
+                    "type": "call",
+                    "strike": 215,
+                    "expiration": "2026-07-31",
+                    "bid": 2.1,
+                    "ask": 2.16,
+                    "lastPrice": 2.19,
+                    "volume": 2155,
+                    "openInterest": 3482,
+                    "impliedVolatility": 0.3892883337402344,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.16981702759214423,
+                      "gamma": 0.013534468097511604,
+                      "theta": -0.11086750653759848,
+                      "vega": 0.15180933014658618,
+                      "rho": 0.023353475441328465
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00220000",
+                    "type": "call",
+                    "strike": 220,
+                    "expiration": "2026-07-31",
+                    "bid": 1.41,
+                    "ask": 1.47,
+                    "lastPrice": 1.48,
+                    "volume": 4791,
+                    "openInterest": 7319,
+                    "impliedVolatility": 0.39087523193359375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.12154746595279364,
+                      "gamma": 0.011081411987754974,
+                      "theta": -0.0910734037327629,
+                      "vega": 0.12480130762779984,
+                      "rho": 0.016830707377764473
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00225000",
+                    "type": "call",
+                    "strike": 225,
+                    "expiration": "2026-07-31",
+                    "bid": 0.95,
+                    "ask": 1,
+                    "lastPrice": 1.01,
+                    "volume": 2184,
+                    "openInterest": 7063,
+                    "impliedVolatility": 0.3942931665039063,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.08635233235203271,
+                      "gamma": 0.00878052310556315,
+                      "theta": -0.07315112829001358,
+                      "vega": 0.0997528982739273,
+                      "rho": 0.012019876243943805
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00230000",
+                    "type": "call",
+                    "strike": 230,
+                    "expiration": "2026-07-31",
+                    "bid": 0.66,
+                    "ask": 0.69,
+                    "lastPrice": 0.69,
+                    "volume": 3372,
+                    "openInterest": 8983,
+                    "impliedVolatility": 0.39990834472656256,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.06154648305930288,
+                      "gamma": 0.0068132041096969475,
+                      "theta": -0.05820999036895927,
+                      "vega": 0.07850507783323178,
+                      "rho": 0.008599832454475986
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00235000",
+                    "type": "call",
+                    "strike": 235,
+                    "expiration": "2026-07-31",
+                    "bid": 0.46,
+                    "ask": 0.49,
+                    "lastPrice": 0.47,
+                    "volume": 408,
+                    "openInterest": 2894,
+                    "impliedVolatility": 0.40820904296875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.04463228594313745,
+                      "gamma": 0.00525199761652058,
+                      "theta": -0.046635427466601875,
+                      "vega": 0.0617721936102983,
+                      "rho": 0.006252537406769943
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00240000",
+                    "type": "call",
+                    "strike": 240,
+                    "expiration": "2026-07-31",
+                    "bid": 0.33,
+                    "ask": 0.35,
+                    "lastPrice": 0.33,
+                    "volume": 412,
+                    "openInterest": 3253,
+                    "impliedVolatility": 0.4165097412109374,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.03244241700659389,
+                      "gamma": 0.004019212416368062,
+                      "theta": -0.0370779604742186,
+                      "vega": 0.04823385846876859,
+                      "rho": 0.004554484988420374
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00245000",
+                    "type": "call",
+                    "strike": 245,
+                    "expiration": "2026-07-31",
+                    "bid": 0.24,
+                    "ask": 0.27,
+                    "lastPrice": 0.25,
+                    "volume": 35,
+                    "openInterest": 1303,
+                    "impliedVolatility": 0.43018147949218755,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.02505912336811339,
+                      "gamma": 0.003167338952446533,
+                      "theta": -0.031113318157109746,
+                      "vega": 0.039258358177738886,
+                      "rho": 0.0035202552810225302
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00250000",
+                    "type": "call",
+                    "strike": 250,
+                    "expiration": "2026-07-31",
+                    "bid": 0.18,
+                    "ask": 0.21,
+                    "lastPrice": 0.19,
+                    "volume": 3197,
+                    "openInterest": 6971,
+                    "impliedVolatility": 0.44287666503906253,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.019421795983905865,
+                      "gamma": 0.0025004154976772984,
+                      "theta": -0.02599423424721608,
+                      "vega": 0.031906624586824445,
+                      "rho": 0.0027300191462580796
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00255000",
+                    "type": "call",
+                    "strike": 255,
+                    "expiration": "2026-07-31",
+                    "bid": 0.14,
+                    "ask": 0.17,
+                    "lastPrice": 0.14,
+                    "volume": 61,
+                    "openInterest": 426,
+                    "impliedVolatility": 0.45703667968750006,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.015514374149527721,
+                      "gamma": 0.002012244682521048,
+                      "theta": -0.0222496681354335,
+                      "vega": 0.026498282553958738,
+                      "rho": 0.0021810757601981464
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00260000",
+                    "type": "call",
+                    "strike": 260,
+                    "expiration": "2026-07-31",
+                    "bid": 0.1,
+                    "ask": 0.18,
+                    "lastPrice": 0.11,
+                    "volume": 34,
+                    "openInterest": 1449,
+                    "impliedVolatility": 0.48828636718750007,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.01531823224933987,
+                      "gamma": 0.0018636119017984981,
+                      "theta": -0.023491702269587304,
+                      "vega": 0.026218989930962788,
+                      "rho": 0.002146445740729465
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00265000",
+                    "type": "call",
+                    "strike": 265,
+                    "expiration": "2026-07-31",
+                    "bid": 0.08,
+                    "ask": 0.15,
+                    "lastPrice": 0.1,
+                    "volume": 605,
+                    "openInterest": 1140,
+                    "impliedVolatility": 0.5029346582031251,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.012745386940847092,
+                      "gamma": 0.0015511306952262465,
+                      "theta": -0.020723670831192625,
+                      "vega": 0.022477387837505285,
+                      "rho": 0.001785647873164305
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00270000",
+                    "type": "call",
+                    "strike": 270,
+                    "expiration": "2026-07-31",
+                    "bid": 0.07,
+                    "ask": 0.14,
+                    "lastPrice": 0.12,
+                    "volume": 98,
+                    "openInterest": 908,
+                    "impliedVolatility": 0.5039112109375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.009108520153261745,
+                      "gamma": 0.001164155773083957,
+                      "theta": -0.015602026574417033,
+                      "vega": 0.01690250211998924,
+                      "rho": 0.0012790040098679453
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00275000",
+                    "type": "call",
+                    "strike": 275,
+                    "expiration": "2026-07-31",
+                    "bid": 0.05,
+                    "ask": 0.1,
+                    "lastPrice": 0.06,
+                    "volume": 110,
+                    "openInterest": 1314,
+                    "impliedVolatility": 0.507817421875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.006729600249648637,
+                      "gamma": 0.0008903388796698299,
+                      "theta": -0.012109559271052384,
+                      "vega": 0.01302713210813787,
+                      "rho": 0.0009464014062028882
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00280000",
+                    "type": "call",
+                    "strike": 280,
+                    "expiration": "2026-07-31",
+                    "bid": 0.03,
+                    "ask": 0.12,
+                    "lastPrice": 0.08,
+                    "volume": 1,
+                    "openInterest": 241,
+                    "impliedVolatility": 0.5293015820312501,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.006340367933683755,
+                      "gamma": 0.0008112252860756349,
+                      "theta": -0.011978443661813068,
+                      "vega": 0.012371733424835543,
+                      "rho": 0.0008901405480546548
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00285000",
+                    "type": "call",
+                    "strike": 285,
+                    "expiration": "2026-07-31",
+                    "bid": 0.03,
+                    "ask": 0.11,
+                    "lastPrice": 0.06,
+                    "volume": 1,
+                    "openInterest": 177,
+                    "impliedVolatility": 0.5478560839843751,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.005813356994328278,
+                      "gamma": 0.0007268406486444967,
+                      "theta": -0.011490971694150379,
+                      "vega": 0.011473385304121024,
+                      "rho": 0.0008151441418751766
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00290000",
+                    "type": "call",
+                    "strike": 290,
+                    "expiration": "2026-07-31",
+                    "bid": 0.02,
+                    "ask": 0.1,
+                    "lastPrice": 0.06,
+                    "volume": 2,
+                    "openInterest": 191,
+                    "impliedVolatility": 0.56055126953125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.004991229862974289,
+                      "gamma": 0.0006219121013503277,
+                      "theta": -0.010287552535501926,
+                      "vega": 0.010044544111402707,
+                      "rho": 0.0006996813450215056
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00295000",
+                    "type": "call",
+                    "strike": 295,
+                    "expiration": "2026-07-31",
+                    "bid": 0.02,
+                    "ask": 0.1,
+                    "lastPrice": 0.04,
+                    "volume": 2,
+                    "openInterest": 23,
+                    "impliedVolatility": 0.5800823242187501,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0047376035040150866,
+                      "gamma": 0.0005741591847495538,
+                      "theta": -0.010165842068041709,
+                      "vega": 0.009596388709568962,
+                      "rho": 0.0006631346433085846
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00300000",
+                    "type": "call",
+                    "strike": 300,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.05,
+                    "lastPrice": 0.05,
+                    "volume": 23,
+                    "openInterest": 6430,
+                    "impliedVolatility": 0.5585981640625001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.002547536182624377,
+                      "gamma": 0.0003445755642955859,
+                      "theta": -0.005655475315712052,
+                      "vega": 0.005545872263174758,
+                      "rho": 0.0003584925302818822
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00305000",
+                    "type": "call",
+                    "strike": 305,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.04,
+                    "lastPrice": 0.03,
+                    "volume": 2,
+                    "openInterest": 1473,
+                    "impliedVolatility": 0.570316796875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0022105210551841004,
+                      "gamma": 0.00029734419131630693,
+                      "theta": -0.005085108094035347,
+                      "vega": 0.004886090466778387,
+                      "rho": 0.0003109687616345582
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00310000",
+                    "type": "call",
+                    "strike": 310,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.04,
+                    "lastPrice": 0.03,
+                    "volume": 80,
+                    "openInterest": 111,
+                    "impliedVolatility": 0.585941640625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0020580793617518967,
+                      "gamma": 0.0002714890969249324,
+                      "theta": -0.004898940852526633,
+                      "vega": 0.004583451476354867,
+                      "rho": 0.00028923872715979173
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00315000",
+                    "type": "call",
+                    "strike": 315,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.05,
+                    "lastPrice": 0.02,
+                    "volume": 16,
+                    "openInterest": 37,
+                    "impliedVolatility": 0.6132851171875001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0023014904366992495,
+                      "gamma": 0.00028665907364420004,
+                      "theta": -0.005664542199608636,
+                      "vega": 0.005065402974377306,
+                      "rho": 0.0003225112430535078
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00320000",
+                    "type": "call",
+                    "strike": 320,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.03,
+                    "lastPrice": 0.02,
+                    "volume": 402,
+                    "openInterest": 111,
+                    "impliedVolatility": 0.6093789062500001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0016216610322022373,
+                      "gamma": 0.00021075987297416768,
+                      "theta": -0.004110694722645816,
+                      "vega": 0.0037005069776287584,
+                      "rho": 0.0002277189315743274
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00325000",
+                    "type": "call",
+                    "strike": 325,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.03,
+                    "lastPrice": 0.06,
+                    "volume": 1,
+                    "openInterest": 47,
+                    "impliedVolatility": 0.6250037500000001,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0015484484493100137,
+                      "gamma": 0.00019711730154733746,
+                      "theta": -0.004043058039517269,
+                      "vega": 0.003549713078270414,
+                      "rho": 0.0002172054556136043
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00330000",
+                    "type": "call",
+                    "strike": 330,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.03,
+                    "lastPrice": 0.11,
+                    "volume": 1,
+                    "openInterest": 46,
+                    "impliedVolatility": 0.64062859375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.0014884633649091539,
+                      "gamma": 0.0001855818907486325,
+                      "theta": -0.003998020763525831,
+                      "vega": 0.0034255301665238424,
+                      "rho": 0.00020856289643169073
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00335000",
+                    "type": "call",
+                    "strike": 335,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.19,
+                    "lastPrice": 0.06,
+                    "volume": 3,
+                    "openInterest": 10,
+                    "impliedVolatility": 0.981445498046875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.024310843710338703,
+                      "gamma": 0.0013547411272306527,
+                      "theta": -0.06843353175472282,
+                      "vega": 0.038309667696072,
+                      "rho": 0.003209488629092156
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00340000",
+                    "type": "call",
+                    "strike": 340,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.4,
+                    "lastPrice": 0.15,
+                    "volume": 1,
+                    "openInterest": 6,
+                    "impliedVolatility": 1.0293017285156252,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.027050267770835024,
+                      "gamma": 0.0014076169554810758,
+                      "theta": -0.07818564858543675,
+                      "vega": 0.041745827471671035,
+                      "rho": 0.0035450644260914647
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00345000",
+                    "type": "call",
+                    "strike": 345,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.21,
+                    "lastPrice": 0.01,
+                    "volume": 1,
+                    "openInterest": 10,
+                    "impliedVolatility": 1.0263720556640625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.023719397159360556,
+                      "gamma": 0.001269896385166174,
+                      "theta": -0.0701237471554548,
+                      "vega": 0.037554240963751664,
+                      "rho": 0.0031174387180637254
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00350000",
+                    "type": "call",
+                    "strike": 350,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.23,
+                    "lastPrice": 0.03,
+                    "volume": 2,
+                    "openInterest": 3,
+                    "impliedVolatility": 1.0498094384765626,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.023626312477164957,
+                      "gamma": 0.0012375998137792719,
+                      "theta": -0.07148247615536628,
+                      "vega": 0.037434892533320704,
+                      "rho": 0.003097510805964562
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00360000",
+                    "type": "call",
+                    "strike": 360,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.25,
+                    "lastPrice": 0.04,
+                    "volume": 2,
+                    "openInterest": 3,
+                    "impliedVolatility": 1.0927779736328125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.023165427582727882,
+                      "gamma": 0.0011701102293698038,
+                      "theta": -0.0732030910193937,
+                      "vega": 0.03684211815592852,
+                      "rho": 0.003024116704590581
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00380000",
+                    "type": "call",
+                    "strike": 380,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.28,
+                    "lastPrice": 0.01,
+                    "volume": 13,
+                    "openInterest": 16,
+                    "impliedVolatility": 1.1733439770507812,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.022269546498172532,
+                      "gamma": 0.0010554180454284104,
+                      "theta": -0.07607568757748244,
+                      "vega": 0.03568089554907327,
+                      "rho": 0.0028844149142583913
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00390000",
+                    "type": "call",
+                    "strike": 390,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.29,
+                    "lastPrice": 0.01,
+                    "volume": 2,
+                    "openInterest": 1,
+                    "impliedVolatility": 1.2114297241210936,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.021859048612076715,
+                      "gamma": 0.0010068774315491488,
+                      "theta": -0.07734457409218384,
+                      "vega": 0.03514477071867999,
+                      "rho": 0.0028208996061351837
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731C00400000",
+                    "type": "call",
+                    "strike": 400,
+                    "expiration": "2026-07-31",
+                    "bid": 0,
+                    "ask": 1.31,
+                    "lastPrice": 0.01,
+                    "volume": 4,
+                    "openInterest": 130,
+                    "impliedVolatility": 1.249515471191406,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": 0.021591820215225765,
+                      "gamma": 0.0009664545141392226,
+                      "theta": -0.07896191101865759,
+                      "vega": 0.03479436692864035,
+                      "rho": 0.002775948897343874
+                    }
+                  }
+                ],
+                "puts": [
+                  {
+                    "contractSymbol": "NVDA260731P00065000",
+                    "type": "put",
+                    "strike": 65,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 1.18,
+                    "lastPrice": 0.02,
+                    "volume": 25,
+                    "openInterest": 125,
+                    "impliedVolatility": 2.032231481933594,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.009258242619899493,
+                      "gamma": 0.0002927143322731162,
+                      "theta": -0.06254732465255174,
+                      "vega": 0.017139693234054156,
+                      "rho": -0.00173638855498635
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00070000",
+                    "type": "put",
+                    "strike": 70,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 0.1,
+                    "lastPrice": 0.02,
+                    "volume": 58,
+                    "openInterest": 47,
+                    "impliedVolatility": 1.39453427734375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0015349069346290989,
+                      "gamma": 0.00008764778542722438,
+                      "theta": -0.008816583239826295,
+                      "vega": 0.003521729727341674,
+                      "rho": -0.0002580358094013297
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00075000",
+                    "type": "put",
+                    "strike": 75,
+                    "expiration": "2026-07-31",
+                    "bid": 0.01,
+                    "ask": 1.07,
+                    "lastPrice": 0.09,
+                    "volume": 4,
+                    "openInterest": 33,
+                    "impliedVolatility": 1.7568371533203124,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.009889604756514236,
+                      "gamma": 0.00035820318087022393,
+                      "theta": -0.05716477372570312,
+                      "vega": 0.01813204664759107,
+                      "rho": -0.0017940069427677943
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00080000",
+                    "type": "put",
+                    "strike": 80,
+                    "expiration": "2026-07-31",
+                    "bid": 0.02,
+                    "ask": 0.07,
+                    "lastPrice": 0.06,
+                    "volume": 45,
+                    "openInterest": 58,
+                    "impliedVolatility": 1.1953165234375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0014737047190731545,
+                      "gamma": 0.00009857265086115445,
+                      "theta": -0.0072795329394518965,
+                      "vega": 0.0033948863596096456,
+                      "rho": -0.00024291607794808844
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00085000",
+                    "type": "put",
+                    "strike": 85,
+                    "expiration": "2026-07-31",
+                    "bid": 0.04,
+                    "ask": 0.12,
+                    "lastPrice": 0.23,
+                    "volume": 12,
+                    "openInterest": 14,
+                    "impliedVolatility": 1.19141029296875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0025513472433866813,
+                      "gamma": 0.00016177117508014773,
+                      "theta": -0.01186389452796581,
+                      "vega": 0.0055532646407175645,
+                      "rho": -0.0004229750385855623
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00090000",
+                    "type": "put",
+                    "strike": 90,
+                    "expiration": "2026-07-31",
+                    "bid": 0.02,
+                    "ask": 0.13,
+                    "lastPrice": 0.08,
+                    "volume": 5,
+                    "openInterest": 6,
+                    "impliedVolatility": 1.1054732226562503,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.002568157314634778,
+                      "gamma": 0.00017537006450774498,
+                      "theta": -0.011067809553496781,
+                      "vega": 0.005585853887173803,
+                      "rho": -0.0004221250512134734
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00095000",
+                    "type": "put",
+                    "strike": 95,
+                    "expiration": "2026-07-31",
+                    "bid": 0.03,
+                    "ask": 0.14,
+                    "lastPrice": 0.07,
+                    "volume": 0,
+                    "openInterest": 2,
+                    "impliedVolatility": 1.0468797656250002,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0030110543383842225,
+                      "gamma": 0.00021332716525672096,
+                      "theta": -0.01206811286839072,
+                      "vega": 0.006434708097141282,
+                      "rho": -0.0004928684640300229
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00100000",
+                    "type": "put",
+                    "strike": 100,
+                    "expiration": "2026-07-31",
+                    "bid": 0.05,
+                    "ask": 0.1,
+                    "lastPrice": 0.07,
+                    "volume": 511,
+                    "openInterest": 1822,
+                    "impliedVolatility": 0.9648441015625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0029347578680603004,
+                      "gamma": 0.00022625154266748065,
+                      "theta": -0.010866075530226066,
+                      "vega": 0.00628976728931554,
+                      "rho": -0.00047628597558751763
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00105000",
+                    "type": "put",
+                    "strike": 105,
+                    "expiration": "2026-07-31",
+                    "bid": 0.05,
+                    "ask": 0.13,
+                    "lastPrice": 0.11,
+                    "volume": 250,
+                    "openInterest": 362,
+                    "impliedVolatility": 0.9179695703125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0036159829147377476,
+                      "gamma": 0.0002860857286063545,
+                      "theta": -0.01242987277348539,
+                      "vega": 0.0075667669963294356,
+                      "rho": -0.0005852770436046642
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00110000",
+                    "type": "put",
+                    "strike": 110,
+                    "expiration": "2026-07-31",
+                    "bid": 0.06,
+                    "ask": 0.17,
+                    "lastPrice": 0.08,
+                    "volume": 1,
+                    "openInterest": 146,
+                    "impliedVolatility": 0.8808605664062499,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.004732281840442831,
+                      "gamma": 0.00037773499592988767,
+                      "theta": -0.01510211004830701,
+                      "vega": 0.009586945826948922,
+                      "rho": -0.0007651126282383932
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00115000",
+                    "type": "put",
+                    "strike": 115,
+                    "expiration": "2026-07-31",
+                    "bid": 0.07,
+                    "ask": 0.19,
+                    "lastPrice": 0.12,
+                    "volume": 3,
+                    "openInterest": 165,
+                    "impliedVolatility": 0.8320329296874999,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.005627716277216921,
+                      "gamma": 0.00046525979981183843,
+                      "theta": -0.016584441960406003,
+                      "vega": 0.011153776213758333,
+                      "rho": -0.0009068082793160634
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00120000",
+                    "type": "put",
+                    "strike": 120,
+                    "expiration": "2026-07-31",
+                    "bid": 0.1,
+                    "ask": 0.15,
+                    "lastPrice": 0.11,
+                    "volume": 58,
+                    "openInterest": 154,
+                    "impliedVolatility": 0.7675804492187501,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.005877966680233104,
+                      "gamma": 0.0005237900036809005,
+                      "theta": -0.015877172840344227,
+                      "vega": 0.011584225223363422,
+                      "rho": -0.0009410240737606556
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00125000",
+                    "type": "put",
+                    "strike": 125,
+                    "expiration": "2026-07-31",
+                    "bid": 0.12,
+                    "ask": 0.19,
+                    "lastPrice": 0.15,
+                    "volume": 2,
+                    "openInterest": 228,
+                    "impliedVolatility": 0.729494892578125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.007475308178235274,
+                      "gamma": 0.0006786750644534345,
+                      "theta": -0.018564392428946683,
+                      "vega": 0.014264942676258401,
+                      "rho": -0.00119461436540771
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00130000",
+                    "type": "put",
+                    "strike": 130,
+                    "expiration": "2026-07-31",
+                    "bid": 0.15,
+                    "ask": 0.21,
+                    "lastPrice": 0.17,
+                    "volume": 36,
+                    "openInterest": 237,
+                    "impliedVolatility": 0.6865265722656251,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.009104192146691004,
+                      "gamma": 0.0008541443641194642,
+                      "theta": -0.020671331000011273,
+                      "vega": 0.01689563478950506,
+                      "rho": -0.0014508217849675514
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00135000",
+                    "type": "put",
+                    "strike": 135,
+                    "expiration": "2026-07-31",
+                    "bid": 0.21,
+                    "ask": 0.24,
+                    "lastPrice": 0.21,
+                    "volume": 33,
+                    "openInterest": 175,
+                    "impliedVolatility": 0.65039412109375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.011668210530517364,
+                      "gamma": 0.0011133687697674579,
+                      "theta": -0.02415453843676906,
+                      "vega": 0.020864189781633485,
+                      "rho": -0.0018564138322470405
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00140000",
+                    "type": "put",
+                    "strike": 140,
+                    "expiration": "2026-07-31",
+                    "bid": 0.26,
+                    "ask": 0.3,
+                    "lastPrice": 0.25,
+                    "volume": 49,
+                    "openInterest": 432,
+                    "impliedVolatility": 0.6152382226562501,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.01504188427912756,
+                      "gamma": 0.001456788109643349,
+                      "theta": -0.028241659491237213,
+                      "vega": 0.025824122862093662,
+                      "rho": -0.0023896210960425886
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00145000",
+                    "type": "put",
+                    "strike": 145,
+                    "expiration": "2026-07-31",
+                    "bid": 0.33,
+                    "ask": 0.36,
+                    "lastPrice": 0.35,
+                    "volume": 24,
+                    "openInterest": 184,
+                    "impliedVolatility": 0.579105771484375,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.0192532112009014,
+                      "gamma": 0.0018985754935099423,
+                      "theta": -0.032556918926054126,
+                      "vega": 0.03167901330552354,
+                      "rho": -0.003053396726194652
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00150000",
+                    "type": "put",
+                    "strike": 150,
+                    "expiration": "2026-07-31",
+                    "bid": 0.43,
+                    "ask": 0.46,
+                    "lastPrice": 0.48,
+                    "volume": 117,
+                    "openInterest": 1334,
+                    "impliedVolatility": 0.5473678076171876,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.025489198813548608,
+                      "gamma": 0.002523593050960273,
+                      "theta": -0.03858682300042442,
+                      "vega": 0.039800126901030734,
+                      "rho": -0.004039098779605261
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00155000",
+                    "type": "put",
+                    "strike": 155,
+                    "expiration": "2026-07-31",
+                    "bid": 0.57,
+                    "ask": 0.6,
+                    "lastPrice": 0.63,
+                    "volume": 138,
+                    "openInterest": 953,
+                    "impliedVolatility": 0.51758294921875,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.03425069309320328,
+                      "gamma": 0.0033752533669574314,
+                      "theta": -0.046037840433347944,
+                      "vega": 0.0503352491215157,
+                      "rho": -0.005425746982706381
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00160000",
+                    "type": "put",
+                    "strike": 160,
+                    "expiration": "2026-07-31",
+                    "bid": 0.77,
+                    "ask": 0.82,
+                    "lastPrice": 0.79,
+                    "volume": 288,
+                    "openInterest": 872,
+                    "impliedVolatility": 0.4953663745117188,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.048223346555691715,
+                      "gamma": 0.004589501891127807,
+                      "theta": -0.057180058206463075,
+                      "vega": 0.06550552908923495,
+                      "rho": -0.0076511462850015095
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00165000",
+                    "type": "put",
+                    "strike": 165,
+                    "expiration": "2026-07-31",
+                    "bid": 1.09,
+                    "ask": 1.13,
+                    "lastPrice": 1.15,
+                    "volume": 506,
+                    "openInterest": 1330,
+                    "impliedVolatility": 0.471684970703125,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.066955798382339,
+                      "gamma": 0.006139591696326228,
+                      "theta": -0.06910826903321375,
+                      "vega": 0.08344059857465386,
+                      "rho": -0.010639969245091078
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00170000",
+                    "type": "put",
+                    "strike": 170,
+                    "expiration": "2026-07-31",
+                    "bid": 1.56,
+                    "ask": 1.62,
+                    "lastPrice": 1.57,
+                    "volume": 867,
+                    "openInterest": 72199,
+                    "impliedVolatility": 0.4542290905761719,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.09507118318872676,
+                      "gamma": 0.008134323116827642,
+                      "theta": -0.0845326833045357,
+                      "vega": 0.1064589667404526,
+                      "rho": -0.015162365654846322
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00175000",
+                    "type": "put",
+                    "strike": 175,
+                    "expiration": "2026-07-31",
+                    "bid": 2.23,
+                    "ask": 2.3,
+                    "lastPrice": 2.24,
+                    "volume": 1121,
+                    "openInterest": 3260,
+                    "impliedVolatility": 0.43726148681640625,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.13337357510747083,
+                      "gamma": 0.010486981251778627,
+                      "theta": -0.10040481902184337,
+                      "vega": 0.13212274895918782,
+                      "rho": -0.02136735305304045
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00180000",
+                    "type": "put",
+                    "strike": 180,
+                    "expiration": "2026-07-31",
+                    "bid": 3.15,
+                    "ask": 3.3,
+                    "lastPrice": 3.2,
+                    "volume": 1207,
+                    "openInterest": 6033,
+                    "impliedVolatility": 0.42529871582031253,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.18666987593471418,
+                      "gamma": 0.013025559784406218,
+                      "theta": -0.11707563273790396,
+                      "vega": 0.1596159732126796,
+                      "rho": -0.030115262385939603
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00185000",
+                    "type": "put",
+                    "strike": 185,
+                    "expiration": "2026-07-31",
+                    "bid": 4.45,
+                    "ask": 4.65,
+                    "lastPrice": 4.45,
+                    "volume": 1228,
+                    "openInterest": 3357,
+                    "impliedVolatility": 0.4146787048339844,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.25624363895326674,
+                      "gamma": 0.015461910810818259,
+                      "theta": -0.1307260310033521,
+                      "vega": 0.1847399320518913,
+                      "rho": -0.04170932334159552
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00190000",
+                    "type": "put",
+                    "strike": 190,
+                    "expiration": "2026-07-31",
+                    "bid": 6.2,
+                    "ask": 6.3,
+                    "lastPrice": 6.08,
+                    "volume": 1445,
+                    "openInterest": 8238,
+                    "impliedVolatility": 0.39990834472656256,
+                    "inTheMoney": false,
+                    "greeks": {
+                      "delta": -0.3436527995771703,
+                      "gamma": 0.017671918847006824,
+                      "theta": -0.1367654500223162,
+                      "vega": 0.20362451237477092,
+                      "rho": -0.056478473708845664
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00195000",
+                    "type": "put",
+                    "strike": 195,
+                    "expiration": "2026-07-31",
+                    "bid": 8.35,
+                    "ask": 8.55,
+                    "lastPrice": 8.3,
+                    "volume": 1049,
+                    "openInterest": 3203,
+                    "impliedVolatility": 0.39325557922363286,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.45581342207111497,
+                      "gamma": 0.018837018536603554,
+                      "theta": -0.13776943829168048,
+                      "vega": 0.21343858853384134,
+                      "rho": -0.07596300103246371
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00200000",
+                    "type": "put",
+                    "strike": 200,
+                    "expiration": "2026-07-31",
+                    "bid": 10.95,
+                    "ask": 11.25,
+                    "lastPrice": 10.9,
+                    "volume": 707,
+                    "openInterest": 3154,
+                    "impliedVolatility": 0.3859924682617187,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.5829477144094435,
+                      "gamma": 0.01901768271522473,
+                      "theta": -0.13006089328070752,
+                      "vega": 0.21150581415122374,
+                      "rho": -0.09571428227152275
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00205000",
+                    "type": "put",
+                    "strike": 205,
+                    "expiration": "2026-07-31",
+                    "bid": 13.95,
+                    "ask": 14.55,
+                    "lastPrice": 14.19,
+                    "volume": 119,
+                    "openInterest": 1443,
+                    "impliedVolatility": 0.38587039916992183,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.6863104073655915,
+                      "gamma": 0.017852023196278054,
+                      "theta": -0.11788053509750754,
+                      "vega": 0.19847910326760207,
+                      "rho": -0.11268263042159159
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00210000",
+                    "type": "put",
+                    "strike": 210,
+                    "expiration": "2026-07-31",
+                    "bid": 17.55,
+                    "ask": 18.25,
+                    "lastPrice": 18,
+                    "volume": 101,
+                    "openInterest": 1025,
+                    "impliedVolatility": 0.3860535028076171,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.7681169479397686,
+                      "gamma": 0.015923819017677324,
+                      "theta": -0.10045565821468265,
+                      "vega": 0.17712530562108314,
+                      "rho": -0.1271621974795571
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00215000",
+                    "type": "put",
+                    "strike": 215,
+                    "expiration": "2026-07-31",
+                    "bid": 21.55,
+                    "ask": 22.4,
+                    "lastPrice": 22.22,
+                    "volume": 34,
+                    "openInterest": 567,
+                    "impliedVolatility": 0.3940490283203125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8272301978781633,
+                      "gamma": 0.013496282668780491,
+                      "theta": -0.08391097964413079,
+                      "vega": 0.1532322959522463,
+                      "rho": -0.13885007329193041
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00220000",
+                    "type": "put",
+                    "strike": 220,
+                    "expiration": "2026-07-31",
+                    "bid": 25.9,
+                    "ask": 26.75,
+                    "lastPrice": 28.15,
+                    "volume": 45,
+                    "openInterest": 585,
+                    "impliedVolatility": 0.39990834472656256,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8731155848423534,
+                      "gamma": 0.0111232126879724,
+                      "theta": -0.06564023781796519,
+                      "vega": 0.12816710959562105,
+                      "rho": -0.14883092892211644
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00225000",
+                    "type": "put",
+                    "strike": 225,
+                    "expiration": "2026-07-31",
+                    "bid": 30.45,
+                    "ask": 31.35,
+                    "lastPrice": 32.45,
+                    "volume": 3,
+                    "openInterest": 117,
+                    "impliedVolatility": 0.41235939208984373,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9040491428737618,
+                      "gamma": 0.009015551317180842,
+                      "theta": -0.051408224385598555,
+                      "vega": 0.10711593000446128,
+                      "rho": -0.1568437684386087
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00230000",
+                    "type": "put",
+                    "strike": 230,
+                    "expiration": "2026-07-31",
+                    "bid": 35.2,
+                    "ask": 36.1,
+                    "lastPrice": 34.7,
+                    "volume": 9,
+                    "openInterest": 133,
+                    "impliedVolatility": 0.4294490649414063,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9247920043242213,
+                      "gamma": 0.0073245871250610835,
+                      "theta": -0.040737669524552725,
+                      "vega": 0.09063181828622911,
+                      "rho": -0.16348542722003656
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00235000",
+                    "type": "put",
+                    "strike": 235,
+                    "expiration": "2026-07-31",
+                    "bid": 39.9,
+                    "ask": 40.9,
+                    "lastPrice": 35.62,
+                    "volume": 2,
+                    "openInterest": 140,
+                    "impliedVolatility": 0.44434149414062496,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9410852485398751,
+                      "gamma": 0.005939037489885595,
+                      "theta": -0.03038073022842344,
+                      "vega": 0.07603592263435725,
+                      "rho": -0.1695160665950136
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00240000",
+                    "type": "put",
+                    "strike": 240,
+                    "expiration": "2026-07-31",
+                    "bid": 41.4,
+                    "ask": 49.25,
+                    "lastPrice": 41.61,
+                    "volume": 17,
+                    "openInterest": 74,
+                    "impliedVolatility": 0.7758811474609376,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8356421517565221,
+                      "gamma": 0.006670193632913669,
+                      "theta": -0.17985673436282645,
+                      "vega": 0.149114378663189,
+                      "rho": -0.16034369217209601
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00245000",
+                    "type": "put",
+                    "strike": 245,
+                    "expiration": "2026-07-31",
+                    "bid": 46.15,
+                    "ask": 54.45,
+                    "lastPrice": 49.43,
+                    "volume": 41,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.8360612097167968,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8387308331819815,
+                      "gamma": 0.006125212729558138,
+                      "theta": -0.19290542022152973,
+                      "vega": 0.14755201099708107,
+                      "rho": -0.16471421281560372
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00250000",
+                    "type": "put",
+                    "strike": 250,
+                    "expiration": "2026-07-31",
+                    "bid": 51,
+                    "ask": 59.9,
+                    "lastPrice": 51.82,
+                    "volume": 27,
+                    "openInterest": 1,
+                    "impliedVolatility": 0.9117440466308593,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8359172437182824,
+                      "gamma": 0.0056709848365778665,
+                      "theta": -0.21473381933197866,
+                      "vega": 0.148976341407307,
+                      "rho": -0.16841836153413844
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00255000",
+                    "type": "put",
+                    "strike": 255,
+                    "expiration": "2026-07-31",
+                    "bid": 56,
+                    "ask": 64.9,
+                    "lastPrice": 54.26,
+                    "volume": 0,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.9555668505859375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.8419883393087708,
+                      "gamma": 0.005298237194528561,
+                      "theta": -0.22032712201175597,
+                      "vega": 0.14587415547921856,
+                      "rho": -0.17306738368290098
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00260000",
+                    "type": "put",
+                    "strike": 260,
+                    "expiration": "2026-07-31",
+                    "bid": 61,
+                    "ask": 69.8,
+                    "lastPrice": 57.47,
+                    "volume": 2,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.5073291455078125,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9813080951708171,
+                      "gamma": 0.0021150984751966556,
+                      "theta": 0.006703259243481428,
+                      "vega": 0.030917636528702382,
+                      "rho": -0.1939977045261086
+                    }
+                  },
+                  {
+                    "contractSymbol": "NVDA260731P00265000",
+                    "type": "put",
+                    "strike": 265,
+                    "expiration": "2026-07-31",
+                    "bid": 66,
+                    "ask": 74.8,
+                    "lastPrice": 62.48,
+                    "volume": 0,
+                    "openInterest": 0,
+                    "impliedVolatility": 0.5351608984375,
+                    "inTheMoney": true,
+                    "greeks": {
+                      "delta": -0.9821582076629458,
+                      "gamma": 0.0019296276777362755,
+                      "theta": 0.006979228406347241,
+                      "vega": 0.02975389159171674,
+                      "rho": -0.19790389345469145
+                    }
+                  }
+                ],
+                "totalCallVolume": 30536,
+                "totalPutVolume": 10189,
+                "putCallRatio": 0.3336717317264868,
+                "quoteStatus": {
+                  "marketSession": "closed",
+                  "bidAskState": "live_quotes",
+                  "zeroBidAskContracts": 0,
+                  "totalContracts": 102,
+                  "warning": "Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens."
+                },
+                "fetchedAt": "2026-07-04T04:03:58.774Z"
+              }
+            },
+            "promptIndex": 0
+          },
+          {
+            "name": "ask_user",
+            "args": {
+              "question_type": "select",
+              "question": "Which calls are you referring to?",
+              "options": [
+                "NVDA Jan 16 2026 200 Call",
+                "AMD Jan 16 2026 150 Call",
+                "Both"
+              ]
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "User cancelled the selection. Proceed with your best judgment and disclose your assumption."
+                }
+              ],
+              "details": {
+                "question": "Which calls are you referring to?",
+                "questionType": "select",
+                "answer": null,
+                "cancelled": true
+              }
+            },
+            "promptIndex": 1
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "AMD"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "AMD: $517.82 (-4.26%)\nOpen: $538.16 | High: $547.65 | Low: $506.00\nVolume: 27,272,794 | Market Cap: N/A\n52W Range: $133.50 - $584.73"
+                }
+              ],
+              "details": {
+                "symbol": "AMD",
+                "price": 517.82,
+                "change": -23.059999999999945,
+                "changePercent": -4.263422570625637,
+                "open": 538.1599731445312,
+                "high": 547.65,
+                "low": 506,
+                "previousClose": 540.88,
+                "volume": 27272794,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 584.73,
+                "week52Low": 133.5,
+                "timestamp": 1783137901386,
+                "currency": "USD"
+              }
+            },
+            "promptIndex": 1
+          },
+          {
+            "name": "get_stock_quote",
+            "args": {
+              "symbol": "NVDA"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "NVDA: $194.83 (-1.39%)\nOpen: $197.14 | High: $200.06 | Low: $192.35\nVolume: 129,935,067 | Market Cap: N/A\n52W Range: $157.34 - $236.54"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "price": 194.83,
+                "change": -2.75,
+                "changePercent": -1.3918412794817288,
+                "open": 197.13999938964844,
+                "high": 200.055,
+                "low": 192.35,
+                "previousClose": 197.58,
+                "volume": 129935067,
+                "marketCap": 0,
+                "pe": null,
+                "week52High": 236.54,
+                "week52Low": 157.34,
+                "timestamp": 1783137901410,
+                "currency": "USD"
+              }
+            },
+            "promptIndex": 1
+          },
+          {
+            "name": "get_option_chain",
+            "args": {
+              "symbol": "AMD",
+              "expiration": "2026-01-16",
+              "type": "call"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**AMD Options Chain** — Expiry: 2026-01-16\nUnderlying: $517.82\nQuote status: closed / mixed_or_unknown\nOption bid/ask and last prices are quoted per share; multiply by 100 for one standard contract premium.\n⚠ Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens. do not treat zero bid/ask as confirmed live illiquidity without broker verification; do not stop at the stale quote caveat. Disclose the gap, avoid naming tradable live premiums, and finish the strategy explanation with mechanics, assignment outcomes, labeled hypotheticals, and what live broker quotes would change.\nAvailable expirations: 2026-07-10, 2026-07-17, 2026-07-24, 2026-07-31, 2026-08-07, 2026-08-21, 2026-09-18, 2026-10-16, 2026-11-20, 2026-12-18, 2027-01-15, 2027-03-19, 2027-06-17, 2027-09-17, 2027-12-17, 2028-01-21, 2028-06-16, 2028-12-15\n\nPut/Call Ratio: 0.00"
+                }
+              ],
+              "details": {
+                "symbol": "AMD",
+                "underlyingPrice": 517.82,
+                "expirationDate": "2026-01-16",
+                "expirationDates": [
+                  "2026-07-10",
+                  "2026-07-17",
+                  "2026-07-24",
+                  "2026-07-31",
+                  "2026-08-07",
+                  "2026-08-21",
+                  "2026-09-18",
+                  "2026-10-16",
+                  "2026-11-20",
+                  "2026-12-18",
+                  "2027-01-15",
+                  "2027-03-19",
+                  "2027-06-17",
+                  "2027-09-17",
+                  "2027-12-17",
+                  "2028-01-21",
+                  "2028-06-16",
+                  "2028-12-15"
+                ],
+                "calls": [],
+                "puts": [],
+                "totalCallVolume": 0,
+                "totalPutVolume": 0,
+                "putCallRatio": 0,
+                "quoteStatus": {
+                  "marketSession": "closed",
+                  "bidAskState": "mixed_or_unknown",
+                  "zeroBidAskContracts": 0,
+                  "totalContracts": 0,
+                  "warning": "Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens."
+                },
+                "fetchedAt": "2026-07-04T04:05:01.532Z"
+              }
+            },
+            "promptIndex": 1
+          },
+          {
+            "name": "get_option_chain",
+            "args": {
+              "type": "call",
+              "symbol": "NVDA",
+              "expiration": "2026-01-16"
+            },
+            "result": {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "**NVDA Options Chain** — Expiry: 2026-01-16\nUnderlying: $194.83\nQuote status: closed / mixed_or_unknown\nOption bid/ask and last prices are quoted per share; multiply by 100 for one standard contract premium.\n⚠ Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens. do not treat zero bid/ask as confirmed live illiquidity without broker verification; do not stop at the stale quote caveat. Disclose the gap, avoid naming tradable live premiums, and finish the strategy explanation with mechanics, assignment outcomes, labeled hypotheticals, and what live broker quotes would change.\nAvailable expirations: 2026-07-06, 2026-07-08, 2026-07-10, 2026-07-17, 2026-07-24, 2026-07-31, 2026-08-07, 2026-08-21, 2026-09-18, 2026-10-16, 2026-11-20, 2026-12-18, 2027-01-15, 2027-03-19, 2027-06-17, 2027-09-17, 2027-12-17, 2028-01-21, 2028-06-16, 2028-12-15\n\nPut/Call Ratio: 0.00"
+                }
+              ],
+              "details": {
+                "symbol": "NVDA",
+                "underlyingPrice": 194.83,
+                "expirationDate": "2026-01-16",
+                "expirationDates": [
+                  "2026-07-06",
+                  "2026-07-08",
+                  "2026-07-10",
+                  "2026-07-17",
+                  "2026-07-24",
+                  "2026-07-31",
+                  "2026-08-07",
+                  "2026-08-21",
+                  "2026-09-18",
+                  "2026-10-16",
+                  "2026-11-20",
+                  "2026-12-18",
+                  "2027-01-15",
+                  "2027-03-19",
+                  "2027-06-17",
+                  "2027-09-17",
+                  "2027-12-17",
+                  "2028-01-21",
+                  "2028-06-16",
+                  "2028-12-15"
+                ],
+                "calls": [],
+                "puts": [],
+                "totalCallVolume": 0,
+                "totalPutVolume": 0,
+                "putCallRatio": 0,
+                "quoteStatus": {
+                  "marketSession": "closed",
+                  "bidAskState": "mixed_or_unknown",
+                  "zeroBidAskContracts": 0,
+                  "totalContracts": 0,
+                  "warning": "Options bid/ask quotes may be stale outside regular options trading hours; verify live executable prices after the market opens."
+                },
+                "fetchedAt": "2026-07-04T04:05:01.580Z"
+              }
+            },
+            "promptIndex": 1
+          }
+        ],
+        "askUserTranscript": [
+          {
+            "question": "Which calls are you referring to?",
+            "answer": null
+          }
+        ],
+        "text": "We were unable to retrieve specific options chain data for the January 16, 2026 expiration for either NVDA or AMD, meaning real-time premiums, Greeks, and liquidity metrics for your exact positions are unavailable at this moment. Our recommendations are based on the current underlying stock prices and the nature of your long call positions.\n\n**NVDA Jan 16 2026 200 Call (Cost Basis: $32.50)**\n\n*   **Commitment:** Our view is to **consider selling** a portion of your NVDA Jan 16 2026 200 Calls.\n*   **Reasoning Chain:** NVDA is currently trading at $194.83, below your $200.00 strike price, making your calls out-of-the-money. With a cost basis of $32.50 and no intrinsic value, the option's current value is purely extrinsic. Selling allows you to recover remaining premium and reallocate capital.\n*   **Confidence Band:** Moderate conviction.\n*   **Invalidation Level:** This thesis would be invalidated if NVDA's price rallies strongly and sustainably above $200.00, coupled with an increase in implied volatility, indicating renewed bullish momentum.\n\n**AMD Jan 16 2026 150 Call (Cost Basis: $12.10)**\n\n*   **Commitment:** Our view is to **consider selling at least a portion** of your AMD Jan 16 2026 150 Calls to lock in profits.\n*   **Reasoning Chain:** AMD is trading at $517.82, significantly above your $150.00 strike price. These calls are deep in-the-money with substantial intrinsic value ($367.82 per share) and are highly profitable relative to your $12.10 cost basis. Realizing profits reduces exposure to potential market reversals or time decay.\n*   **Confidence Band:** High conviction.\n*   **Invalidation Level:** This thesis would be invalidated if you have a strong, specific thesis for AMD's continued exponential growth that outweighs the benefits of profit-taking, and are comfortable with the increased risk of holding deep ITM calls.\n\n**Risk Caveats:**\n*   **Missing Live Data:** The absence of live option chain data means actual current premiums, bid/ask spreads, and specific Greek values for your options could not be assessed; verify with your broker.\n*   **Time Decay:** While both options have several months to expiry, time decay (theta) erodes the value of options, especially as they get closer to expiration.\n*   **Market Volatility:** Options are highly sensitive to market movements. Rapid changes in the underlying stock price can significantly impact the value of your positions.",
+        "customEntries": [
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "workflow_dispatch",
+                "route": "workflow",
+                "workflow": "options_screener",
+                "entities": {
+                  "symbols": [
+                    "NVDA"
+                  ],
+                  "direction": "bullish"
+                },
+                "slots": {
+                  "symbol": {
+                    "value": "NVDA",
+                    "source": "user",
+                    "confidence": "high"
+                  }
+                },
+                "preference_updates": [],
+                "missing_required": [],
+                "tool_bundles": [
+                  "core_market",
+                  "options",
+                  "sentiment",
+                  "clarification"
+                ],
+                "diagnostics": [
+                  {
+                    "code": "dispatchable_workflow_corrected_to_workflow_dispatch",
+                    "message": "options_screener is a dispatchable workflow"
+                  }
+                ],
+                "reasoning": "The user is asking about options for NVDA, which aligns with the options_screener workflow. Since no specific action (like 'screen' or 'buy') is requested, it's an agent_task."
+              }
+            },
+            "timestamp": "2026-07-04T04:03:50.569Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "I'm looking at my NVDA calls.",
+              "priorTurns": [],
+              "routeKind": "workflow_dispatch",
+              "legacyRoute": "workflow",
+              "workflow": "options_screener",
+              "entities": {
+                "symbols": [
+                  "NVDA"
+                ],
+                "direction": "bullish"
+              },
+              "slots": {
+                "symbol": {
+                  "value": "NVDA",
+                  "source": "user",
+                  "confidence": "high"
+                }
+              },
+              "missingRequired": [],
+              "toolBundles": [
+                "core_market",
+                "options",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_option_chain",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_fear_greed",
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "workflow_dispatch",
+                "workflow": "options_screener",
+                "categories": [
+                  "investor_profile",
+                  "interaction_feedback",
+                  "workflow_history"
+                ],
+                "symbols": [
+                  "NVDA"
+                ],
+                "slotKeys": [
+                  "symbol"
+                ]
+              },
+              "memoryProvenance": [],
+              "promptPlaybook": "workflow_dispatch",
+              "diagnostics": [
+                {
+                  "code": "dispatchable_workflow_corrected_to_workflow_dispatch",
+                  "message": "options_screener is a dispatchable workflow"
+                }
+              ],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "options_strategy",
+                "commitmentMode": "decision",
+                "policyCardId": "options_strategy",
+                "evidencePlanId": "placeholder_options_strategy",
+                "answerContractId": "options_strategy",
+                "structuredCheckIds": [
+                  "required_evidence_present",
+                  "freshness_disclosed"
+                ],
+                "capabilityGapIds": [],
+                "behaviorMode": "replacement_active",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": [
+                  {
+                    "code": "planning_after_router_corrections",
+                    "message": "planning selected after router diagnostics were applied"
+                  }
+                ]
+              }
+            },
+            "timestamp": "2026-07-04T04:03:50.569Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "workflow_dispatch",
+              "workflow": "options_screener",
+              "toolBundles": [
+                "core_market",
+                "options",
+                "sentiment",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_option_chain",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_fear_greed",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:03:50.569Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-workflow",
+            "data": {
+              "workflow": "options_screener",
+              "entities": {
+                "symbols": [
+                  "NVDA"
+                ],
+                "direction": "bullish"
+              },
+              "resolved": {
+                "symbol": "NVDA",
+                "direction": "bullish",
+                "dteTarget": "25_to_45_days",
+                "objective": "balanced_leverage_and_probability",
+                "moneynessPreference": "atm_to_slightly_otm",
+                "liquidityMinimum": "high_open_interest_and_tight_spread"
+              }
+            },
+            "timestamp": "2026-07-04T04:03:50.570Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-user-input",
+            "data": {
+              "original": "I'm looking at my NVDA calls."
+            },
+            "timestamp": "2026-07-04T04:03:50.570Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:04:11.306Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:04:23.485Z",
+            "promptIndex": 0
+          },
+          {
+            "customType": "opencandle-router",
+            "data": {
+              "output": {
+                "routeKind": "agent_task",
+                "route": "fallback",
+                "workflow": "general_finance_qa",
+                "entities": {
+                  "symbols": [],
+                  "direction": "bullish"
+                },
+                "slots": {},
+                "preference_updates": [],
+                "missing_required": [],
+                "tool_bundles": [
+                  "core_market",
+                  "macro",
+                  "sentiment",
+                  "sec",
+                  "clarification"
+                ],
+                "diagnostics": [],
+                "reasoning": "The user is asking for advice on managing an existing options position, which is a general finance question best handled by the main agent."
+              }
+            },
+            "timestamp": "2026-07-04T04:04:55.410Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-route-context",
+            "data": {
+              "userInput": "Should I sell my calls?",
+              "priorTurns": [
+                {
+                  "role": "user",
+                  "text": "Current date: 2026-07-04\nDo NOT invent or assume a different current date.\nTarget expiration window: 2026-07-29 to 2026-08-18\n\nScreen and rank options contracts for NVDA:\n- Direction: bullish\n- DTE target: 25_to_45_days [DEFAULT]\n- Objective: balanced_leverage_and_probability [DEFAULT]\n- Moneyness: atm_to_slightly_otm [DEFAULT]\n- Liquidity: high_open_interest_and_tight_spread [DEFAULT]\n\nSteps:\n1. Use get_stock_quote for NVDA to get current price and recent movement.\n2. Use get_option_chain for NVDA to get the full chain with Greeks. If you filter by contract type, pass `type: \"call\"` or `type: \"put\"` in lowercase.\n3. Filter contracts matching: calls, DTE near 25_to_45_days, atm_to_slightly_otm strikes.\n4. Rank by balanced_leverage_and_probability: balance premium cost, delta exposure, and probability of profit.\n5. Filter for high_open_interest_and_tight_spread: high open interest and tight bid-ask spread.\n\n\n\n\n\nRanking constraints:\n- Only include contracts with |delta| >= 0.20.\n- Prefer ATM to slightly OTM before farther OTM.\n- Do NOT rank ultra-cheap near-zero-delta contracts as \"best.\"\n\nAssumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbol (NVDA), direction (bullish)\n  Defaults: DTE target (25_to_45_days), objective (balanced_leverage_and_probability), moneyness (atm_to_slightly_otm), liquidity (high_open_interest_and_tight_spread)\n  Workflow constraints: delta >= 0.20 (balanced objective), prefer ATM to slightly OTM\n\nResponse format:\n- Start with the assumptions block above exactly as written. Do not relabel source attribution anywhere else in your response.\n- State the interpretation only if the user's requested underlying is ambiguous.\n- Present top 3-5 ranked contracts in a table: strike, expiry, premium, delta, gamma, theta, vega, rho, IV, OI, bid-ask spread.\n- Explain why the top pick is ranked #1.\n- Verify bid/ask and open interest in the user's broker before trading, even when OC shows live values.\n- Include risk caveats (max loss = premium, IV crush risk, time decay)."
+                },
+                {
+                  "role": "assistant",
+                  "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbol (NVDA), direction (bullish)\n  Defaults: DTE target (25_to_45_days), objective (balanced_leverage_and_probability), moneyness (atm_to_slightly_otm), liquidity (high_open_interest_and_tight_spread)\n  Workflow constraints: delta >= 0.20 (balanced objective), prefer ATM to slightly OTM\n\n"
+                },
+                {
+                  "role": "assistant",
+                  "text": "Here are the top options contracts for NVDA, ranked based on balanced leverage and probability, considering the bullish direction, ATM to slightly OTM moneyness, DTE between 25-45 days, and high liquidity.\n\n**Assumptions (reproduce this block exactly — do not relabel sources):**\n  User-specified: symbol (NVDA), direction (bullish)\n  Defaults: DTE target (25_to_45_days), objective (balanced_leverage_and_probability), moneyness (atm_to_slightly_otm), liquidity (high_open_interest_and_tight_spread)\n  Workflow constraints: delta >= 0.20 (balanced objective), prefer ATM to slightly OTM\n\nNVDA's current price is $194.83 (as of 2026-07-04, close).\nThe options chain for 2026-07-31 expiry was analyzed, which has 27 days to expiration (DTE), fitting within the target window of 25-45 days.\n\n### Top Ranked NVDA Call Options (Expiry: 2026-07-31)\n\n| Rank | Strike | Expiry | Premium (Bid/Ask) | Delta | Gamma | Theta | Vega | Rho | IV | OI | Bid-Ask Spread |\n|------|--------|--------|-------------------|-------|-------|-------|------|-----|----|----|----------------|\n| 1    | $200.00 | 2026-07-31 | $6.20 / $6.35    | 0.421 | 0.018 | -0.162 | 0.212 | 0.056 | 39.9% | 8008 | $0.15          |\n| 2    | $205.00 | 2026-07-31 | $4.40 / $4.55    | 0.318 | 0.018 | -0.150 | 0.199 | 0.043 | 39.4% | 5680 | $0.15          |\n| 3    | $195.00 | 2026-07-31 | $8.50 / $8.75    | 0.545 | 0.018 | -0.171 | 0.213 | 0.071 | 41.0% | 2861 | $0.25          |\n| 4    | $210.00 | 2026-07-31 | $3.10 / $3.20    | 0.236 | 0.016 | -0.132 | 0.178 | 0.032 | 39.3% | 4856 | $0.10          |\n\n**Why the $200.00 Strike is Ranked #1:**\nOur read is that the **NVDA 2026-07-31 $200.00 Call** provides the best balance of leverage and probability for a bullish outlook. It has a strong delta of 0.421, indicating a good participation in potential upward stock movement, but at a more accessible premium ($6.20/$6.35) compared to the ATM $195.00 strike. It also exhibits high liquidity with the largest open interest (8008) among the filtered contracts and a tight bid-ask spread of $0.15. This combination offers a reasonable probability of profit for the implied cost, making it a compelling choice for balanced exposure.\n\n**Important Considerations:**\n*   **Verify Bid/Ask and Open Interest:** Options bid/ask quotes may be stale outside regular trading hours. Always verify live executable prices and open interest with your broker before placing any trades.\n*   **Max Loss = Premium Paid:** The maximum loss on a long call option is limited to the premium paid for the contract.\n*   **IV Crush Risk:** Implied Volatility (IV) for NVDA is currently around 39-41% for these contracts. A drop in IV (often after an earnings event or significant news) can negatively impact the option's value, even if the underlying stock price moves favorably.\n*   **Time Decay (Theta):** Options lose value as they approach expiration due to time decay (Theta). These contracts have approximately 27 DTE, so time decay will accelerate as expiration nears.\n*   **Assignment Risk:** While primarily a concern for short options, deep in-the-money long calls nearing expiration may carry increased assignment risk if exercised early.\n*   **Expiration Value:** For the call to be profitable at expiration, NVDA's price must be above the strike price plus the premium paid per share (e.g., for the $200 strike and $6.35 premium, NVDA needs to be above $206.35)."
+                },
+                {
+                  "role": "user",
+                  "text": "Now rank and present the top calls for NVDA. You MUST produce a final text response — never end this turn with only tool calls.\n\n1. From the option chain data already fetched, select the top 3-5 contracts matching: atm_to_slightly_otm strikes, DTE near 25_to_45_days, with high_open_interest_and_tight_spread.\n2. Rank by balanced_leverage_and_probability: balance premium cost, delta exposure, and probability of profit. Only include contracts with |delta| >= 0.20.\n3. Present a table: strike, expiry, premium, delta, gamma, theta, vega, rho, IV, open interest, bid-ask spread.\n4. Explain why the #1 pick is ranked highest.\n5. Reproduce the exact Assumptions block from the initial prompt; keep the provenance label text intact and do not shorten it to \"Assumptions:\".\n6. State the requested option horizon in plain language (25-45 day target, roughly one month) in the bottom line or table intro; use the user's horizon wording or approximate DTE window without forcing a fixed sentence.\n7. Include risk caveats: max loss = premium, IV crush risk, time decay (theta).\n\nIf some or all of the option chain fetches returned \"⚠ Options chain unavailable\" or similar gaps, do NOT abort. Instead:\n- Rank and present whatever contracts you did retrieve from the successful fetches, even if fewer than 3.\n- If no chain data is usable at all, still produce a text response: reproduce the Assumptions block, state which expirations failed, and give actionable fallback guidance for the requested DTE instead of ranking nonexistent contracts. Do not promise to retry later. Never end the turn with only tool calls.\n\n\n\n\nLength constraints:\n- Max 1 sentence explaining the #1 pick.\n- Risk section: max 3 bullets.\n- Keep total response under 30 lines."
+                },
+                {
+                  "role": "assistant",
+                  "text": "Assumptions (reproduce this block exactly — do not relabel sources):\n  User-specified: symbol (NVDA), direction (bullish)\n  Defaults: DTE target (25_to_45_days), objective (balanced_leverage_and_probability), moneyness (atm_to_slightly_otm), liquidity (high_open_interest_and_tight_spread)\n  Workflow constraints: delta >= 0.20 (balanced objective), prefer ATM to slightly OTM\n\nNVDA's current price is $194.83 (as of 2026-07-04, close).\nThe following top call options have an expiration of 2026-07-31 (27 days to expiry), aligning with the 25-45 day target.\n\n### Top Ranked NVDA Call Options (Expiry: 2026-07-31)\n\n| Rank | Strike | Premium (Bid/Ask) | Delta | Gamma | Theta | Vega | Rho | IV | OI | Bid-Ask Spread |\n|------|--------|-------------------|-------|-------|-------|------|-----|----|----|----------------|\n| 1    | $200.00 | $6.20 / $6.35    | 0.421 | 0.018 | -0.162 | 0.212 | 0.056 | 39.9% | 8008 | $0.15          |\n| 2    | $205.00 | $4.40 / $4.55    | 0.318 | 0.018 | -0.150 | 0.199 | 0.043 | 39.4% | 5680 | $0.15          |\n| 3    | $195.00 | $8.50 / $8.75    | 0.545 | 0.018 | -0.171 | 0.213 | 0.071 | 41.0% | 2861 | $0.25          |\n| 4    | $210.00 | $3.10 / $3.20    | 0.236 | 0.016 | -0.132 | 0.178 | 0.032 | 39.3% | 4856 | $0.10          |\n\nOur read is that the NVDA 2026-07-31 $200.00 Call is ranked #1 due to its strong delta (0.421) for bullish participation at a moderate premium, coupled with high open interest (8008) and a tight bid-ask spread ($0.15).\n\n**Risk Caveats:**\n*   **Max Loss = Premium Paid:** The maximum loss on a long call option is limited to the premium paid for the contract.\n*   **IV Crush Risk:** A drop in implied volatility (IV) can negatively impact the option's value, even with favorable stock movement.\n*   **Time Decay:** Options lose value due to time decay (Theta) as they approach their expiration date, which will accelerate for these 27-DTE contracts.\n*   Always verify live bid/ask and open interest with your broker before trading."
+                }
+              ],
+              "routeKind": "agent_task",
+              "legacyRoute": "fallback",
+              "workflow": "general_finance_qa",
+              "entities": {
+                "symbols": [],
+                "direction": "bullish"
+              },
+              "slots": {},
+              "missingRequired": [],
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "memoryQueryPlan": {
+                "routeKind": "agent_task",
+                "workflow": "general_finance_qa",
+                "categories": [
+                  "investor_profile",
+                  "workflow_history"
+                ],
+                "symbols": [],
+                "slotKeys": []
+              },
+              "memoryProvenance": [],
+              "promptPlaybook": "agent_task",
+              "diagnostics": [],
+              "planning": {
+                "version": "planning-v1",
+                "taskFamily": "general_fallback",
+                "commitmentMode": "framework",
+                "policyCardId": "general_fallback",
+                "evidencePlanId": "placeholder_general_fallback",
+                "answerContractId": "general_fallback",
+                "structuredCheckIds": [
+                  "data_gap_disclosed"
+                ],
+                "capabilityGapIds": [],
+                "behaviorMode": "observe_only",
+                "workspacePlaceholderIds": [],
+                "artifactPlaceholderIds": [],
+                "artifactContractIds": [],
+                "diagnostics": [
+                  {
+                    "code": "planning_observe_only",
+                    "message": "planning metadata is recorded without changing active prompt, route, workflow, tools, or answer behavior"
+                  }
+                ]
+              }
+            },
+            "timestamp": "2026-07-04T04:04:55.410Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-tool-scope",
+            "data": {
+              "mode": "observe",
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ],
+              "enforced": false
+            },
+            "timestamp": "2026-07-04T04:04:55.410Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:05:01.277Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-tool-scope-violation",
+            "data": {
+              "routeKind": "agent_task",
+              "workflow": "general_finance_qa",
+              "toolName": "get_option_chain",
+              "toolBundles": [
+                "core_market",
+                "macro",
+                "sentiment",
+                "sec",
+                "clarification"
+              ],
+              "activeToolNames": [
+                "search_ticker",
+                "get_stock_quote",
+                "get_stock_history",
+                "screen_stocks",
+                "get_crypto_price",
+                "get_crypto_history",
+                "get_company_overview",
+                "get_financials",
+                "get_earnings",
+                "compare_companies",
+                "compute_dcf",
+                "get_technical_indicators",
+                "backtest_strategy",
+                "analyze_risk",
+                "analyze_correlation",
+                "analyze_holdings_overlap",
+                "track_portfolio",
+                "manage_watchlist",
+                "manage_alerts",
+                "daily_watchlist_report",
+                "manage_notifications",
+                "search_web",
+                "get_economic_data",
+                "get_fear_greed",
+                "get_reddit_sentiment",
+                "get_twitter_sentiment",
+                "get_web_sentiment",
+                "get_sentiment_trend",
+                "get_sentiment_summary",
+                "get_sec_filings",
+                "ask_user"
+              ]
+            },
+            "timestamp": "2026-07-04T04:05:01.277Z",
+            "promptIndex": 1
+          },
+          {
+            "customType": "opencandle-disclaimer",
+            "data": {
+              "text": "OpenCandle is a research and analysis tool, not financial advice or a fiduciary financial advisor. Views, targets, and allocations are informational analyst output — not personalized recommendations. Verify independently before acting."
+            },
+            "timestamp": "2026-07-04T04:05:10.414Z",
+            "promptIndex": 1
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/evals/product/cases.ts
+++ b/tests/evals/product/cases.ts
@@ -50,6 +50,23 @@ const toolBacked: ProductEvalDimension = {
   requiredToolNames: ["get_stock_quote"],
 };
 
+const exactlyOneFocusedAskUser: ProductEvalDimension = {
+  id: "ask_instead_of_guess",
+  description: "Asks exactly one focused clarification question instead of guessing.",
+  expectedAskUserCount: 1,
+  askUserQuestionPatterns: [/\b(which|what|ticker|symbol|position|bank|calls?)\b/i],
+  mandatory: true,
+  weight: 2,
+};
+
+const noAskUser: ProductEvalDimension = {
+  id: "no_unneeded_clarification",
+  description: "Does not ask for clarification when context resolves the request.",
+  expectedAskUserCount: 0,
+  mandatory: true,
+  weight: 2,
+};
+
 export const PRODUCT_SCENARIO_TEMPLATES: ScenarioTemplate[] = [
   {
     id: "compare_assets_with_horizon",
@@ -156,6 +173,40 @@ export const PRODUCT_EVAL_CASES: ProductEvalCase[] = [
     prompt: "Screen MSFT bullish call options with good liquidity for the next month.",
     assertions: { expectedWorkflow: "options_screener", requiredTools: ["get_option_chain"] },
   }),
+  // PROMOTE: E5 ask-vs-guess cases are live-model boundary evals. Promote only
+  // after the paired ambiguous/resolvable traces pass reliably on the integration branch.
+  makeCase("ask-vs-guess-ambiguous-sell-my-calls", "options_screen_with_dte_objective", {
+    tier: "opt-in",
+    prompt: "Should I sell my calls?",
+    setup: { marketStateFixture: "e5_two_option_positions" },
+    dimensions: [
+      exactlyOneFocusedAskUser,
+      {
+        id: "ambiguous_calls_no_guess",
+        description: "Does not resolve either saved option position before the user clarifies.",
+        forbiddenResolvedSymbols: ["NVDA", "AMD"],
+        mandatory: true,
+      },
+    ],
+  }),
+  makeCase("ask-vs-guess-prior-turn-sell-my-calls", "options_screen_with_dte_objective", {
+    tier: "opt-in",
+    prompt: "Should I sell my calls?",
+    prompts: ["I'm looking at my NVDA calls.", "Should I sell my calls?"],
+    setup: { marketStateFixture: "e5_two_option_positions" },
+    assertions: { expectedWorkflow: "options_screener", requiredTools: ["get_option_chain"] },
+    dimensions: [
+      noAskUser,
+      {
+        id: "prior_turn_calls_resolution",
+        description: "Resolves the pronoun-backed option request to NVDA from prior turn context.",
+        requiredResolvedSymbols: ["NVDA"],
+        forbiddenResolvedSymbols: ["AMD"],
+        mandatory: true,
+      },
+      riskFraming,
+    ],
+  }),
   makeCase("sentiment-meta-source-gaps", "sentiment_request_with_source_gaps", {
     prompt: "What is Reddit and news sentiment saying about META?",
     assertions: { requiredTools: ["get_sentiment_summary"] },
@@ -171,6 +222,37 @@ export const PRODUCT_EVAL_CASES: ProductEvalCase[] = [
   makeCase("macro-inflation-portfolio-risk", "macro_market_context", {
     prompt: "What macro risks matter most for a balanced portfolio right now?",
     assertions: { expectedWorkflow: "general_finance_qa" },
+  }),
+  // PROMOTE: E5 ask-vs-guess cases are live-model boundary evals. Promote only
+  // after the paired ambiguous/resolvable traces pass reliably on the integration branch.
+  makeCase("ask-vs-guess-ambiguous-compare-the-banks", "compare_assets_with_horizon", {
+    tier: "opt-in",
+    prompt: "Compare the banks.",
+    dimensions: [
+      exactlyOneFocusedAskUser,
+      {
+        id: "ambiguous_banks_no_guess",
+        description: "Does not choose bank tickers before the user specifies them.",
+        forbiddenResolvedSymbols: ["JPM", "BAC", "WFC", "C", "GS", "MS"],
+        mandatory: true,
+      },
+    ],
+  }),
+  makeCase("ask-vs-guess-prior-turn-compare-the-banks", "compare_assets_with_horizon", {
+    tier: "opt-in",
+    prompt: "Compare the banks.",
+    prompts: ["I'm deciding between JPM and BAC.", "Compare the banks."],
+    assertions: { expectedWorkflow: "compare_assets", requiredTools: ["get_stock_quote"] },
+    dimensions: [
+      noAskUser,
+      {
+        id: "prior_turn_banks_resolution",
+        description: "Resolves the bank comparison to JPM and BAC from prior turn context.",
+        requiredResolvedSymbols: ["JPM", "BAC"],
+        mandatory: true,
+      },
+      riskFraming,
+    ],
   }),
   makeCase("education-pe-ratio", "education_without_fake_current_data", {
     prompt: "Explain how to use P/E ratios without over relying on them.",

--- a/tests/evals/product/scorer.ts
+++ b/tests/evals/product/scorer.ts
@@ -137,6 +137,34 @@ function scoreDimension(
     }
   }
 
+  if (
+    dimension.expectedAskUserCount !== undefined &&
+    trace.askUserTranscript.length !== dimension.expectedAskUserCount
+  ) {
+    issues.push(
+      `expected exactly ${dimension.expectedAskUserCount} ask_user calls, got ${trace.askUserTranscript.length}`,
+    );
+  }
+
+  for (const pattern of dimension.askUserQuestionPatterns ?? []) {
+    if (!trace.askUserTranscript.some((interaction) => pattern.test(interaction.question))) {
+      issues.push(`missing ask_user question pattern ${pattern}`);
+    }
+  }
+
+  const resolvedSymbols = traceResolvedSymbols(trace);
+  for (const symbol of dimension.requiredResolvedSymbols ?? []) {
+    if (!resolvedSymbols.has(symbol.toUpperCase())) {
+      issues.push(`missing resolved symbol ${symbol}`);
+    }
+  }
+
+  for (const symbol of dimension.forbiddenResolvedSymbols ?? []) {
+    if (resolvedSymbols.has(symbol.toUpperCase())) {
+      issues.push(`forbidden resolved symbol ${symbol}`);
+    }
+  }
+
   for (const pattern of dimension.requiredPatterns ?? []) {
     if (!pattern.test(text) && !passesFamilyAwareDimension(dimension.id, evalCase, trace, text)) {
       issues.push(`missing pattern ${pattern}`);
@@ -209,6 +237,32 @@ function getVisibleText(trace: EvalTrace): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function traceResolvedSymbols(trace: EvalTrace): Set<string> {
+  const symbols = new Set<string>();
+  for (const symbol of trace.classification.entities.symbols ?? []) {
+    symbols.add(symbol.toUpperCase());
+  }
+  for (const call of trace.toolCalls) {
+    collectSymbols(call.args, symbols);
+  }
+  return symbols;
+}
+
+function collectSymbols(value: unknown, symbols: Set<string>): void {
+  if (typeof value === "string") {
+    if (/^[A-Z][A-Z0-9.-]{0,9}$/.test(value)) symbols.add(value.toUpperCase());
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectSymbols(item, symbols);
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, item] of Object.entries(value)) {
+    if (/symbol/i.test(key)) collectSymbols(item, symbols);
+  }
 }
 
 function average(values: number[]): number {

--- a/tests/evals/product/state-fixtures.ts
+++ b/tests/evals/product/state-fixtures.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { MarketStateService } from "../../../src/market-state/service.js";
+import { initDatabase } from "../../../src/memory/sqlite.js";
+
+export function seedProductEvalMarketState(
+  fixture: "e5_two_option_positions",
+  openCandleHome: string,
+): void {
+  if (fixture === "e5_two_option_positions") {
+    seedE5TwoOptionPositions(openCandleHome);
+    return;
+  }
+}
+
+function seedE5TwoOptionPositions(openCandleHome: string): void {
+  const db = initDatabase(join(openCandleHome, "state.db"));
+  try {
+    const service = new MarketStateService(db);
+    service.addPortfolioLot({
+      instrument: {
+        symbol: "NVDA260116C00200000",
+        name: "NVDA Jan 16 2026 200 Call",
+        assetType: "option",
+        exchange: "OPRA",
+        currency: "USD",
+        provider: "fixture",
+        aliases: [{ source: "underlying", sourceSymbol: "NVDA", sourceAssetType: "equity" }],
+      },
+      quantity: 2,
+      avgCost: 32.5,
+      currency: "USD",
+      notes: "E5 ask-vs-guess fixture: NVDA calls",
+      source: "eval-fixture",
+    });
+    service.addPortfolioLot({
+      instrument: {
+        symbol: "AMD260116C00150000",
+        name: "AMD Jan 16 2026 150 Call",
+        assetType: "option",
+        exchange: "OPRA",
+        currency: "USD",
+        provider: "fixture",
+        aliases: [{ source: "underlying", sourceSymbol: "AMD", sourceAssetType: "equity" }],
+      },
+      quantity: 3,
+      avgCost: 12.1,
+      currency: "USD",
+      notes: "E5 ask-vs-guess fixture: AMD calls",
+      source: "eval-fixture",
+    });
+  } finally {
+    db.close();
+  }
+}

--- a/tests/evals/product/types.ts
+++ b/tests/evals/product/types.ts
@@ -18,6 +18,10 @@ export interface ProductEvalDimension {
   forbiddenPatterns?: RegExp[];
   requiredToolNames?: string[];
   forbiddenToolNames?: string[];
+  expectedAskUserCount?: number;
+  askUserQuestionPatterns?: RegExp[];
+  requiredResolvedSymbols?: string[];
+  forbiddenResolvedSymbols?: string[];
   mandatory?: boolean;
   weight?: number;
 }
@@ -33,8 +37,13 @@ export interface ProductEvalCase {
   id: string;
   templateId: string;
   family: PromptFamily;
+  tier?: "default" | "opt-in";
   prompt: string;
+  prompts?: string[];
   answers?: string[];
+  setup?: {
+    marketStateFixture?: "e5_two_option_positions";
+  };
   assertions?: {
     expectedWorkflow?: WorkflowType;
     requiredTools?: string[];

--- a/tests/scripts/run-product-evals.ts
+++ b/tests/scripts/run-product-evals.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env tsx
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PRODUCT_EVAL_CASES } from "../evals/product/cases.js";
 import { productEvalExitCode } from "../evals/product/reporting.js";
 import { buildProductEvalReport, scoreProductEvalCase } from "../evals/product/scorer.js";
+import { seedProductEvalMarketState } from "../evals/product/state-fixtures.js";
 import type { ProductEvalCase, PromptFamily } from "../evals/product/types.js";
 import { runOpenCandleSession } from "../harness/opencandle-runner.js";
 
@@ -15,16 +17,28 @@ if (selectedCases.length === 0) {
 const results = [];
 for (const evalCase of selectedCases) {
   console.log(`\n=== ${evalCase.id}: ${evalCase.prompt}`);
-  const { evalTrace } = await runOpenCandleSession({
-    prompt: evalCase.prompt,
-    scriptedAnswers: evalCase.answers,
-    timeoutMs: 900_000,
-  });
-  const result = scoreProductEvalCase(evalCase, evalTrace);
-  results.push(result);
-  console.log(`score=${formatPct(result.score)} ${result.passed ? "PASS" : "FAIL"}`);
-  for (const dimension of result.dimensions) {
-    console.log(`  ${dimension.passed ? "✓" : "✗"} ${dimension.id}: ${dimension.message}`);
+  const openCandleHome = evalCase.setup?.marketStateFixture
+    ? mkdtempSync(join(tmpdir(), "oc-product-eval-home-"))
+    : undefined;
+  try {
+    if (openCandleHome && evalCase.setup?.marketStateFixture) {
+      seedProductEvalMarketState(evalCase.setup.marketStateFixture, openCandleHome);
+    }
+    const { evalTrace } = await runOpenCandleSession({
+      prompt: evalCase.prompts ? undefined : evalCase.prompt,
+      prompts: evalCase.prompts,
+      scriptedAnswers: evalCase.answers,
+      openCandleHome,
+      timeoutMs: 900_000,
+    });
+    const result = scoreProductEvalCase(evalCase, evalTrace);
+    results.push(result);
+    console.log(`score=${formatPct(result.score)} ${result.passed ? "PASS" : "FAIL"}`);
+    for (const dimension of result.dimensions) {
+      console.log(`  ${dimension.passed ? "✓" : "✗"} ${dimension.id}: ${dimension.message}`);
+    }
+  } finally {
+    if (openCandleHome) rmSync(openCandleHome, { recursive: true, force: true });
   }
 }
 
@@ -41,8 +55,10 @@ process.exitCode = productEvalExitCode(report);
 function selectCases(cases: ProductEvalCase[]): ProductEvalCase[] {
   const id = process.env.PRODUCT_EVAL_CASE?.trim();
   const family = process.env.PRODUCT_EVAL_FAMILY?.trim() as PromptFamily | undefined;
+  const includeOptIn = process.env.PRODUCT_EVAL_INCLUDE_OPT_IN === "1";
   const limit = numberFromEnv("PRODUCT_EVAL_LIMIT");
   let selected = cases;
+  if (!id && !includeOptIn) selected = selected.filter((evalCase) => evalCase.tier !== "opt-in");
   if (id) selected = selected.filter((evalCase) => evalCase.id === id);
   if (family) selected = selected.filter((evalCase) => evalCase.family === family);
   return limit ? selected.slice(0, limit) : selected;
@@ -55,7 +71,7 @@ function writeReport(report: ReturnType<typeof buildProductEvalReport>): string 
     runsDir,
     `${new Date().toISOString().replace(/[:.]/g, "-")}_product-evals.json`,
   );
-  writeFileSync(path, JSON.stringify(report, null, 2) + "\n", "utf-8");
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
   return path;
 }
 

--- a/tests/unit/evals/product-evals.test.ts
+++ b/tests/unit/evals/product-evals.test.ts
@@ -314,6 +314,99 @@ describe("product eval scoring", () => {
     );
   });
 
+  it("scores E5 ambiguous cases with exactly one focused ask_user and no guessed symbol", () => {
+    const ambiguousCallsCase = PRODUCT_EVAL_CASES.find(
+      (evalCase) => evalCase.id === "ask-vs-guess-ambiguous-sell-my-calls",
+    );
+    if (!ambiguousCallsCase) throw new Error("missing E5 ambiguous calls eval case");
+
+    const result = scoreProductEvalCase(
+      ambiguousCallsCase,
+      makeTrace({
+        classification: {
+          ...makeTrace().classification,
+          workflow: "options_screener",
+          entities: { symbols: [] },
+        },
+        askUserTranscript: [
+          { question: "Which call position do you mean: NVDA or AMD?", answer: "the NVDA calls" },
+        ],
+        text: "Which call position should I evaluate? Selling calls can lock in gains but carries timing risk.",
+      }),
+    );
+
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "ask_instead_of_guess"),
+    ).toMatchObject({
+      passed: true,
+    });
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "ambiguous_calls_no_guess"),
+    ).toMatchObject({ passed: true });
+  });
+
+  it("fails E5 ambiguous cases when the agent over-asks or guesses a seeded option symbol", () => {
+    const ambiguousCallsCase = PRODUCT_EVAL_CASES.find(
+      (evalCase) => evalCase.id === "ask-vs-guess-ambiguous-sell-my-calls",
+    );
+    if (!ambiguousCallsCase) throw new Error("missing E5 ambiguous calls eval case");
+
+    const result = scoreProductEvalCase(
+      ambiguousCallsCase,
+      makeTrace({
+        classification: {
+          ...makeTrace().classification,
+          workflow: "options_screener",
+          entities: { symbols: ["NVDA"] },
+        },
+        askUserTranscript: [
+          { question: "Which calls?", answer: "NVDA" },
+          { question: "What expiry?", answer: "January" },
+        ],
+        toolCalls: [{ name: "get_option_chain", args: { symbol: "NVDA" } }],
+        text: "I will assume you meant NVDA calls.",
+      }),
+    );
+
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "ask_instead_of_guess"),
+    ).toMatchObject({ passed: false });
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "ambiguous_calls_no_guess"),
+    ).toMatchObject({ passed: false });
+  });
+
+  it("scores E5 resolvable twins with zero ask_user and correct prior-turn symbol resolution", () => {
+    const resolvableBanksCase = PRODUCT_EVAL_CASES.find(
+      (evalCase) => evalCase.id === "ask-vs-guess-prior-turn-compare-the-banks",
+    );
+    if (!resolvableBanksCase) throw new Error("missing E5 resolvable banks eval case");
+
+    const result = scoreProductEvalCase(
+      resolvableBanksCase,
+      makeTrace({
+        classification: {
+          ...makeTrace().classification,
+          workflow: "compare_assets",
+          entities: { symbols: ["JPM", "BAC"] },
+        },
+        askUserTranscript: [],
+        toolCalls: [
+          { name: "get_stock_quote", args: { symbol: "JPM" } },
+          { name: "get_stock_quote", args: { symbol: "BAC" } },
+        ],
+        text: "Compare JPM and BAC directly. Both carry rate, credit, deposit beta, and recession downside risks.",
+      }),
+    );
+
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "no_unneeded_clarification"),
+    ).toMatchObject({ passed: true });
+    expect(
+      result.dimensions.find((dimension) => dimension.id === "prior_turn_banks_resolution"),
+    ).toMatchObject({ passed: true });
+  });
+
   it("maps failed product eval reports to a failing process exit code", () => {
     expect(productEvalExitCode({ failed: 0 })).toBe(0);
     expect(productEvalExitCode({ failed: 1 })).toBe(1);
@@ -346,5 +439,27 @@ describe("product eval cases", () => {
     );
     expect(compareCases.map((evalCase) => evalCase.prompt).join("\n")).toMatch(/AAPL|SPY|BTC/i);
     expect(compareCases.map((evalCase) => evalCase.prompt).join("\n")).toMatch(/MSFT|QQQ|GLD/i);
+  });
+
+  it("defines E5 ask-vs-guess cases as paired ambiguous and resolvable twins", () => {
+    const e5Cases = PRODUCT_EVAL_CASES.filter((evalCase) =>
+      evalCase.id.startsWith("ask-vs-guess-"),
+    );
+
+    expect(e5Cases.map((evalCase) => evalCase.id).sort()).toEqual([
+      "ask-vs-guess-ambiguous-compare-the-banks",
+      "ask-vs-guess-ambiguous-sell-my-calls",
+      "ask-vs-guess-prior-turn-compare-the-banks",
+      "ask-vs-guess-prior-turn-sell-my-calls",
+    ]);
+    expect(e5Cases.every((evalCase) => evalCase.tier === "opt-in")).toBe(true);
+    expect(
+      e5Cases.filter((evalCase) => evalCase.prompts && evalCase.prompts.length > 1),
+    ).toHaveLength(2);
+    expect(
+      e5Cases.filter(
+        (evalCase) => evalCase.setup?.marketStateFixture === "e5_two_option_positions",
+      ),
+    ).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Adds opt-in E5 product eval cases for ask-instead-of-guess boundaries:
  - ambiguous `Should I sell my calls?` with two seeded option positions
  - ambiguous `Compare the banks.` with no tickers
  - prior-turn resolvable twins for calls and banks
- Extends product eval scoring with exact `ask_user` count checks, focused ask question matching, and resolved-symbol assertions from trace evidence.
- Adds disposable seeded market-state fixture support for product eval runs.

## Findings

These cases are `tier: "opt-in"` because current live behavior fails three of four cases:

- `ask-vs-guess-ambiguous-compare-the-banks`: asks once, but also guesses bank symbols before clarification.
- `ask-vs-guess-ambiguous-sell-my-calls`: does not ask and resolves both seeded option underlyings.
- `ask-vs-guess-prior-turn-sell-my-calls`: asks despite prior context, routes as general QA, and includes AMD.
- `ask-vs-guess-prior-turn-compare-the-banks`: passes with zero asks and JPM/BAC resolution.

See `docs/internal/pr-evidence/feat-eval-ask-vs-guess/FINDINGS.md` and the committed live product eval JSON traces.

## Gates

- `npx vitest run tests/unit/evals/product-evals.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npx biome ci .`
- `graphify update .`
- Live product eval traces for all four E5 cases committed under `docs/internal/pr-evidence/feat-eval-ask-vs-guess/`
