### PR TITLE
CI follow-up: slim Node matrix, first-run journey smoke, richer packed-install asserts, nightly drift canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,17 @@ jobs:
         run: npm ci
 
       - name: Typecheck
+        if: matrix.node-version == '24.x'
         run: npx tsc --noEmit
 
       - name: Lint
+        if: matrix.node-version == '24.x'
         run: npx biome ci .
 
-      # Every matrix leg builds the site: the public-site build contract
-      # tests in `npm test` read website/dist output.
+      # The full Node 24.x leg builds the site because the public-site build
+      # contract tests in `npm test` read website/dist output.
       - name: Build public docs
+        if: matrix.node-version == '24.x'
         run: npm run docs:site:build
 
       - name: Validate package contents
@@ -50,6 +53,7 @@ jobs:
         run: npm run package:contents:check
 
       - name: Run tests
+        if: matrix.node-version == '24.x'
         run: npm test
 
       - name: Run agent tool tests
@@ -65,8 +69,13 @@ jobs:
         run: npm run test:gui:release-smoke
 
       - name: Packed install smoke
-        if: matrix.node-version == '24.x'
         run: npm run test:packed-install
+
+      - name: Verify packaged CLI boots
+        run: |
+          expected_version="$(node -p "require('./package.json').version")"
+          test "$(node dist/cli.js --version)" = "$expected_version"
+          node dist/cli.js --help > /dev/null
 
       - name: Check public docs external links
         if: matrix.node-version == '24.x'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,67 @@
