### PR TITLE
Fix #106: trust explicit Polymarket open flags over stale end dates, bounded e2e retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Polymarket searches no longer drop explicitly open markets when Gamma supplies stale past end dates; authoritative `closed` and `active` flags now take precedence.
+- The live provider e2e harness now retries one non-environment-limited failure after a short delay before recording it as failed.
 - The live provider e2e suite (used by the nightly drift canary) now records CI environment limitations — shared-runner HTTP 429 rate limits and missing external CLI tools such as `rdt` — as skips with a labeled summary section instead of failures, so a red nightly means provider drift rather than runner noise.
 
 ## [0.12.0] - 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 
-- Polymarket searches no longer drop explicitly open markets when Gamma supplies stale past end dates; authoritative `closed` and `active` flags now take precedence.
+- Polymarket searches no longer drop explicitly open markets when Gamma supplies stale past end dates; an explicit `active` flag now takes precedence over the date heuristic, and the stale past close date is omitted from those quotes instead of being shown as if an open market had already closed.
 - The live provider e2e harness now retries one non-environment-limited failure after a short delay before recording it as failed.
 - The live provider e2e suite (used by the nightly drift canary) now records CI environment limitations — shared-runner HTTP 429 rate limits and missing external CLI tools such as `rdt` — as skips with a labeled summary section instead of failures, so a red nightly means provider drift rather than runner noise.
 

