### PR TITLE
Nightly canary: skip runner rate limits and missing CLI tools in provider e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - CI now keeps the full validation gate on Node 24.x while Node 22.19.0 and 26.x run install/build, packed-install, and CLI boot envelope checks.
 - The packed-install smoke now verifies the packed CLI version, help usage, and blocked JSON doctor report in a fresh consumer home.
 
+### Fixed
+
+- The live provider e2e suite (used by the nightly drift canary) now records CI environment limitations — shared-runner HTTP 429 rate limits and missing external CLI tools such as `rdt` — as skips with a labeled summary section instead of failures, so a red nightly means provider drift rather than runner noise.
+
 ## [0.12.0] - 2026-07-10
 
 ### Added

--- a/tests/e2e/providers.test.ts
+++ b/tests/e2e/providers.test.ts
@@ -71,8 +71,14 @@ const CRYPTO_YAHOO = [
 const avKey = process.env.ALPHA_VANTAGE_API_KEY;
 const fredKey = process.env.FRED_API_KEY;
 
-type Result = { tool: string; ticker: string; status: "PASS" | "FAIL"; error?: string };
+type Result = { tool: string; ticker: string; status: "PASS" | "FAIL" | "SKIP"; error?: string };
 const results: Result[] = [];
+
+// Environment limitations, not provider drift: shared CI runner IPs get
+// rate-limited (the provider is reachable, which is what the canary tracks),
+// and external CLI tools such as rdt need a browser session no runner has.
+// Genuine outages (network errors, 5xx, shape changes) still fail.
+const ENVIRONMENT_LIMITATIONS = /HTTP 429|Too Many Requests|rate limited|is not installed/i;
 
 async function test(tool: string, ticker: string, fn: () => Promise<any>) {
   try {
@@ -81,8 +87,14 @@ async function test(tool: string, ticker: string, fn: () => Promise<any>) {
     results.push({ tool, ticker, status: "PASS" });
     process.stdout.write(".");
   } catch (e: any) {
-    results.push({ tool, ticker, status: "FAIL", error: e.message?.slice(0, 80) });
-    process.stdout.write("X");
+    const message = e.message?.slice(0, 80);
+    if (ENVIRONMENT_LIMITATIONS.test(e.message ?? "")) {
+      results.push({ tool, ticker, status: "SKIP", error: message });
+      process.stdout.write("s");
+    } else {
+      results.push({ tool, ticker, status: "FAIL", error: message });
+      process.stdout.write("X");
+    }
   }
 }
 
@@ -244,13 +256,23 @@ console.log("\n\n=== RESULTS ===\n");
 
 const passed = results.filter((r) => r.status === "PASS");
 const failed = results.filter((r) => r.status === "FAIL");
+const skipped = results.filter((r) => r.status === "SKIP");
 
-console.log(`Total: ${results.length} | PASS: ${passed.length} | FAIL: ${failed.length}\n`);
+console.log(
+  `Total: ${results.length} | PASS: ${passed.length} | FAIL: ${failed.length} | SKIP: ${skipped.length}\n`,
+);
 
 if (failed.length > 0) {
   console.log("FAILURES:");
   for (const f of failed) {
     console.log(`  ❌ ${f.tool} [${f.ticker}]: ${f.error}`);
+  }
+}
+
+if (skipped.length > 0) {
+  console.log("SKIPPED (environment limitation, not provider drift):");
+  for (const s of skipped) {
+    console.log(`  ⏭️ ${s.tool} [${s.ticker}]: ${s.error}`);
   }
 }
 
@@ -265,7 +287,9 @@ console.log("\nBy Tool:");
 for (const [tool, toolResults] of byTool) {
   const p = toolResults.filter((r) => r.status === "PASS").length;
   const f = toolResults.filter((r) => r.status === "FAIL").length;
-  const tickers = toolResults.map((r) => (r.status === "PASS" ? "✅" : "❌") + r.ticker).join(" ");
+  const tickers = toolResults
+    .map((r) => (r.status === "PASS" ? "✅" : r.status === "SKIP" ? "⏭️" : "❌") + r.ticker)
+    .join(" ");
   console.log(`  ${p}/${p + f} ${tool}: ${tickers}`);
 }
 


### PR DESCRIPTION
Follow-up to #104. The first `workflow_dispatch` of the nightly drift canary (run 29116762762) failed on two environment limitations rather than provider drift:

- CoinGecko returned HTTP 429 for 8 of 20 crypto calls — shared GitHub runner IPs are throttled harder than the suite's 6.5s pacing assumes. A 429 proves the provider is reachable, which is what the canary tracks.
- All Reddit legs failed with "rdt is not installed" — the Reddit provider shells out to `rdt-cli`, which needs a logged-in browser session no CI runner can have.

The provider e2e harness now classifies these (plus provider-side throttle messages like Alpha Vantage's "rate limited") as `SKIP` with a labeled summary section, keeping the exit code green. Network errors, 5xx responses, empty-result contract failures, and shape changes still fail the run.

Verified with a live local run: CoinGecko 429s record as skips, Reddit passes where `rdt` is installed, and genuine failures (a Polymarket empty-result case) still fail the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqbTj2vTu797sgw9PrtUr7