+name: Nightly drift canary
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    env:
+      ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run live provider checks
+        run: npm run test:e2e:providers
+
+      - name: Report missing Gemini API key
+        if: env.GEMINI_API_KEY == ''
+        run: |
+          {
+            echo "## :warning: GEMINI_API_KEY is not configured"
+            echo
+            echo "The deterministic eval and advisory live-router eval were skipped. Add the repository secret to enable the full nightly drift canary."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run deterministic eval cases
+        if: env.GEMINI_API_KEY != ''
+        run: npm run eval -- cases
+
+      - name: Run advisory live router eval
+        if: env.GEMINI_API_KEY != ''
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Explicit `shell: bash` runs with -e -o pipefail; capture the eval's
+          # exit code without aborting so the summary below is still written.
+          status=0
+          OPENCANDLE_ROUTER_PROVIDER=google OPENCANDLE_ROUTER_MODEL=gemini-2.5-flash npm run eval -- router-live 2>&1 | tee /tmp/router-live.log || status=$?
+          pass_rate="$(grep '^pass: ' /tmp/router-live.log | tail -n 1 || true)"
+          {
+            echo "## Advisory live-router eval"
+            echo
+            echo "${pass_rate:-Pass rate unavailable (the eval did not reach its summary).}"
+            if [ "$status" -ne 0 ]; then
+              echo
+              echo "This is advisory because known Gemini drift fixtures may fail."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - A non-gating nightly GitHub Actions drift canary now runs live provider checks and, when `GEMINI_API_KEY` is configured, deterministic and advisory live-router evals.
+- GUI release smoke coverage now exercises first-run invalid OpenAI and Google model-key feedback, cold diagnostics readiness, and composer key management without relying on third-party APIs.
+- `OPENCANDLE_MODEL_KEY_PROBE_BASE_URL` provides a test-support override for routing model-key validation probes to a local server while retaining each provider's probe path.
 
 ### Changed
 
 - CI now keeps the full validation gate on Node 24.x while Node 22.19.0 and 26.x run install/build, packed-install, and CLI boot envelope checks.
+- The packed-install smoke now verifies the packed CLI version, help usage, and blocked JSON doctor report in a fresh consumer home.
 
 ## [0.12.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - A non-gating nightly GitHub Actions drift canary now runs live provider checks and, when `GEMINI_API_KEY` is configured, deterministic and advisory live-router evals.
 - GUI release smoke coverage now exercises first-run invalid OpenAI and Google model-key feedback, cold diagnostics readiness, and composer key management without relying on third-party APIs.
-- `OPENCANDLE_MODEL_KEY_PROBE_BASE_URL` provides a test-support override for routing model-key validation probes to a local server while retaining each provider's probe path.
+- `OPENCANDLE_MODEL_KEY_PROBE_BASE_URL` provides a test-support override for routing model-key validation probes to a local server while retaining each provider's probe path; only loopback override hosts are honored so the probe's key-bearing headers cannot be redirected to a foreign host.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- A non-gating nightly GitHub Actions drift canary now runs live provider checks and, when `GEMINI_API_KEY` is configured, deterministic and advisory live-router evals.
+
+### Changed
+
+- CI now keeps the full validation gate on Node 24.x while Node 22.19.0 and 26.x run install/build, packed-install, and CLI boot envelope checks.
+
 ## [0.12.0] - 2026-07-10
 
 ### Added

--- a/docs/testing-and-evals.md
+++ b/docs/testing-and-evals.md
@@ -24,6 +24,8 @@ npm run docs:site:build
 
 `npm test` runs the [Vitest](https://vitest.dev) suite. Unit tests should be fixture-backed and should not call live APIs.
 
+CI runs the full gate on Node 24.x and install/packed/CLI envelope checks on Node 22.19.0 and 26.x; the scheduled nightly drift canary is non-gating and reports live-provider and eval results in the repository's Actions tab.
+
 For release-facing changes, run the same local gate that release and publish paths use:
 
 ```bash

--- a/scripts/packed-install-smoke.mjs
+++ b/scripts/packed-install-smoke.mjs
@@ -186,9 +186,16 @@ async function main() {
       ...process.env,
       HOME: osHomeDir,
       OPENCANDLE_HOME: homeDir,
+      // Model keys are blanked so the fresh-consumer doctor contract below is
+      // deterministic on machines with exported credentials.
+      GEMINI_API_KEY: "",
+      GOOGLE_API_KEY: "",
+      OPENAI_API_KEY: "",
+      ANTHROPIC_API_KEY: "",
     };
     // A fresh consumer home has no model credentials, so doctor reports
-    // blocked health and exits 1 by contract; 0 covers runners with keys.
+    // blocked health and exits 1 by contract; the JSON status assertion
+    // below is the strong gate on that state.
     run("npx", ["--no-install", "opencandle", "doctor"], {
       cwd: packageDir,
       env,

--- a/scripts/packed-install-smoke.mjs
+++ b/scripts/packed-install-smoke.mjs
@@ -34,7 +34,8 @@ function capture(command, args, options = {}) {
   });
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
-  if (result.status !== 0) {
+  const allowed = options.allowedExitCodes ?? [0];
+  if (!allowed.includes(result.status)) {
     throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
   }
   return result.stdout.trim();
@@ -193,6 +194,39 @@ async function main() {
       env,
       allowedExitCodes: [0, 1],
     });
+
+    const packedPackageJson = JSON.parse(
+      readFileSync(join(packageDir, "node_modules", packageJson.name, "package.json"), "utf8"),
+    );
+    const version = capture("npx", ["--no-install", "opencandle", "--version"], {
+      cwd: packageDir,
+      env,
+    });
+    if (version !== packedPackageJson.version) {
+      throw new Error(
+        `Expected packed CLI version ${packedPackageJson.version}, received ${version}`,
+      );
+    }
+
+    const help = capture("npx", ["--no-install", "opencandle", "--help"], { cwd: packageDir, env });
+    if (!help.includes("Usage: opencandle")) {
+      throw new Error("Packed CLI help did not include usage information");
+    }
+
+    const doctorJson = capture("npx", ["--no-install", "opencandle", "doctor", "--json"], {
+      cwd: packageDir,
+      env,
+      allowedExitCodes: [0, 1],
+    });
+    const doctorReport = JSON.parse(doctorJson);
+    if (!doctorReport.schemaVersion) {
+      throw new Error("Packed CLI doctor JSON did not include schemaVersion");
+    }
+    if (doctorReport.status !== "blocked") {
+      throw new Error(
+        `Expected fresh packed CLI doctor status blocked, received ${doctorReport.status}`,
+      );
+    }
     await smokeGui(packageDir, env);
     console.log("Packed install smoke passed.");
   } finally {

--- a/src/onboarding/validate-model-key.ts
+++ b/src/onboarding/validate-model-key.ts
@@ -1,4 +1,5 @@
 const VALIDATION_TIMEOUT_MS = 5_000;
+const MODEL_KEY_PROBE_BASE_URL_ENV = "OPENCANDLE_MODEL_KEY_PROBE_BASE_URL";
 
 export type ModelKeyProviderId = "google" | "openai" | "anthropic";
 
@@ -41,7 +42,7 @@ export async function validateModelKey(
 ): Promise<ModelKeyValidationResult> {
   const probe = MODEL_KEY_PROBES[providerId];
   try {
-    const response = await fetch(probe.url, {
+    const response = await fetch(resolveProbeUrl(probe.url), {
       method: "GET",
       headers: probe.headers(key),
       signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
@@ -68,4 +69,15 @@ export async function validateModelKey(
       reason: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function resolveProbeUrl(probeUrl: string): string {
+  const override = process.env[MODEL_KEY_PROBE_BASE_URL_ENV]?.trim();
+  if (!override) return probeUrl;
+
+  const url = new URL(probeUrl);
+  const baseUrl = new URL(override);
+  url.protocol = baseUrl.protocol;
+  url.host = baseUrl.host;
+  return url.toString();
 }

--- a/src/onboarding/validate-model-key.ts
+++ b/src/onboarding/validate-model-key.ts
@@ -75,9 +75,27 @@ function resolveProbeUrl(probeUrl: string): string {
   const override = process.env[MODEL_KEY_PROBE_BASE_URL_ENV]?.trim();
   if (!override) return probeUrl;
 
+  // Test-support hook only. Overrides are limited to loopback hosts because
+  // the probe request carries the typed API key in its headers; honoring an
+  // arbitrary origin (for example from a poisoned .env) would forward that
+  // key to a foreign host.
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(override);
+  } catch {
+    return probeUrl;
+  }
+  if (!isLoopbackHostname(baseUrl.hostname)) return probeUrl;
+
   const url = new URL(probeUrl);
-  const baseUrl = new URL(override);
   url.protocol = baseUrl.protocol;
   url.host = baseUrl.host;
   return url.toString();
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === "localhost" || host === "::1" || host === "[::1]" || /^127(\.\d{1,3}){3}$/.test(host)
+  );
 }

--- a/src/onboarding/validate-model-key.ts
+++ b/src/onboarding/validate-model-key.ts
@@ -46,6 +46,11 @@ export async function validateModelKey(
       method: "GET",
       headers: probe.headers(key),
       signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+      // Probes carry the typed key in headers that survive cross-origin
+      // redirects (x-goog-api-key, x-api-key); provider probe endpoints do
+      // not redirect, so any redirect is treated as a transient failure
+      // rather than followed.
+      redirect: "error",
     });
     if (response.status === 401 || response.status === 403) {
       return { status: "invalid", providerLabel: probe.label };

--- a/tests/e2e/gui-release-smoke.test.ts
+++ b/tests/e2e/gui-release-smoke.test.ts
@@ -43,6 +43,11 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
         GOOGLE_API_KEY: "",
         OPENAI_API_KEY: "",
         ANTHROPIC_API_KEY: "",
+        // Keyed data providers are blanked too: the GUI server loads the
+        // repo .env, and the diagnostics journey asserts the cold-home
+        // never-configured provider presentation.
+        ALPHA_VANTAGE_API_KEY: "",
+        FRED_API_KEY: "",
         OPENCANDLE_MODEL_KEY_PROBE_BASE_URL: probeBaseUrl,
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -151,10 +156,17 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
     const warnings = page.getByText("Warnings", { exact: true }).locator("xpath=..");
     await expectVisible(warnings.getByText("0", { exact: true }));
 
+    // Never-configured optional keyed providers report skip (0.12.0), not a
+    // warning: the Alpha Vantage credential row reads as optional with a
+    // Connect action. The section-level badge is deliberately not asserted —
+    // it folds in live public-provider reachability probes (Yahoo,
+    // TradingView, Polymarket), which this smoke must not depend on.
     const providersSection = page
       .getByRole("heading", { name: "Providers", exact: true })
       .locator("xpath=../..");
-    await expectVisible(providersSection.getByText("Ready", { exact: true }));
+    const alphaVantageRow = providersSection.getByRole("row").filter({ hasText: "Alpha Vantage" });
+    await expectVisible(alphaVantageRow.getByText("Not connected — optional."));
+    await expectVisible(alphaVantageRow.getByRole("button", { name: "Connect" }));
     await expectVisible(
       page.getByRole("main").locator("header").getByText("Blocked", { exact: true }),
     );

--- a/tests/e2e/gui-release-smoke.test.ts
+++ b/tests/e2e/gui-release-smoke.test.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:net";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Browser, chromium, type Locator, type Page } from "playwright-core";
@@ -20,6 +21,8 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
   let page: Page;
   let serverProcess: ChildProcessWithoutNullStreams;
   let baseUrl: string;
+  let probeBaseUrl: string;
+  let probeServer: HttpServer;
   let smokeHome: string;
   let serverLog = "";
 
@@ -27,6 +30,7 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
     smokeHome = mkdtempSync(join(tmpdir(), "opencandle-gui-release-smoke-"));
     const port = await allocatePort();
     baseUrl = `http://127.0.0.1:${port}`;
+    ({ server: probeServer, baseUrl: probeBaseUrl } = await startModelKeyProbeStub());
     serverProcess = spawn("npm", ["run", "gui"], {
       cwd: process.cwd(),
       env: {
@@ -39,6 +43,7 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
         GOOGLE_API_KEY: "",
         OPENAI_API_KEY: "",
         ANTHROPIC_API_KEY: "",
+        OPENCANDLE_MODEL_KEY_PROBE_BASE_URL: probeBaseUrl,
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -65,6 +70,7 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
       serverProcess.kill("SIGTERM");
       await waitForExit(serverProcess);
     }
+    await closeServer(probeServer);
     if (smokeHome) rmSync(smokeHome, { recursive: true, force: true });
   });
 
@@ -100,10 +106,76 @@ describe.skipIf(!runGuiReleaseSmoke)("GUI release-gate smoke", () => {
     const screenshot = await page.screenshot({ fullPage: true });
     writeEvidence("first-run-home.png", screenshot);
   });
+
+  it("rejects an invalid OpenAI key inline without connecting a model", async () => {
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+    const setupCard = page
+      .getByRole("heading", { name: "Connect an AI model" })
+      .locator("xpath=../..");
+    // The provider heading sits in an inner wrapper div; the card with the
+    // key textbox and Save button is one level further up.
+    const openAiCard = setupCard
+      .getByRole("heading", { name: "OpenAI", exact: true })
+      .locator("xpath=../..");
+    await openAiCard.getByRole("textbox", { name: "API key" }).fill("garbage-openai-key");
+    await openAiCard.getByRole("button", { name: "Save key" }).click();
+
+    await expectVisible(
+      setupCard.getByRole("alert").filter({ hasText: "Key was rejected by OpenAI" }),
+    );
+    await expectVisible(page.getByRole("button", { name: "No model connected" }));
+  });
+
+  it("rejects a Google API_KEY_INVALID response from the local probe stub", async () => {
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+    const setupCard = page
+      .getByRole("heading", { name: "Connect an AI model" })
+      .locator("xpath=../..");
+    const googleCard = setupCard
+      .getByRole("heading", { name: "Google Gemini", exact: true })
+      .locator("xpath=../..");
+    await googleCard.getByRole("textbox", { name: "API key" }).fill("garbage-google-key");
+    await googleCard.getByRole("button", { name: "Save key" }).click();
+
+    await expectVisible(
+      setupCard.getByRole("alert").filter({ hasText: "Key was rejected by Google Gemini" }),
+    );
+    await expectVisible(page.getByRole("button", { name: "No model connected" }));
+  });
+
+  it("reports a blocked cold home while optional providers are ready", async () => {
+    await page.goto(`${baseUrl}/diagnostics`, { waitUntil: "networkidle" });
+
+    const warnings = page.getByText("Warnings", { exact: true }).locator("xpath=..");
+    await expectVisible(warnings.getByText("0", { exact: true }));
+
+    const providersSection = page
+      .getByRole("heading", { name: "Providers", exact: true })
+      .locator("xpath=../..");
+    await expectVisible(providersSection.getByText("Ready", { exact: true }));
+    await expectVisible(
+      page.getByRole("main").locator("header").getByText("Blocked", { exact: true }),
+    );
+  });
+
+  it("opens model-key management from the disconnected composer", async () => {
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+    await page.getByRole("button", { name: "No model connected" }).click();
+    const manageKeys = page.getByRole("menuitem", { name: "Manage model keys…" });
+    await expectVisible(manageKeys);
+    await manageKeys.click();
+
+    await expect(
+      page.getByRole("dialog").getByRole("textbox", { name: "API key" }).count(),
+    ).resolves.toBeGreaterThanOrEqual(3);
+  });
 });
 
 async function allocatePort(): Promise<number> {
-  const server = createServer();
+  const server = createNetServer();
   return await new Promise((resolve, reject) => {
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
@@ -113,6 +185,34 @@ async function allocatePort(): Promise<number> {
         else reject(new Error("Failed to allocate a local port"));
       });
     });
+  });
+}
+
+async function startModelKeyProbeStub(): Promise<{ server: HttpServer; baseUrl: string }> {
+  const server = createHttpServer((request, response) => {
+    if (request.url === "/v1beta/models") {
+      response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { details: [{ reason: "API_KEY_INVALID" }] } }));
+      return;
+    }
+    response.writeHead(401, { "content-type": "text/plain" });
+    response.end("Unauthorized");
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") resolve(address.port);
+      else reject(new Error("Failed to start model-key probe stub"));
+    });
+  });
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function closeServer(server: HttpServer | undefined): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
   });
 }
 

