### PR TITLE
Add frozen competitive adversarial panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a release-runnable frozen competitive adversarial panel for historical loss classes, with a `test:evals:competitive:frozen` command, cached-baseline runner mode, prompt-policy hard assertions, and documentation separating frozen reruns from generated competitive discovery.
 - Added an opt-in GUI/TUI parity eval that sends the same live prompt through `runOpenCandleSession()` and the GUI server chat-run API, diffs `opencandle-*` entry sequences, and asserts projector dashboard `analystsDone` matches emitted analyst-step entries; the case is recorded as an expected failure for the current GUI chat-run parity gap.
 - Added opt-in known-fail E2 saved market-state fidelity eval coverage for seeded portfolio rate-exposure and SPY cost-basis prompts, including trace assertions for saved-state route context, portfolio-review routing, and fixture value reuse.
 - Added a live, usually-tier E1 multi-turn coreference eval for prior-turn ticker carryover and saved-portfolio holding references, currently marked known-fail/opt-in with committed trace evidence for the saved-state AMD resolution gap.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,25 @@
+# E7 Frozen Competitive Panel
+
+Branch: `feat/eval-frozen-competitive`
+
+## Scope
+
+- Added `OPENCANDLE_COMPETITIVE_PANEL=frozen` and `npm run test:evals:competitive:frozen`.
+- Kept `npm run test:evals:competitive` as generated-prompt discovery.
+- Frozen panel loss classes:
+  - portfolio-review-not-builder
+  - "1-2 weeks" DTE preservation
+  - protective-put-not-bullish-call
+  - unknown-ticker-no-dead-end
+  - hedge sizing with share count
+- Prompt-specific literals and hard assertions live in `docs/internal/prompt-to-policy-migration-manifest.json`, not production prompts.
+
+## Evidence
+
+- Focused unit and guard logs are stored under `docs/internal/pr-evidence/feat-eval-frozen-competitive/`.
+- Live frozen competitive rerun is opt-in/release-runnable because it needs model/provider credentials and generic-agent baselines.
+- Live attempt on 2026-07-04 stopped before model calls: Pi model auth did not expose an API key for `google/gemini-2.5-flash`, including when mapping `.env` `GEMINI_API_KEY` to `GOOGLE_API_KEY` for the command. See `docs/internal/pr-evidence/feat-eval-frozen-competitive/frozen-competitive-live.log`.
+
 # feat/eval-router-fixtures
 
 # PR Notes: Deterministic Synthesis Validation

--- a/docs/internal/competitive-benchmarking.md
+++ b/docs/internal/competitive-benchmarking.md
@@ -52,6 +52,16 @@ The runner:
 
 Reports are ignored by git. Commit reusable code and benchmark design, not one-off run transcripts or screenshots.
 
+## Frozen Release Panel
+
+Generated competitive prompts remain the discovery tool. Release preparation should also rerun the frozen historical-loss panel:
+
+```bash
+npm run test:evals:competitive:frozen
+```
+
+This sets `OPENCANDLE_COMPETITIVE_PANEL=frozen` and reuses the competitive runner's exact-prompt cache for Claude, Codex, and Gemini baselines when previous reports contain matching answers. The panel covers portfolio-review-not-builder, requested 1-2 week DTE preservation, protective-put-not-bullish-call, unknown-ticker-no-dead-end, and hedge sizing with share count. The deterministic hard assertions for these prompts live in `docs/internal/prompt-to-policy-migration-manifest.json`; do not copy those literals into production prompt guidance.
+
 ## Recording Improvement History
 
 Raw JSON reports under `tests/evals/runs/` are local evidence only and are ignored by git. When a competitive run leads to a product or harness change, record a compact, committed summary in `docs/internal/competitive-benchmark-history.md`.
@@ -78,6 +88,7 @@ Useful environment variables:
 
 - `COMPETITIVE_PROMPT_COUNT`: number of generated prompts. Defaults to `5`.
 - `COMPETITIVE_PROMPT_SEED`: text seed for varying or reproducing prompt generation.
