### PR TITLE
Fix Fear and Greed routing canary regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fear & Greed index requests now retain the macro tool bundle even when the LLM router omits the general-finance workflow label, so the agent can call the live index instead of answering without it.
 - Polymarket searches no longer drop explicitly open markets when Gamma supplies stale past end dates; an explicit `active` flag now takes precedence over the date heuristic, and the stale past close date is omitted from those quotes instead of being shown as if an open market had already closed.
 - The live provider e2e harness now retries one non-environment-limited failure after a short delay before recording it as failed.
 - The live provider e2e suite (used by the nightly drift canary) now records CI environment limitations — shared-runner HTTP 429 rate limits and missing external CLI tools such as `rdt` — as skips with a labeled summary section instead of failures, so a red nightly means provider drift rather than runner noise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 
-- Fear & Greed index requests now retain the macro tool bundle even when the LLM router omits the general-finance workflow label, so the agent can call the live index instead of answering without it.
+- Fear & Greed index requests now retain the macro tool bundle even when the LLM router assigns an incorrect workflow label, so the agent can call the live index instead of answering without it.
 - Polymarket searches no longer drop explicitly open markets when Gamma supplies stale past end dates; an explicit `active` flag now takes precedence over the date heuristic, and the stale past close date is omitted from those quotes instead of being shown as if an open market had already closed.
 - The live provider e2e harness now retries one non-environment-limited failure after a short delay before recording it as failed.
 - The live provider e2e suite (used by the nightly drift canary) now records CI environment limitations — shared-runner HTTP 429 rate limits and missing external CLI tools such as `rdt` — as skips with a labeled summary section instead of failures, so a red nightly means provider drift rather than runner noise.

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -789,7 +789,7 @@ export function postProcessRouterOutput(
 }
 
 function isExplicitMacroDataRequest(text: string): boolean {
-  return /\b(?:get_economic_data|fred|cpi|inflation|fed\s+funds?|unemployment|gdp|macro)\b/i.test(
+  return /\b(?:get_economic_data|fred|cpi|inflation|fed\s+funds?|unemployment|gdp|macro|fear\s*(?:&|and)\s*greed)\b/i.test(
     text,
   );
 }

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -764,6 +764,13 @@ export function postProcessRouterOutput(
   const selectedToolBundles = isConceptualEducationRequest(text, next)
     ? []
     : selectToolBundles(next);
+  if (isExplicitMacroDataRequest(text) && !selectedToolBundles.includes("macro")) {
+    selectedToolBundles.push("macro");
+    diagnostics.push({
+      code: "macro_tool_bundle_recovered",
+      message: "explicit macro data request retained the macro tool bundle",
+    });
+  }
   if (selectedToolBundles.length === 0 && isConceptualEducationRequest(text, next)) {
     diagnostics.push({
       code: "conceptual_education_no_tools",

--- a/tests/unit/routing/router.test.ts
+++ b/tests/unit/routing/router.test.ts
@@ -1401,6 +1401,32 @@ describe("route()", () => {
     expect(activeToolsForBundles(result.tool_bundles)).toContain("get_fear_greed");
   });
 
+  it("retains the Fear and Greed tool when the router assigns a non-macro workflow", async () => {
+    const result = await route(
+      {
+        ...BASE_INPUT,
+        text: "Show me the current Fear and Greed index",
+      },
+      fixedClient(
+        JSON.stringify({
+          routeKind: "agent_task",
+          route: "fallback",
+          workflow: "watchlist_or_tracking",
+          entities: { symbols: [] },
+          slots: {},
+          preference_updates: [],
+          missing_required: [],
+          tool_bundles: ["core_market"],
+          diagnostics: [],
+          reasoning: "misclassified current index request",
+        }),
+      ),
+    );
+
+    expect(result.tool_bundles).toContain("macro");
+    expect(activeToolsForBundles(result.tool_bundles)).toContain("get_fear_greed");
+  });
+
   it("routes missing options symbol to clarification with ask_user bundle", async () => {
     const result = await route(
       { ...BASE_INPUT, text: "build me an options setup" },

--- a/tests/unit/routing/router.test.ts
+++ b/tests/unit/routing/router.test.ts
@@ -1375,6 +1375,32 @@ describe("route()", () => {
     );
   });
 
+  it("recovers the macro tool bundle for a current Fear and Greed request when the router omits a workflow", async () => {
+    const result = await route(
+      {
+        ...BASE_INPUT,
+        text: "Show me the current Fear and Greed index",
+      },
+      fixedClient(
+        JSON.stringify({
+          routeKind: "agent_task",
+          route: "fallback",
+          entities: { symbols: [] },
+          slots: {},
+          preference_updates: [],
+          missing_required: [],
+          tool_bundles: ["core_market"],
+          diagnostics: [],
+          reasoning: "simple market sentiment request",
+        }),
+      ),
+    );
+
+    expect(result.workflow).toBe("general_finance_qa");
+    expect(result.tool_bundles).toContain("macro");
+    expect(activeToolsForBundles(result.tool_bundles)).toContain("get_fear_greed");
+  });
+
   it("routes missing options symbol to clarification with ask_user bundle", async () => {
     const result = await route(
       { ...BASE_INPUT, text: "build me an options setup" },


### PR DESCRIPTION
## Summary
- restore the macro capability when a current Fear and Greed request has no LLM workflow label
- add a regression test for the tool-bundle recovery path
- record the fix in the changelog

## Validation
- `npm test` (2610 passed, 1 skipped)
- `npm run build`
- `npm run lint`