### PR TITLE
ci: install chromium for publish smoke

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Chromium for GUI smoke tests
+        run: npx playwright-core install --with-deps chromium
+
       - name: Verify release tag
         run: |
           if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish workflow now installs the Chromium browser binary required by the GUI release smoke before running `release:check`.
+
 ## [0.11.1] - 2026-07-08
 
 ### Added


### PR DESCRIPTION
## Summary
- Install the Playwright Chromium browser binary in the publish workflow before running release checks
- Document the release-infra fix in the changelog

## Verification
- npx playwright-core install --dry-run chromium
- npm test