--- a/tests/unit/onboarding/validate-model-key.test.ts
+++ b/tests/unit/onboarding/validate-model-key.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateModelKey } from "../../../src/onboarding/validate-model-key.js";
 
 const originalFetch = globalThis.fetch;
+const originalProbeBaseUrl = process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL;
 
 function mockFetch(response: Response | Error): ReturnType<typeof vi.fn> {
   const fetchMock = vi.fn(async () => {
@@ -15,6 +16,11 @@ function mockFetch(response: Response | Error): ReturnType<typeof vi.fn> {
 describe("validateModelKey", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    if (originalProbeBaseUrl === undefined) {
+      delete process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL;
+    } else {
+      process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL = originalProbeBaseUrl;
+    }
     vi.restoreAllMocks();
   });
 
@@ -49,6 +55,23 @@ describe("validateModelKey", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({ "x-goog-api-key": "good-key" }),
+      }),
+    );
+  });
+
+  it("uses the probe base URL override while retaining the provider probe path", async () => {
+    process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL = "http://127.0.0.1:9876";
+    const fetchMock = mockFetch(new Response("Unauthorized", { status: 401 }));
+
+    await expect(validateModelKey("openai", "bad-key")).resolves.toEqual({
+      status: "invalid",
+      providerLabel: "OpenAI",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:9876/v1/models",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer bad-key" }),
       }),
     );
   });

