### PR TITLE
Stabilize nightly canary live-agent evals

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,12 +38,26 @@ jobs:
           {
             echo "## :warning: GEMINI_API_KEY is not configured"
             echo
-            echo "The deterministic eval and advisory live-router eval were skipped. Add the repository secret to enable the full nightly drift canary."
+            echo "The advisory live-agent and live-router evals were skipped. Add the repository secret to enable the full nightly drift canary."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run deterministic eval cases
+      - name: Run advisory live agent eval cases
         if: env.GEMINI_API_KEY != ''
-        run: npm run eval -- cases
+        continue-on-error: true
+        shell: bash
+        run: |
+          status=0
+          npm run eval -- cases 2>&1 | tee /tmp/live-agent-eval.log || status=$?
+          {
+            echo "## Advisory live-agent eval"
+            echo
+            if [ "$status" -eq 0 ]; then
+              echo "All live-agent eval cases passed."
+            else
+              echo "Live-model drift was detected; the blocking provider and deterministic test gates still passed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
 
       - name: Run advisory live router eval
         if: env.GEMINI_API_KEY != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- The nightly drift canary now reports Gemini-backed agent evals as advisory, keeping provider and deterministic test gates blocking while surfacing live-model wording drift and slow workflow traces in the run summary.
 - CI now keeps the full validation gate on Node 24.x while Node 22.19.0 and 26.x run install/build, packed-install, and CLI boot envelope checks.
 - The packed-install smoke now verifies the packed CLI version, help usage, and blocked JSON doctor report in a fresh consumer home.
 


### PR DESCRIPTION
## Summary
- classify Gemini-backed agent evals as advisory live-model drift checks
- keep provider checks and regular CI as blocking gates
- add an explicit nightly summary for advisory drift

## Validation
- YAML parsed successfully
- `npm test` (2611 passed, 1 skipped)
- `npm run lint`