+- `OPENCANDLE_COMPETITIVE_PANEL=frozen`: use the frozen release panel instead of generated prompts.
 - `OPENCANDLE_COMPETITIVE_PROMPT`: fixed user prompt for rerunning the same case after a change. When set, prompt generation is skipped.
 - `OPENCANDLE_COMPETITIVE_PROMPT_ID`: optional id for the fixed prompt. Defaults to `fixed-prompt`.
 - `OPENCANDLE_COMPETITIVE_PROMPT_TOPIC`: optional topic for the fixed prompt. Defaults to `fixed prompt`.

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/biome-ci.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/biome-ci.log
@@ -1,0 +1,1 @@
+[0m[34mChecked 602 files in 255[0m[0m[2m[34mms[0m[0m[34m.[0m[0m[34m No fixes applied.[0m

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/competitive-finance-vitest.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/competitive-finance-vitest.log
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive
+
+
+ Test Files  1 passed (1)
+      Tests  31 passed (31)
+   Start at  00:32:05
+   Duration  1.46s (transform 340ms, setup 0ms, import 1.37s, tests 17ms, environment 0ms)
+

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/focused-vitest.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/focused-vitest.log
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive
+
+
+ Test Files  3 passed (3)
+      Tests  37 passed (37)
+   Start at  00:32:55
+   Duration  1.25s (transform 415ms, setup 0ms, import 1.23s, tests 28ms, environment 0ms)
+

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/frozen-competitive-live.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/frozen-competitive-live.log
@@ -1,0 +1,14 @@
+
+> opencandle@0.11.0 test:evals:competitive:frozen
+> OPENCANDLE_COMPETITIVE_PANEL=frozen tsx tests/scripts/run-competitive-finance-eval.ts
+
+/Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive/tests/scripts/run-competitive-finance-eval.ts:693
+    throw new Error(
+          ^
+
+Error: No API key available for google/gemini-2.5-flash.
+Set OPENCANDLE_COMPETITIVE_PROVIDER and OPENCANDLE_COMPETITIVE_MODEL, plus the matching API key, or configure a model through the OpenCandle/Pi setup flow.
+    at resolveModelWithAuth (/Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive/tests/scripts/run-competitive-finance-eval.ts:693:11)
+    at async <anonymous> (/Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive/tests/scripts/run-competitive-finance-eval.ts:122:20)
+
+Node.js v22.23.0

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/graphify-update.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/graphify-update.log
@@ -1,0 +1,18 @@
+Re-extracting code files in . (no LLM needed)...
+  AST extraction: 100/1196 uncached files (8%) [10 workers]
+  AST extraction: 200/1196 uncached files (16%) [10 workers]
+  AST extraction: 300/1196 uncached files (25%) [10 workers]
+  AST extraction: 400/1196 uncached files (33%) [10 workers]
+  AST extraction: 500/1196 uncached files (41%) [10 workers]
+  AST extraction: 600/1196 uncached files (50%) [10 workers]
+  AST extraction: 700/1196 uncached files (58%) [10 workers]
+  AST extraction: 800/1196 uncached files (66%) [10 workers]
+  AST extraction: 900/1196 uncached files (75%) [10 workers]
+  AST extraction: 1000/1196 uncached files (83%) [10 workers]
+  AST extraction: 1100/1196 uncached files (91%) [10 workers]
+  AST extraction: 1198/1198 files (100%) [10 workers]
+[graphify watch] Skipped graph.html: Graph has 11323 nodes - too large for HTML viz (limit: 5000). Use --no-viz, raise GRAPHIFY_VIZ_NODE_LIMIT, or reduce input size.
+[graphify watch] Rebuilt: 11323 nodes, 16396 edges, 874 communities
+[graphify watch] graph.json and GRAPH_REPORT.md updated in graphify-out
+Code graph updated. For doc/paper/image changes run /graphify --update in your AI assistant.
+Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction.

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/npm-test.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/npm-test.log
@@ -1,0 +1,21 @@
+
+> opencandle@0.11.0 pretest
+> npm run check:node
+
+
+> opencandle@0.11.0 check:node
+> node scripts/check-node-version.mjs
+
+
+> opencandle@0.11.0 test
+> vitest run
+
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive
+
+
+ Test Files  222 passed (222)
+      Tests  2350 passed | 2 skipped (2352)
+   Start at  00:33:16
+   Duration  16.35s (transform 6.74s, setup 0ms, import 31.62s, tests 52.10s, environment 13ms)
+

--- a/docs/internal/pr-evidence/feat-eval-frozen-competitive/prompt-policy-guard-vitest.log
+++ b/docs/internal/pr-evidence/feat-eval-frozen-competitive/prompt-policy-guard-vitest.log
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.9 /Users/kahtaf/Documents/workspace/oc-eval-frozen-competitive
+
+
+ Test Files  2 passed (2)
+      Tests  6 passed (6)
+   Start at  00:32:13
+   Duration  109ms (transform 39ms, setup 0ms, import 56ms, tests 8ms, environment 0ms)
+

--- a/docs/internal/prompt-to-policy-migration-manifest.json
+++ b/docs/internal/prompt-to-policy-migration-manifest.json
@@ -285,13 +285,41 @@
         "commitmentMode": "decision",
         "toolBundles": ["core_market", "options", "sentiment", "clarification"],
         "requiredEvidence": ["owned underlying DRAM", "catalyst symbol NVDA", "options chain when available"],
-        "finalAnswerHardAssertions": [],
+        "finalAnswerHardAssertions": [
+          "uses DRAM as the covered-call underlying",
+          "preserves NVDA as catalyst context",
+          "preserves cost basis and event-week DTE hint"
+        ],
         "providerGapDisclosure": []
       },
       "optionalJudgeAssertions": ["strategy/risk framing", "uses DRAM as the covered-call underlying", "preserves NVDA as catalyst context, not the option-chain symbol", "preserves cost basis and event-week DTE hint", "frames covered-call assignment/downside/opportunity-cost risk"],
       "baselineOpenCandleReportPath": "tests/unit/routing/router.test.ts",
       "competitorBaselineReportPathOrHash": "not-applicable-router-boundary",
       "cachedCompetitorAnswersAllowed": false
+    },
+    {
+      "id": "covered-call-dte-preservation",
+      "text": "I own 100 shares of DRAM at a $51 cost basis. NVDA earnings are today, but I want a covered call 1-2 weeks out. What strike and expiry should I look at?",
+      "followupSequence": [],
+      "ledgerRows": ["options-existing-position", "frozen-competitive-panel"],
+      "expected": {
+        "routeKind": "workflow_dispatch",
+        "workflow": "options_screener",
+        "taskFamily": "options_strategy",
+        "commitmentMode": "decision",
+        "toolBundles": ["core_market", "options", "sentiment", "clarification"],
+        "requiredEvidence": ["owned underlying DRAM", "catalyst symbol NVDA", "requested 1-2 week DTE", "options chain when available"],
+        "finalAnswerHardAssertions": [
+          "uses DRAM as the covered-call underlying",
+          "preserves NVDA as catalyst context",
+          "preserves requested 1-2 week DTE"
+        ],
+        "providerGapDisclosure": []
+      },
+      "optionalJudgeAssertions": ["strategy/risk framing", "uses DRAM as the covered-call underlying", "preserves NVDA as catalyst context, not the option-chain symbol", "preserves requested 1-2 week DTE instead of same-day expiry", "frames covered-call assignment/downside/opportunity-cost risk"],
+      "baselineOpenCandleReportPath": "not-applicable-frozen-competitive-panel",
+      "competitorBaselineReportPathOrHash": "not-applicable-frozen-competitive-panel",
+      "cachedCompetitorAnswersAllowed": true
     },
     {
       "id": "protective-put-routing",
@@ -305,7 +333,12 @@
         "commitmentMode": "decision",
         "toolBundles": ["core_market", "options", "sentiment", "clarification"],
         "requiredEvidence": ["owned underlying AMD", "catalyst symbol NVDA", "share quantity", "options chain when available"],
-        "finalAnswerHardAssertions": [],
+        "finalAnswerHardAssertions": [
+          "uses AMD as protective-put underlying",
+          "preserves NVDA as catalyst context",
+          "preserves 200-share hedge quantity and month DTE hint",
+          "does not convert protective put request into a bullish call strategy"
+        ],
         "providerGapDisclosure": []
       },
       "optionalJudgeAssertions": ["cost-sensitive hedge quality", "uses AMD as protective-put underlying", "preserves NVDA as catalyst context", "preserves 200-share hedge quantity and month DTE hint", "frames hedge floor, premium, Greeks, liquidity, and protective-put risks"],
@@ -363,7 +396,8 @@
         "requiredEvidence": [],
         "finalAnswerHardAssertions": [
           "does not ask for a portfolio budget",
-          "does not route as portfolio construction requiring a budget"
+          "does not route as portfolio construction requiring a budget",
+          "starts with a bottom-line structural portfolio read"
         ],
         "providerGapDisclosure": []
       },
@@ -371,6 +405,30 @@
       "baselineOpenCandleReportPath": "not-applicable-new-prompt-policy-case",
       "competitorBaselineReportPathOrHash": "not-applicable-new-prompt-policy-case",
       "cachedCompetitorAnswersAllowed": false
+    },
+    {
+      "id": "hedge-sizing-share-count",
+      "text": "I own 450 shares of AAPL and want downside protection through the next month. How many puts should I consider and what tradeoffs matter?",
+      "followupSequence": [],
+      "ledgerRows": ["options-existing-position", "frozen-competitive-panel"],
+      "expected": {
+        "routeKind": "workflow_dispatch",
+        "workflow": "options_screener",
+        "taskFamily": "options_strategy",
+        "commitmentMode": "decision",
+        "toolBundles": ["core_market", "options", "sentiment", "clarification"],
+        "requiredEvidence": ["owned underlying AAPL", "share quantity", "one contract per 100 shares sizing", "options chain when available"],
+        "finalAnswerHardAssertions": [
+          "uses AAPL as protective-put underlying",
+          "sizes hedge from 450 shares into 4 puts plus residual 50 shares or explicitly explains rounding",
+          "frames hedge floor, premium, Greeks, liquidity, and protective-put risks"
+        ],
+        "providerGapDisclosure": []
+      },
+      "optionalJudgeAssertions": ["cost-sensitive hedge quality", "uses AAPL as protective-put underlying", "preserves 450-share hedge quantity and month DTE hint", "sizes hedge contracts from the 100-share options multiplier", "frames hedge floor, premium, Greeks, liquidity, and protective-put risks"],
+      "baselineOpenCandleReportPath": "not-applicable-frozen-competitive-panel",
+      "competitorBaselineReportPathOrHash": "not-applicable-frozen-competitive-panel",
+      "cachedCompetitorAnswersAllowed": true
     },
     {
       "id": "provider-degradation-disclosure",

--- a/docs/testing-and-evals.md
+++ b/docs/testing-and-evals.md
@@ -73,6 +73,7 @@ npm run test:evals:usually
 npm run eval:router-live
 npm run test:evals:product
 npm run test:evals:competitive
+npm run test:evals:competitive:frozen
 ```
 
 | Command | What it runs | When to use it |
@@ -82,6 +83,7 @@ npm run test:evals:competitive
 | `npm run eval:router-live` | `tests/scripts/run-live-router-eval.ts` against request-understanding fixtures with a live model | Opt-in task-selection quality check. Requires live model credentials and compares live output to fixture expectations. |
 | `npm run test:evals:product` | `tests/scripts/run-product-evals.ts` | Full-session product evals over curated finance prompts, using the OpenCandle harness and rubric-style dimensions. |
 | `npm run test:evals:competitive` | `tests/scripts/run-competitive-finance-eval.ts` | Competitive finance benchmark against generic no-tool Claude, Codex, and Gemini baselines. See [Competitive Benchmarking](#competitive-benchmarking). |
+| `npm run test:evals:competitive:frozen` | `tests/scripts/run-competitive-finance-eval.ts` with `OPENCANDLE_COMPETITIVE_PANEL=frozen` | Per-release frozen competitive panel over historical loss classes, using exact prompt text and cached competitor baselines when available. Not part of per-PR CI. |
 
 Eval reports are written under `tests/evals/runs/` when a runner produces a JSON report. Treat those run files as local evidence, not committed documentation.
 
@@ -131,9 +133,18 @@ npm run test:evals:competitive
 
 The runner generates (or accepts) finance prompts, runs each through OpenCandle and the baselines, judges usefulness, correctness, evidence, clarity, and uncertainty handling with a configured judge model, and writes a timestamped `*_competitive-finance.json` report under `tests/evals/runs/`.
 
+For release preparation, rerun the frozen competitive panel:
+
+```bash
+npm run test:evals:competitive:frozen
+```
+
+The frozen panel keeps generated prompt discovery separate from regression tracking. It covers portfolio-review-not-builder, requested DTE preservation, protective-put-not-bullish-call, unknown-ticker-no-dead-end, and hedge sizing with share count. Its hard assertions live in `docs/internal/prompt-to-policy-migration-manifest.json` so benchmark literals stay out of production prompts.
+
 Useful knobs (all optional):
 
 - `COMPETITIVE_PROMPT_COUNT` / `COMPETITIVE_PROMPT_SEED`: size and reproducibility of the generated prompt set.
+- `OPENCANDLE_COMPETITIVE_PANEL=frozen`: rerun the fixed historical-loss panel instead of generating prompts.
 - `OPENCANDLE_COMPETITIVE_PROMPT` (with `_ID`, `_TOPIC`, `_COMPLEXITY`, `_FOCUS`): pin one fixed prompt instead of generating.
 - `OPENCANDLE_COMPETITIVE_PROVIDER` / `OPENCANDLE_COMPETITIVE_MODEL`: judge and prompt-generation model. Defaults prefer configured Google auth with `gemini-2.5-flash`, then the first configured model.
 - `OPENCANDLE_COMPETITIVE_ACPX_COMMAND` and per-baseline `*_AGENT_COMMAND` / `*_MODEL` overrides, timeouts, and `OPENCANDLE_COMPETITIVE_PREFLIGHT=0` to skip baseline smoke calls.

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "test:evals:usually": "EVAL_TIER=usually vitest run --config vitest.config.evals.ts",
     "test:evals:product": "tsx tests/scripts/run-product-evals.ts",
     "test:evals:competitive": "tsx tests/scripts/run-competitive-finance-eval.ts",
+    "test:evals:competitive:frozen": "OPENCANDLE_COMPETITIVE_PANEL=frozen tsx tests/scripts/run-competitive-finance-eval.ts",
     "test:packed-install": "node scripts/packed-install-smoke.mjs",
     "eval:competitive:analyze": "tsx tests/scripts/analyze-competitive-finance-report.ts",
     "review:pr": ".agents/skills/autoreview/scripts/autoreview --mode branch --prompt-file .agents/skills/autoreview/references/opencandle-review.md --parallel-tests \"npx tsc --noEmit && npx biome ci . && npx vitest run\"",

--- a/tests/evals/competitive-finance.ts
+++ b/tests/evals/competitive-finance.ts
@@ -9,6 +9,11 @@ export interface GeneratedFinancePrompt {
   evaluationFocus: string;
 }
 
+export interface FrozenCompetitivePanelPrompt extends GeneratedFinancePrompt {
+  lossClass: string;
+  promptPolicyManifestId: string;
+}
+
 export interface PromptGenerationOptions {
   count: number;
   seed?: string;
@@ -54,6 +59,70 @@ export const COMPETITIVE_STATE_FIXTURE: SeededMarketStateFixture = {
     { symbol: "JPM", name: "JPMorgan Chase & Co.", thesis: "rate-cycle beneficiary" },
   ],
 };
+
+export const FROZEN_COMPETITIVE_PANEL: FrozenCompetitivePanelPrompt[] = [
+  {
+    id: "frozen-portfolio-review-not-builder",
+    prompt:
+      "Critically evaluate a 60/40 portfolio for the next year. Do not build a new portfolio; just review the existing allocation.",
+    topic: "portfolio review",
+    complexity: "moderate",
+    evaluationFocus:
+      "Preserve the user's review request and avoid turning an existing-allocation critique into portfolio construction.",
+    lossClass: "portfolio-review-not-builder",
+    promptPolicyManifestId: "existing-allocation-review",
+  },
+  {
+    id: "frozen-covered-call-dte-preservation",
+    prompt:
+      "I own 100 shares of DRAM at a $51 cost basis. NVDA earnings are today, but I want a covered call 1-2 weeks out. What strike and expiry should I look at?",
+    topic: "options existing position",
+    complexity: "complex",
+    evaluationFocus:
+      "Preserve the owned underlying, catalyst context, cost basis, and requested 1-2 week DTE instead of drifting to the catalyst ticker or same-day expiry.",
+    lossClass: "1-2 weeks DTE preservation",
+    promptPolicyManifestId: "covered-call-dte-preservation",
+  },
+  {
+    id: "frozen-protective-put-not-bullish-call",
+    prompt:
+      "NVDA earnings are today. I own 200 shares of AMD. What protective put should I buy for the next month?",
+    topic: "options existing position",
+    complexity: "complex",
+    evaluationFocus:
+      "Keep the strategy as a protective put on AMD sized to the owned share count, not a bullish call or catalyst-ticker options trade.",
+    lossClass: "protective-put-not-bullish-call",
+    promptPolicyManifestId: "protective-put-routing",
+  },
+  {
+    id: "frozen-unknown-ticker-no-dead-end",
+    prompt:
+      "I hold 300 shares of ZZZZ and earnings are tonight. Should I trim, hedge, or hold through it?",
+    topic: "unknown ticker event risk",
+    complexity: "complex",
+    evaluationFocus:
+      "Avoid dead-ending on an unknown ticker: disclose unverifiability, avoid fabricated earnings facts, and still give a useful event-risk framework.",
+    lossClass: "unknown-ticker-no-dead-end",
+    promptPolicyManifestId: "unknown-ticker-earnings-risk",
+  },
+  {
+    id: "frozen-hedge-sizing-with-share-count",
+    prompt:
+      "I own 450 shares of AAPL and want downside protection through the next month. How many puts should I consider and what tradeoffs matter?",
+    topic: "options hedge sizing",
+    complexity: "complex",
+    evaluationFocus:
+      "Use the stated share count to size protective puts by 100-share contracts and explain residual unhedged shares and hedge tradeoffs.",
+    lossClass: "hedge sizing with share count",
+    promptPolicyManifestId: "hedge-sizing-share-count",
+  },
+];
+
+export function frozenCompetitivePanelFromEnv(
+  env: Record<string, string | undefined>,
+): FrozenCompetitivePanelPrompt[] | null {
+  return env.OPENCANDLE_COMPETITIVE_PANEL === "frozen" ? FROZEN_COMPETITIVE_PANEL : null;
+}
 
 export function buildSavedStateSummary(fixture: SeededMarketStateFixture): string {
   const lines = ["The user's saved OpenCandle state:"];

--- a/tests/evals/prompt-policy-assertions.ts
+++ b/tests/evals/prompt-policy-assertions.ts
@@ -158,6 +158,11 @@ function evaluateManifestAssertion(
     reason: `registered qualitative assertion; not enforced with brittle keyword matching (${terms.map(String).join(", ")})`,
     deterministic: false,
   });
+  const requires = (...terms: RegExp[]) => ({
+    passed: terms.every((term) => term.test(text)),
+    reason: `expected final answer to include: ${terms.map(String).join(", ")}`,
+    deterministic: true,
+  });
   const forbids = (...terms: RegExp[]) => ({
     passed: terms.every((term) => !term.test(text)),
     reason: `expected final answer not to include: ${terms.map(String).join(", ")}`,
@@ -351,37 +356,43 @@ function evaluateManifestAssertion(
     return requiredTerms(/6\.8\s*%|6\.8 percent/, /default|would|practical/);
   }
   if (lowerAssertion.includes("uses dram as the covered-call underlying")) {
-    return requiredTerms(/\bdram\b/);
+    return requires(/\bdram\b/);
   }
   if (lowerAssertion.includes("preserves nvda as catalyst context")) {
-    return requiredTerms(/\bnvda\b/, /catalyst|context|earnings|event/);
+    return requires(/\bnvda\b/, /catalyst|context|earnings|event/);
   }
   if (lowerAssertion.includes("cost basis and event-week dte")) {
-    return requiredTerms(/cost basis/, /event[- ]week|DTE|days? to expiration/);
+    return requires(/cost basis/, /event[- ]week|dte|days? to expiration/);
+  }
+  if (lowerAssertion.includes("preserves requested 1-2 week dte")) {
+    return requires(/1\s*[-–]\s*2|one\s+to\s+two|two[- ]week|weekly/, /dte|expiry|expiration/);
   }
   if (lowerAssertion.includes("covered-call assignment")) {
     return requiredTerms(/assignment/, /downside/, /opportunity cost|capped upside/);
   }
   if (lowerAssertion.includes("uses amd as protective-put underlying")) {
-    return requiredTerms(/\bamd\b/);
+    return requires(/\bamd\b/);
+  }
+  if (lowerAssertion.includes("uses aapl as protective-put underlying")) {
+    return requires(/\baapl\b/);
   }
   if (lowerAssertion.includes("200-share hedge quantity")) {
-    return requiredTerms(/200/, /month|DTE|days? to expiration/);
+    return requires(/200/, /month|dte|days? to expiration/);
+  }
+  if (lowerAssertion.includes("does not convert protective put request into a bullish call")) {
+    return forbids(/bullish call|bull call|call spread|covered call/);
+  }
+  if (lowerAssertion.includes("sizes hedge from 450 shares")) {
+    return requires(/450/, /\b4\b|four/, /50|residual|unhedged|round/);
   }
   if (lowerAssertion.includes("hedge floor, premium")) {
-    return requiredTerms(
-      /hedge floor|floor/,
-      /premium/,
-      /delta|theta|greeks?/,
-      /liquidity/,
-      /risk/,
-    );
+    return requires(/hedge floor|floor/, /premium/, /delta|theta|greeks?/, /liquidity/, /risk/);
   }
   if (
     lowerAssertion.includes("bottom-line portfolio risk/reward") ||
     lowerAssertion.includes("bottom-line structural portfolio read")
   ) {
-    return requiredTerms(/bottom line/, /portfolio/, /risk|reward|structural/);
+    return requires(/bottom line/, /portfolio/, /risk|reward|structural/);
   }
   if (lowerAssertion.includes("current macro evidence")) {
     return requiredTerms(

--- a/tests/scripts/run-competitive-finance-eval.ts
+++ b/tests/scripts/run-competitive-finance-eval.ts
@@ -41,6 +41,7 @@ import {
   findCachedPromptMetadata,
   fixedPromptFromEnv,
   formatCompetitiveReportAnalysisMarkdown,
+  frozenCompetitivePanelFromEnv,
   type GeneratedFinancePrompt,
   parseComparisonJudgment,
   parseGeneratedPrompts,
@@ -123,16 +124,19 @@ const judgeModel = await resolveModelWithAuth(
   requestedModelId,
   "Set OPENCANDLE_COMPETITIVE_PROVIDER and OPENCANDLE_COMPETITIVE_MODEL, plus the matching API key, or configure a model through the OpenCandle/Pi setup flow.",
 );
+const frozenPanel = frozenCompetitivePanelFromEnv(process.env);
 const fixedPrompt = fixedPromptFromEnv(process.env);
-const rawPrompts = fixedPrompt
-  ? [fixedPrompt]
-  : parseGeneratedPrompts(
-      await completeText(
-        judgeModel,
-        buildPromptGenerationPrompt({ count: promptCount, seed, asOfDate, savedStateSummary }),
-        { temperature: 0.8, maxTokens: 3000 },
-      ),
-    );
+const rawPrompts = frozenPanel
+  ? frozenPanel
+  : fixedPrompt
+    ? [fixedPrompt]
+    : parseGeneratedPrompts(
+        await completeText(
+          judgeModel,
+          buildPromptGenerationPrompt({ count: promptCount, seed, asOfDate, savedStateSummary }),
+          { temperature: 0.8, maxTokens: 3000 },
+        ),
+      );
 const prompts = rawPrompts.map((prompt) => {
   const cached = findCachedPromptMetadata(competitorAnswerCache, prompt.prompt);
   return cached
@@ -265,8 +269,9 @@ const report = {
   })),
   skippedCompetitors: preflight.skipped,
   promptCount: results.length,
-  promptMode: fixedPrompt ? "fixed" : "generated",
+  promptMode: frozenPanel ? "frozen" : fixedPrompt ? "fixed" : "generated",
   seededState: seedState,
+  frozenPanel: Boolean(frozenPanel),
   summary,
   results,
 };

--- a/tests/unit/evals/competitive-finance.test.ts
+++ b/tests/unit/evals/competitive-finance.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -17,10 +17,12 @@ import {
   competitivePreflightTimeoutMs,
   competitiveReportAnalysisPath,
   extractUsableAnswerFromCliFailure,
+  FROZEN_COMPETITIVE_PANEL,
   findCachedCompetitorAnswer,
   findCachedPromptMetadata,
   fixedPromptFromEnv,
   formatCompetitiveReportAnalysisMarkdown,
+  frozenCompetitivePanelFromEnv,
   parseComparisonJudgment,
   parseGeneratedPrompts,
   selectCliFailureMessage,
@@ -504,6 +506,40 @@ describe("competitive finance benchmarking", () => {
       complexity: "complex",
       evaluationFocus: "Check whether OC improves after a prompt fix.",
     });
+  });
+
+  it("defines a frozen competitive panel from historical loss classes", () => {
+    const manifest = JSON.parse(
+      readFileSync("docs/internal/prompt-to-policy-migration-manifest.json", "utf-8"),
+    ) as {
+      prompts: Array<{ id: string; expected: { finalAnswerHardAssertions?: string[] } }>;
+    };
+    const promptsById = new Map(manifest.prompts.map((prompt) => [prompt.id, prompt]));
+
+    expect(frozenCompetitivePanelFromEnv({})).toBeNull();
+    expect(frozenCompetitivePanelFromEnv({ OPENCANDLE_COMPETITIVE_PANEL: "frozen" })).toStrictEqual(
+      FROZEN_COMPETITIVE_PANEL,
+    );
+    expect(FROZEN_COMPETITIVE_PANEL).toHaveLength(5);
+    expect(FROZEN_COMPETITIVE_PANEL.map((prompt) => prompt.lossClass)).toEqual([
+      "portfolio-review-not-builder",
+      "1-2 weeks DTE preservation",
+      "protective-put-not-bullish-call",
+      "unknown-ticker-no-dead-end",
+      "hedge sizing with share count",
+    ]);
+    expect(new Set(FROZEN_COMPETITIVE_PANEL.map((prompt) => prompt.prompt)).size).toBe(5);
+    expect(
+      FROZEN_COMPETITIVE_PANEL.every((prompt) => prompt.promptPolicyManifestId.length > 0),
+    ).toBe(true);
+    for (const prompt of FROZEN_COMPETITIVE_PANEL) {
+      expect(
+        promptsById.get(prompt.promptPolicyManifestId)?.expected.finalAnswerHardAssertions,
+      ).toBeDefined();
+      expect(
+        promptsById.get(prompt.promptPolicyManifestId)?.expected.finalAnswerHardAssertions?.length,
+      ).toBeGreaterThan(0);
+    }
   });
 
   it("finds cached competitor answers by exact prompt text and competitor id", () => {


### PR DESCRIPTION
## Summary
- Add `OPENCANDLE_COMPETITIVE_PANEL=frozen` and `npm run test:evals:competitive:frozen` for the E7 release-runnable frozen competitive panel.
- Freeze five historical competitive loss classes while keeping generated competitive benchmarking for discovery.
- Promote the panel expectations into `finalAnswerHardAssertions` in the prompt-policy manifest and register deterministic hard-assertion checkers.
- Document release cadence and record evidence under `docs/internal/pr-evidence/feat-eval-frozen-competitive/`.

## Frozen panel classes
- portfolio-review-not-builder
- 1-2 weeks DTE preservation
- protective-put-not-bullish-call
- unknown-ticker-no-dead-end
- hedge sizing with share count

## Validation
- `npx vitest run tests/unit/evals/competitive-finance.test.ts tests/unit/evals/prompt-policy-assertions.test.ts tests/unit/prompts/prompt-debt-guard.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npx biome ci . --diagnostic-level=error`
- `graphify update .`

## Live eval note
- Attempted `npm run test:evals:competitive:frozen` with `.env` credentials present.
- Blocked before model calls because Pi model auth did not expose an API key for `google/gemini-2.5-flash`, including when mapping `.env` `GEMINI_API_KEY` to `GOOGLE_API_KEY` for the command. See `docs/internal/pr-evidence/feat-eval-frozen-competitive/frozen-competitive-live.log`.