--- a/tests/unit/onboarding/validate-model-key.test.ts
+++ b/tests/unit/onboarding/validate-model-key.test.ts
@@ -72,6 +72,9 @@ describe("validateModelKey", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({ Authorization: "Bearer bad-key" }),
+        // A loopback probe stub must not be able to bounce the key-bearing
+        // request to a foreign host via a 3xx.
+        redirect: "error",
       }),
     );
   });

--- a/tests/unit/onboarding/validate-model-key.test.ts
+++ b/tests/unit/onboarding/validate-model-key.test.ts
@@ -76,6 +76,24 @@ describe("validateModelKey", () => {
     );
   });
 
+  it("ignores a non-loopback probe base URL override so keys cannot be exfiltrated", async () => {
+    process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL = "http://attacker.example";
+    const fetchMock = mockFetch(new Response("Unauthorized", { status: 401 }));
+
+    await validateModelKey("openai", "typed-key");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.openai.com/v1/models", expect.anything());
+  });
+
+  it("ignores an unparseable probe base URL override", async () => {
+    process.env.OPENCANDLE_MODEL_KEY_PROBE_BASE_URL = "not a url";
+    const fetchMock = mockFetch(new Response("Unauthorized", { status: 401 }));
+
+    await validateModelKey("openai", "typed-key");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.openai.com/v1/models", expect.anything());
+  });
+
   it("rejects a Google key when the provider flags API_KEY_INVALID on a 400", async () => {
     mockFetch(
       new Response(


### PR DESCRIPTION
Implements #103 (all four work items). Closes #103.

## What changed

**Item 1 — envelope legs.** The 22.19.0 and 26.x legs now run only `npm ci` (whose `prepare` builds `dist/` and the GUI bundle), the packed-install smoke, and a packaged-CLI boot check (`--version` asserted against `package.json`, never hardcoded; `--help` exit 0). Everything else moved behind `if: matrix.node-version == '24.x'`. The job id and matrix values are untouched, so the three required status contexts keep their exact names.

**Item 2 — first-run journey smoke.** `tests/e2e/gui-release-smoke.test.ts` gains four journeys on the existing cold-home harness: invalid OpenAI key rejected inline (`role="alert"`, nothing saved), Google's 400 `API_KEY_INVALID` classification end-to-end, honest cold diagnostics, and key management reachable from the disconnected composer. Probes go to a local Node `http` stub via the new `OPENCANDLE_MODEL_KEY_PROBE_BASE_URL` override in `src/onboarding/validate-model-key.ts` — no third-party API dependency. The override is hardened: only loopback hosts are honored and probe requests use `redirect: "error"`, so the key-bearing headers cannot be redirected off-box (autoreview P1s, fixed with unit coverage).

**Item 3 — packed-install asserts.** After the existing doctor step, the smoke asserts `--version` equals the *packed* `package.json` version, `--help` contains `Usage: opencandle`, and `doctor --json` parses with a `schemaVersion` and `status === "blocked"`. Model-key env vars are blanked in the smoke env so the blocked contract is deterministic on machines with exported keys (autoreview P2).

**Item 4 — nightly drift canary.** `.github/workflows/nightly.yml` (cron 09:00 UTC + manual dispatch, non-gating): live keyless provider checks, then `eval -- cases` and the advisory `router-live` eval (`continue-on-error`, pass rate written to the step summary — the runner has no threshold flag and exits 1 below 100%).

## ⚠️ Owner prerequisite

The nightly eval steps need a **`GEMINI_API_KEY` repository secret**. Until it exists, those steps skip and write a loud warning to the run summary (they do not fail). `ALPHA_VANTAGE_API_KEY` / `FRED_API_KEY` secrets are optional; the provider suite skips them when absent (`tests/e2e/providers.test.ts:151-183`).

## Deviations from the issue spec

1. **Diagnostics journey does not assert the Providers section `Ready` badge.** The `/api/doctor` handler force-probes public HTTP providers (Yahoo, TradingView, Polymarket) live, so that badge depends on third-party availability — contradicting the item-2 done-when ("passes offline apart from Chromium"). The journey instead asserts the deterministic 0.12.0 behavior the badge was standing in for: a never-configured keyed provider (Alpha Vantage) renders as optional skip with a Connect action, warnings stay 0, and the page pill is `Blocked` for model readiness only.
2. **Provider suite coverage note:** `test:e2e:providers` covers Yahoo, CoinGecko, Polymarket, Reddit, and Fear & Greed (plus keyed Alpha Vantage/FRED) — it does not currently reference TradingView or SEC as the issue text assumed. Kept as-is; expanding the suite was out of scope. Reddit uses unauthenticated fetch, so the first nightly may surface runner-IP blocking there — that would be a legitimate canary finding, not a broken workflow.

## Verification

- `npm test` — 248 files, 2606 passed / 1 skipped
- `npx tsc --noEmit`, `npx biome ci .` — clean
- `npm run test:gui:release-smoke` — 6/6 in ~10s, offline apart from Chromium
- Revert spot-check: disabling `handleSaveModelApiKey` validation makes the smoke fail 4/6, so the journeys really gate the 0.12.0 fixes
- `npm run test:packed-install` — passes with keys exported in the shell (blanked in smoke env)
- Repo autoreview (`npm run review:pr`) — final verdict "patch is correct", after fixing its three earlier findings (loopback-only override, redirect refusal, deterministic doctor contract)
- This PR's CI run demonstrates the new leg shapes; the nightly can be exercised via `workflow_dispatch` once the secret is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqbTj2vTu797sgw9PrtUr7