### PR TITLE
test: allow autoreview helper commit skip path to finish

### DIFF
--- a/tests/unit/skills/autoreview-helper.test.ts
+++ b/tests/unit/skills/autoreview-helper.test.ts
@@ -852,7 +852,7 @@ fs.writeFileSync(outputPath, JSON.stringify(report));
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("react-doctor: skipped");
     expect(result.stderr).not.toContain("react doctor should have been skipped");
-  });
+  }, 15_000);
 
   it("fails forced branch review when the worktree has uncommitted changes", () => {
     dir = mkdtempSync(join(tmpdir(), "autoreview-dirty-"));


### PR DESCRIPTION
## Summary
- Extends the timeout for the subprocess-heavy autoreview helper commit skip test.
- Keeps the assertion unchanged; this unblocks the release gate after the test exceeded Vitest's default 5s timeout.

## Verification
- npx vitest run tests/unit/skills/autoreview-helper.test.ts
- npm test