### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.12.0] - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.12.0] - 2026-07-10
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Open source financial investigator: evidence-first market research agent for your terminal and local GUI",
   "license": "MIT",
   "homepage": "https://opencandle.app",


### PR DESCRIPTION
Version bump to 0.12.0 (minor — the Unreleased section contains two BREAKING entries) plus changelog rotation, stacked on the release-readiness fixes from #101.

Merge order: either merge #101 first and then this PR (it shrinks to the two release commits), or merge this PR alone and close #101 (it contains all of its commits).

After this lands on main I will push the `v0.12.0` tag at the merge commit; the publish workflow verifies the tag against package.json, re-runs `release:check` (including the Chromium GUI smoke), and publishes to npm with provenance.

Pre-tag verification already done locally: full `release:check` passed (exit 0); release evals reviewed — `cases` no regression (91.7% vs 93.0% baseline), `product` 22/24 checks with known soft-miss classes only, `router-live` 28/32 on Gemini (failures are documented Gemini-drift fixtures; no routing code changed in this release). The `competitive:frozen` panel did not run (stopped mid-run); this release touches no routing/prompt/tool surface, so the frozen loss-classes are not at risk from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqbTj2vTu797sgw9PrtUr7