--- a/src/providers/polymarket.ts
+++ b/src/providers/polymarket.ts
@@ -136,7 +136,11 @@ function isOpenMarket(market: GammaMarket): boolean {
   const active = booleanValue(market.active);
   if (closed === true) return false;
   if (active === false) return false;
-  if (closed !== undefined || active !== undefined) return true;
+  // An explicit affirmative active flag is Gamma's authoritative openness
+  // signal and beats the endDate heuristic, whose metadata is demonstrably
+  // stale on live markets. A lone `closed: false` only says "not settled",
+  // so it still falls through to the date check.
+  if (active === true) return true;
 
   const endDate = stringValue(market.endDate) ?? stringValue(market.endDateIso);
   if (!endDate) return true;

--- a/src/providers/polymarket.ts
+++ b/src/providers/polymarket.ts
@@ -105,8 +105,15 @@ function marketToQuotes(market: GammaMarket, event?: GammaEvent): PredictionMark
     numberValue(market.liquidityNum) ??
     numberValue(market.liquidity) ??
     numberValue(event?.liquidity);
-  const closeDate =
+  const rawCloseDate =
     stringValue(market.endDate) ?? normalizeDateOnly(market.endDateIso ?? event?.endDate);
+  // A past close date on a market Gamma explicitly marks active is the same
+  // stale metadata isOpenMarket ignores; presenting it as a close date would
+  // tell users an open market already closed, so it is omitted instead.
+  const closeDate =
+    rawCloseDate !== undefined && booleanValue(market.active) === true && isPastDate(rawCloseDate)
+      ? undefined
+      : rawCloseDate;
   const url = marketUrl(market, event);
   const asOf = stringValue(market.updatedAt) ?? stringValue(event?.updatedAt);
 
@@ -144,8 +151,12 @@ function isOpenMarket(market: GammaMarket): boolean {
 
   const endDate = stringValue(market.endDate) ?? stringValue(market.endDateIso);
   if (!endDate) return true;
-  const parsed = new Date(endDate);
-  return Number.isNaN(parsed.getTime()) || parsed.getTime() > Date.now();
+  return !isPastDate(endDate);
+}
+
+function isPastDate(value: string): boolean {
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.getTime() <= Date.now();
 }
 
 function normalizeLimit(limit: number): number {

--- a/src/providers/polymarket.ts
+++ b/src/providers/polymarket.ts
@@ -132,8 +132,12 @@ function marketToQuotes(market: GammaMarket, event?: GammaEvent): PredictionMark
 }
 
 function isOpenMarket(market: GammaMarket): boolean {
-  if (booleanValue(market.closed) === true) return false;
-  if (booleanValue(market.active) === false) return false;
+  const closed = booleanValue(market.closed);
+  const active = booleanValue(market.active);
+  if (closed === true) return false;
+  if (active === false) return false;
+  if (closed !== undefined || active !== undefined) return true;
+
   const endDate = stringValue(market.endDate) ?? stringValue(market.endDateIso);
   if (!endDate) return true;
   const parsed = new Date(endDate);

--- a/tests/e2e/providers.test.ts
+++ b/tests/e2e/providers.test.ts
@@ -80,19 +80,35 @@ const results: Result[] = [];
 // Genuine outages (network errors, 5xx, shape changes) still fail.
 const ENVIRONMENT_LIMITATIONS = /HTTP 429|Too Many Requests|rate limited|is not installed/i;
 
-async function test(tool: string, ticker: string, fn: () => Promise<any>) {
+async function test(tool: string, ticker: string, fn: () => Promise<unknown>) {
   try {
     const data = await fn();
     if (data == null) throw new Error("null response");
     results.push({ tool, ticker, status: "PASS" });
     process.stdout.write(".");
-  } catch (e: any) {
-    const message = e.message?.slice(0, 80);
-    if (ENVIRONMENT_LIMITATIONS.test(e.message ?? "")) {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (ENVIRONMENT_LIMITATIONS.test(message)) {
       results.push({ tool, ticker, status: "SKIP", error: message });
       process.stdout.write("s");
-    } else {
-      results.push({ tool, ticker, status: "FAIL", error: message });
+      return;
+    }
+
+    process.stdout.write("r");
+    await sleep(2000);
+    try {
+      const data = await fn();
+      if (data == null) throw new Error("null response");
+      results.push({ tool, ticker, status: "PASS" });
+      process.stdout.write(".");
+    } catch (retryError) {
+      const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+      if (ENVIRONMENT_LIMITATIONS.test(retryMessage)) {
+        results.push({ tool, ticker, status: "SKIP", error: retryMessage.slice(0, 80) });
+        process.stdout.write("s");
+        return;
+      }
+      results.push({ tool, ticker, status: "FAIL", error: retryMessage.slice(0, 80) });
       process.stdout.write("X");
     }
   }

--- a/tests/unit/providers/polymarket.test.ts
+++ b/tests/unit/providers/polymarket.test.ts
@@ -97,6 +97,15 @@ describe("Polymarket provider", () => {
               endDate: "2020-01-01T00:00:00Z",
             },
             {
+              id: "not-settled-but-unconfirmed-stale-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-not-settled-stale",
+              outcomes: '["Yes"]',
+              outcomePrices: '["0.5"]',
+              closed: false,
+              endDate: "2020-01-01T00:00:00Z",
+            },
+            {
               id: "flagless-future-date",
               question: "Will the Fed cut rates?",
               slug: "fed-cut-flagless-future",
@@ -127,6 +136,7 @@ describe("Polymarket provider", () => {
     const marketIds = quotes.map((quote) => quote.marketId);
     expect(marketIds).not.toContain("explicitly-closed");
     expect(marketIds).not.toContain("flagless-stale-date");
+    expect(marketIds).not.toContain("not-settled-but-unconfirmed-stale-date");
   });
 
   it("preserves outcome-price positions when skipping malformed Polymarket prices", async () => {

--- a/tests/unit/providers/polymarket.test.ts
+++ b/tests/unit/providers/polymarket.test.ts
@@ -63,6 +63,72 @@ describe("Polymarket provider", () => {
     );
   });
 
+  it("keeps explicitly open markets despite stale end dates while using end dates for flagless markets", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          markets: [
+            {
+              id: "explicitly-open-stale-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-stale-date",
+              outcomes: '["Yes","No"]',
+              outcomePrices: '["0.0485","0.9515"]',
+              closed: false,
+              active: true,
+              endDate: "2020-01-01T00:00:00Z",
+            },
+            {
+              id: "explicitly-closed",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-closed",
+              outcomes: '["Yes"]',
+              outcomePrices: '["1"]',
+              closed: true,
+              active: true,
+            },
+            {
+              id: "flagless-stale-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-flagless-stale",
+              outcomes: '["Yes"]',
+              outcomePrices: '["0.5"]',
+              endDate: "2020-01-01T00:00:00Z",
+            },
+            {
+              id: "flagless-future-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-flagless-future",
+              outcomes: '["Yes"]',
+              outcomePrices: '["0.5"]',
+              endDate: "2030-01-01T00:00:00Z",
+            },
+            {
+              id: "flagless-no-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-flagless-no-date",
+              outcomes: '["Yes"]',
+              outcomePrices: '["0.5"]',
+            },
+          ],
+        }),
+    });
+
+    const quotes = await searchPredictionMarkets("fed rate cut market status", 8);
+
+    expect(quotes.map((quote) => quote.marketId)).toEqual(
+      expect.arrayContaining([
+        "explicitly-open-stale-date",
+        "flagless-future-date",
+        "flagless-no-date",
+      ]),
+    );
+    const marketIds = quotes.map((quote) => quote.marketId);
+    expect(marketIds).not.toContain("explicitly-closed");
+    expect(marketIds).not.toContain("flagless-stale-date");
+  });
+
   it("preserves outcome-price positions when skipping malformed Polymarket prices", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/tests/unit/providers/polymarket.test.ts
+++ b/tests/unit/providers/polymarket.test.ts
@@ -80,6 +80,16 @@ describe("Polymarket provider", () => {
               endDate: "2020-01-01T00:00:00Z",
             },
             {
+              id: "explicitly-open-future-date",
+              question: "Will the Fed cut rates?",
+              slug: "fed-cut-future-date",
+              outcomes: '["Yes"]',
+              outcomePrices: '["0.5"]',
+              closed: false,
+              active: true,
+              endDate: "2030-01-01T00:00:00Z",
+            },
+            {
               id: "explicitly-closed",
               question: "Will the Fed cut rates?",
               slug: "fed-cut-closed",
@@ -129,6 +139,7 @@ describe("Polymarket provider", () => {
     expect(quotes.map((quote) => quote.marketId)).toEqual(
       expect.arrayContaining([
         "explicitly-open-stale-date",
+        "explicitly-open-future-date",
         "flagless-future-date",
         "flagless-no-date",
       ]),
@@ -137,6 +148,15 @@ describe("Polymarket provider", () => {
     expect(marketIds).not.toContain("explicitly-closed");
     expect(marketIds).not.toContain("flagless-stale-date");
     expect(marketIds).not.toContain("not-settled-but-unconfirmed-stale-date");
+
+    // A past close date on an explicitly active market is the same stale
+    // metadata the filter ignores; it must not surface as a "Close:" line.
+    const staleDateQuote = quotes.find((quote) => quote.marketId === "explicitly-open-stale-date");
+    expect(staleDateQuote?.closeDate).toBeUndefined();
+    const futureDateQuote = quotes.find(
+      (quote) => quote.marketId === "explicitly-open-future-date",
+    );
+    expect(futureDateQuote?.closeDate).toBe("2030-01-01T00:00:00Z");
   });
 
   it("preserves outcome-price positions when skipping malformed Polymarket prices", async () => {


### PR DESCRIPTION
Fixes #106 (both findings from the first nightly canary dispatches).

## Finding 1 — Polymarket search returned no markets for "fed rate cut"

Verified live against Gamma: `public-search` returns the current Fed-rate-cut event whose **open** markets (`closed: false`, `active: true`, live prices) all carry a stale `endDate` of 2026-06-17 — in the past. `isOpenMarket` passed the flag checks but then rejected on the date, dropping every open market.

Fix: an explicit `active: true` flag now bypasses the end-date heuristic (Gamma's authoritative openness signal; the date metadata is demonstrably stale on live markets). A lone `closed: false` still falls through to the date check — it only means "not settled", so a paused market with a past end date is still excluded (hardened per autoreview, with regression coverage for the nullable-`active` case).

Live spot-check after the fix: `searchPredictionMarkets("fed rate cut", 8)` returns 8 quotes (July/September/October/December 2026 FOMC markets with plausible probabilities).

## Finding 2 — sporadic Yahoo HTTP 400s redden the nightly

The provider e2e harness now retries a non-environment-limited failure once after ~2s before recording FAIL (an `r` marker shows retries in run output). Environment limitations skip immediately — no retry — so rate-limited providers don't get hammered, and a limitation surfacing on the retry still classifies as SKIP.

## Verification

- Polymarket unit suite: 10 passed, including the new stale-date regression case (shown red before the fix)
- Full suite 2609 passed / 1 skipped; `tsc --noEmit`, `biome ci` clean; `test:agent-tools` 15 passed
- Repo autoreview: final verdict "patch is correct" after addressing its P1 (the `closed: false`-alone hardening above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqbTj2vTu797sgw9PrtUr7