### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.11.1] - 2026-07-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.11.1] - 2026-07-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Financial trading & investing agent",
   "license": "MIT",
   "homepage": "https://opencandle.app",


### PR DESCRIPTION
## Summary
- Cut OpenCandle v0.11.1
- Move the current changelog entries into the v0.11.1 section
- Restore an empty [Unreleased] section for the next cycle

## Verification
- npm run release:patch preflight passed locally before protected-branch push was rejected
- Release preflight included TypeScript, Biome, full Vitest, GUI release smoke, docs build, package contents check, packed install smoke, and public docs link check