### PR TITLE
chore(deps): refresh dependencies and migrate Pi runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: npm

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/gui/server/http-routes.ts
+++ b/gui/server/http-routes.ts
@@ -1,7 +1,7 @@
 import { createReadStream, existsSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { extname, join, resolve } from "node:path";
-import { type AgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
+import { type AgentSession, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
 import { buildDoctorReport } from "../../src/doctor/report.js";
 import { MarketStateService } from "../../src/market-state/service.js";
 import {
@@ -173,7 +173,7 @@ export function createHttpRequestHandler(options: GuiHttpRouteOptions) {
 
     if (url.pathname === "/api/model-setup/refresh" && req.method === "POST") {
       if (!allowTrustedGuiRequest(req, res, "Model setup API", options)) return;
-      options.getSession().modelRegistry.refresh();
+      void options.getSession().modelRuntime.refresh();
       options.wsHub.broadcastModelSetup();
       writeJson(res, await options.wsHub.buildBootstrapPayload());
       return;
@@ -249,7 +249,7 @@ export function createHttpRequestHandler(options: GuiHttpRouteOptions) {
             reachable: true,
             healthEndpoint: `http://${options.host}:${options.port}/health`,
           },
-          modelSetup: buildModelSetupState(session.modelRegistry, session.model),
+          modelSetup: buildModelSetupState(new ModelRegistry(session.modelRuntime), session.model),
         }),
       );
       return;
@@ -766,7 +766,10 @@ async function streamAcceptedSseChatRun({
 
   try {
     recordPendingSessionAction(runSessionManager, actionId);
-    const modelSetup = buildModelSetupState(runSession.modelRegistry, runSession.model);
+    const modelSetup = buildModelSetupState(
+      new ModelRegistry(runSession.modelRuntime),
+      runSession.model,
+    );
     if (!prompt.startsWith("/") && modelSetup.requirement !== "ready") {
       runSessionManager.appendMessage({ role: "user", content: prompt, timestamp: Date.now() });
       recordAcceptedAction();

--- a/gui/server/model-setup.ts
+++ b/gui/server/model-setup.ts
@@ -1,4 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { ModelRegistry, type ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { persistProviderCredential } from "../../src/onboarding/connect.js";
 import {
   getCredentialSource,
@@ -35,17 +36,8 @@ export interface ModelSetupRegistry {
   hasConfiguredAuth(model: Model<Api>): boolean;
 }
 
-interface ModelSetupAuthStorage {
-  set(provider: string, credential: { type: "api_key"; key: string }): void;
-}
-
-interface MutableModelSetupRegistry extends ModelSetupRegistry {
-  authStorage: ModelSetupAuthStorage;
-  find(provider: string, modelId: string): Model<Api> | undefined;
-}
-
 interface ModelSetupSession {
-  modelRegistry: MutableModelSetupRegistry;
+  modelRuntime: ModelRuntime;
   model?: Model<Api>;
   setModel(model: Model<Api>): Promise<void>;
   settingsManager: {
@@ -167,7 +159,7 @@ export function createModelSetupController({
 
   function buildCurrentModelSetupState(): ModelSetupState {
     const session = getSession();
-    return buildModelSetupState(session.modelRegistry, session.model);
+    return buildModelSetupState(new ModelRegistry(session.modelRuntime), session.model);
   }
 
   async function handleSaveModelApiKey(providerId: string, apiKey: string): Promise<void> {
@@ -187,10 +179,13 @@ export function createModelSetupController({
     }
 
     const session = getSession();
-    session.modelRegistry.authStorage.set(provider.id, { type: "api_key", key: trimmed });
-    session.modelRegistry.refresh();
+    await session.modelRuntime.login(provider.id, "api_key", {
+      prompt: async () => trimmed,
+      notify: () => {},
+    });
+    const modelRegistry = new ModelRegistry(session.modelRuntime);
 
-    const model = findPreferredModel(session.modelRegistry, provider);
+    const model = findPreferredModel(modelRegistry, provider);
     if (!model) {
       throw new Error(
         `Saved the ${provider.label} key, but no ${provider.label} models are available yet.`,
@@ -256,8 +251,8 @@ export function createModelSetupController({
   async function handleSelectModel(provider: string, modelId: string): Promise<void> {
     ensureWriter();
     const session = getSession();
-    session.modelRegistry.refresh();
-    const model = session.modelRegistry.find(provider, modelId);
+    await session.modelRuntime.refresh();
+    const model = session.modelRuntime.getModel(provider, modelId);
     if (!model) throw new Error(`Unknown model: ${provider}/${modelId}`);
     await session.setModel(model);
     await session.settingsManager.flush();

--- a/gui/server/server.ts
+++ b/gui/server/server.ts
@@ -4,11 +4,10 @@ import { createServer } from "node:http";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  AuthStorage,
   createAgentSessionRuntime,
   createAgentSessionServices,
   getAgentDir,
-  ModelRegistry,
+  ModelRuntime,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import { createOpenCandleSession } from "../../src/index.js";
@@ -60,8 +59,10 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const webDist = resolveGuiWebDist(__dirname);
 
 const agentDir = getAgentDir();
-const authStorage = AuthStorage.create();
-const modelRegistry = ModelRegistry.create(authStorage);
+const modelRuntime = await ModelRuntime.create({
+  authPath: resolve(agentDir, "auth.json"),
+  modelsPath: resolve(agentDir, "models.json"),
+});
 const settingsManager = SettingsManager.create(cwd, agentDir);
 const initialSessionManager = createInitialGuiSessionManager(cwd);
 let sessionManager = initialSessionManager;
@@ -84,15 +85,13 @@ const runtime = await createAgentSessionRuntime(
     const services = await createAgentSessionServices({
       cwd: opts.cwd,
       agentDir: opts.agentDir,
-      authStorage,
       settingsManager,
-      modelRegistry,
+      modelRuntime,
     });
     const result = await createOpenCandleSession({
       cwd: opts.cwd,
       agentDir: opts.agentDir,
-      authStorage,
-      modelRegistry,
+      modelRuntime,
       settingsManager,
       sessionManager: opts.sessionManager,
       askUserHandler: askUserBridge.ask,

--- a/gui/server/ws-hub.ts
+++ b/gui/server/ws-hub.ts
@@ -138,7 +138,7 @@ export function createWsHub({
           client.send({ type: "catalog", catalog: buildCatalog() });
           break;
         case "model.setup.refresh":
-          getSession().modelRegistry.refresh();
+          void getSession().modelRuntime.refresh();
           broadcastModelSetup();
           break;
         case "model.setup.save_api_key":

--- a/gui/web/package.json
+++ b/gui/web/package.json
@@ -22,7 +22,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lightweight-charts": "^5.0.0",
-    "lucide-react": "^1.24.0",
+    "lucide-react": "^1.25.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "recharts": "^3.9.2",

--- a/gui/web/package.json
+++ b/gui/web/package.json
@@ -9,19 +9,19 @@
   "dependencies": {
     "@opencandle/ui": "file:../../packages/ui",
     "@radix-ui/react-alert-dialog": "^1.1.19",
-    "@radix-ui/react-dialog": "^1.1.18",
+    "@radix-ui/react-dialog": "^1.1.19",
     "@radix-ui/react-dropdown-menu": "^2.1.20",
     "@radix-ui/react-scroll-area": "^1.2.14",
     "@radix-ui/react-separator": "^1.1.11",
     "@radix-ui/react-tabs": "^1.1.17",
     "@radix-ui/react-toast": "^1.2.19",
     "@radix-ui/react-tooltip": "^1.2.12",
-    "@radix-ui/react-visually-hidden": "^1.2.6",
+    "@radix-ui/react-visually-hidden": "^1.2.7",
     "@tanstack/react-router": "^1.170.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "lightweight-charts": "^5.0.0",
+    "lightweight-charts": "^5.2.0",
     "lucide-react": "^1.25.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -33,8 +33,8 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
     "autoprefixer": "^10.5.4",
-    "postcss": "^8.5.16",
-    "tailwindcss": "^4.3.1",
+    "postcss": "^8.5.20",
+    "tailwindcss": "^4.3.3",
     "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/gui/web/package.json
+++ b/gui/web/package.json
@@ -30,9 +30,9 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.3.2",
+    "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
-    "autoprefixer": "^10.5.2",
+    "autoprefixer": "^10.5.4",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.1",
     "tailwindcss-animate": "^1.0.7"

--- a/gui/web/package.json
+++ b/gui/web/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-toast": "^1.2.19",
     "@radix-ui/react-tooltip": "^1.2.12",
     "@radix-ui/react-visually-hidden": "^1.2.6",
-    "@tanstack/react-router": "^1.170.17",
+    "@tanstack/react-router": "^1.170.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,14 @@
         "opencandle": "dist/cli.js"
       },
       "devDependencies": {
-        "@agentclientprotocol/claude-agent-acp": "^0.58.1",
+        "@agentclientprotocol/claude-agent-acp": "^0.59.0",
         "@agentclientprotocol/codex-acp": "^1.0.1",
         "@biomejs/biome": "^2.5.1",
         "@sinclair/typebox": "^0.34.49",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.0.1",
         "acpx": "^0.12.0",
-        "jsdom": "^27.0.0",
+        "jsdom": "^29.1.1",
         "playwright-core": "^1.61.1",
         "tsx": "^4.22.4",
         "typescript": "^7.0.2",
@@ -76,30 +76,23 @@
         "vaul": "^1.1.2"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.3.2",
+        "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/typography": "^0.5.20",
-        "autoprefixer": "^10.5.2",
+        "autoprefixer": "^10.5.4",
         "postcss": "^8.5.16",
         "tailwindcss": "^4.3.1",
         "tailwindcss-animate": "^1.0.7"
       }
     },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@agentclientprotocol/claude-agent-acp": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.58.1.tgz",
-      "integrity": "sha512-F1/W6EJdoYbrEUluRUknx0Nn0MAKDOkn2C/9YcP/joVkmdFUGTAxlGDpwdYu239TOkpc8Qm4+ffGsQjPZdryTg==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.59.0.tgz",
+      "integrity": "sha512-GejLH5qxsI5IoSDfhyOVDEsRNxqi6y0Rcj5FstVeOwMACSht/bUXII0HILbzOQNoA5qlyZle3FRvf+CAjD7Rpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",
-        "@anthropic-ai/claude-agent-sdk": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk": "0.3.207",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -110,14 +103,14 @@
       }
     },
     "node_modules/@agentclientprotocol/codex-acp": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/codex-acp/-/codex-acp-1.1.2.tgz",
-      "integrity": "sha512-qE/R1WdqJJ9OFHsHGvbmVmS2j9iCMZzpWT3g2XIViXrGHu1fLOALLINBIlW+WzKDllCh131aB6cqcIWSt0otbw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/codex-acp/-/codex-acp-1.1.4.tgz",
+      "integrity": "sha512-DzusIpGwlQwMWuHgJhU8FWMsyQvzjenB93IEzQATkdbNulo5Rd9GKOz8+B+/C9iWWxmyXgtgmjzaL+iRFyDryQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.2.1",
-        "@openai/codex": "^0.144.0",
+        "@openai/codex": "^0.144.4",
         "diff": "^9.0.0",
         "open": "^11.0.0",
         "vscode-jsonrpc": "^9.0.1",
@@ -151,23 +144,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.205.tgz",
-      "integrity": "sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
+      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.205"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -176,9 +169,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.205.tgz",
-      "integrity": "sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
+      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
       "cpu": [
         "arm64"
       ],
@@ -190,9 +183,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.205.tgz",
-      "integrity": "sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
+      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
       "cpu": [
         "x64"
       ],
@@ -204,13 +197,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.205.tgz",
-      "integrity": "sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
+      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -218,13 +214,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.205.tgz",
-      "integrity": "sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
+      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -232,13 +231,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.205.tgz",
-      "integrity": "sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
+      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -246,13 +248,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.205.tgz",
-      "integrity": "sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
+      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -260,9 +265,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.205.tgz",
-      "integrity": "sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
+      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
       "cpu": [
         "arm64"
       ],
@@ -274,9 +279,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.205.tgz",
-      "integrity": "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
+      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
       "cpu": [
         "x64"
       ],
@@ -288,9 +293,9 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.111.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
-      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
+      "version": "0.112.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.112.3.tgz",
+      "integrity": "sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -311,31 +316,47 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -787,9 +808,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
+      "integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -803,20 +824,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.4",
+        "@biomejs/cli-darwin-x64": "2.5.4",
+        "@biomejs/cli-linux-arm64": "2.5.4",
+        "@biomejs/cli-linux-arm64-musl": "2.5.4",
+        "@biomejs/cli-linux-x64": "2.5.4",
+        "@biomejs/cli-linux-x64-musl": "2.5.4",
+        "@biomejs/cli-win32-arm64": "2.5.4",
+        "@biomejs/cli-win32-x64": "2.5.4"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
+      "integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
       "cpu": [
         "arm64"
       ],
@@ -831,9 +852,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
+      "integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
       "cpu": [
         "x64"
       ],
@@ -848,13 +869,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
+      "integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -865,13 +889,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
+      "integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -882,13 +909,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
+      "integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -899,13 +929,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
+      "integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -916,9 +949,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
+      "integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
       "cpu": [
         "arm64"
       ],
@@ -933,9 +966,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
+      "integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
       "cpu": [
         "x64"
       ],
@@ -947,6 +980,19 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@clack/core": {
@@ -3720,9 +3766,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.144.6",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6.tgz",
+      "integrity": "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3732,19 +3778,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.144.6-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
+      "integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
       "cpu": [
         "arm64"
       ],
@@ -3760,9 +3806,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.144.6-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-x64.tgz",
+      "integrity": "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==",
       "cpu": [
         "x64"
       ],
@@ -3778,9 +3824,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.144.6-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+      "integrity": "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
       "cpu": [
         "arm64"
       ],
@@ -3796,9 +3842,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.144.6-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+      "integrity": "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
       "cpu": [
         "x64"
       ],
@@ -3814,9 +3860,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.144.6-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-arm64.tgz",
+      "integrity": "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==",
       "cpu": [
         "arm64"
       ],
@@ -3832,9 +3878,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.144.6-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+      "integrity": "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
       "cpu": [
         "x64"
       ],
@@ -3883,9 +3929,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -4750,9 +4796,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -4766,9 +4812,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -4782,9 +4828,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -4798,9 +4844,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -4814,9 +4860,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -4830,11 +4876,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4846,11 +4895,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4862,11 +4914,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4878,11 +4933,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4894,11 +4952,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4910,11 +4971,14 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4926,9 +4990,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -4942,9 +5006,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -4960,9 +5024,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -4976,9 +5040,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -4998,9 +5062,9 @@
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.51.tgz",
-      "integrity": "sha512-Nu4sNPT4G3QgAvxmdUCR/NBmsi23F2tEIcbMOZJVHS+qEgk+rmXxQikEeoKFyaX+UEggAoTvHUvIlj8MfYPzXQ==",
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5144,49 +5208,49 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -5201,9 +5265,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -5218,9 +5282,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -5235,9 +5299,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -5252,9 +5316,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -5269,13 +5333,16 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5286,13 +5353,16 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5303,13 +5373,16 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5320,13 +5393,16 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5337,9 +5413,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -5366,10 +5442,76 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -5384,9 +5526,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -5401,17 +5543,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "postcss": "^8.5.15",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -6269,9 +6411,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -6289,8 +6431,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.4",
-        "caniuse-lite": "^1.0.30001799",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6449,9 +6591,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6558,9 +6700,9 @@
       "license": "MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -6578,10 +6720,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -6676,9 +6818,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -6920,22 +7062,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -7067,27 +7193,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^15.1.0"
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -7299,9 +7415,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7324,9 +7440,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8484,35 +8600,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
-      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.28",
-        "@asamuzakjp/dom-selector": "^6.7.6",
-        "@exodus/bytes": "^1.6.0",
-        "cssstyle": "^5.3.4",
-        "data-urls": "^6.0.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.0",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.1.0",
-        "ws": "^8.18.3",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -9820,9 +9937,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -9931,9 +10048,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10155,9 +10272,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -10174,7 +10291,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10711,12 +10828,12 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -10726,21 +10843,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -11236,9 +11353,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11500,9 +11617,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -11600,6 +11717,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11885,15 +12012,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -12094,27 +12221,28 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.0"
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -12315,9 +12443,9 @@
         "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.3.2",
+        "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/typography": "^0.5.20",
-        "autoprefixer": "^10.5.2",
+        "autoprefixer": "^10.5.4",
         "postcss": "^8.5.16",
         "tailwindcss": "^4.3.1",
         "tailwindcss-animate": "^1.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@radix-ui/react-toast": "^1.2.19",
         "@radix-ui/react-tooltip": "^1.2.12",
         "@radix-ui/react-visually-hidden": "^1.2.6",
-        "@tanstack/react-router": "^1.170.17",
+        "@tanstack/react-router": "^1.170.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5441,14 +5441,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.170.17",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.17.tgz",
-      "integrity": "sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==",
+      "version": "1.170.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.18.tgz",
+      "integrity": "sha512-wpbGYZEp/fmz1q4bn7BD8VZ+/VZ7GBqSJv5V969pU+chP8y7dquWDmKTFMohvUegb9lg12m1uPVvD6kB2wORvQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
-        "@tanstack/router-core": "1.171.14",
+        "@tanstack/router-core": "1.171.15",
         "isbot": "^5.1.22"
       },
       "engines": {
@@ -5482,9 +5482,9 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.171.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.14.tgz",
-      "integrity": "sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==",
+      "version": "1.171.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.15.tgz",
+      "integrity": "sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.0",
@@ -10878,18 +10878,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
-      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.5.tgz",
+      "integrity": "sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
-      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.5.tgz",
+      "integrity": "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==",
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "website"
       ],
       "dependencies": {
-        "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.11",
-        "@earendil-works/pi-ai": ">=0.80.2 <0.80.11",
-        "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.11",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
         "better-sqlite3": "^12.11.1",
         "duck-duck-scrape": "^2.2.7",
         "yahoo-finance2": "^4.0.0"
@@ -27,18 +27,18 @@
       },
       "devDependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.59.0",
-        "@agentclientprotocol/codex-acp": "^1.0.1",
-        "@biomejs/biome": "^2.5.1",
-        "@sinclair/typebox": "^0.34.49",
+        "@agentclientprotocol/codex-acp": "^1.1.4",
+        "@biomejs/biome": "^2.5.4",
+        "@sinclair/typebox": "^0.34.52",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^26.0.1",
+        "@types/node": "^26.1.1",
         "acpx": "^0.12.0",
         "jsdom": "^29.1.1",
         "playwright-core": "^1.61.1",
-        "tsx": "^4.22.4",
+        "tsx": "^4.23.1",
         "typescript": "^7.0.2",
-        "vite": "^8.1.0",
-        "vitest": "^4.1.9"
+        "vite": "^8.1.5",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": "^22.19.0 || >=24.0.0 <27"
@@ -55,19 +55,19 @@
       "dependencies": {
         "@opencandle/ui": "file:../../packages/ui",
         "@radix-ui/react-alert-dialog": "^1.1.19",
-        "@radix-ui/react-dialog": "^1.1.18",
+        "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-dropdown-menu": "^2.1.20",
         "@radix-ui/react-scroll-area": "^1.2.14",
         "@radix-ui/react-separator": "^1.1.11",
         "@radix-ui/react-tabs": "^1.1.17",
         "@radix-ui/react-toast": "^1.2.19",
         "@radix-ui/react-tooltip": "^1.2.12",
-        "@radix-ui/react-visually-hidden": "^1.2.6",
+        "@radix-ui/react-visually-hidden": "^1.2.7",
         "@tanstack/react-router": "^1.170.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "lightweight-charts": "^5.0.0",
+        "lightweight-charts": "^5.2.0",
         "lucide-react": "^1.25.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -79,8 +79,8 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/typography": "^0.5.20",
         "autoprefixer": "^10.5.4",
-        "postcss": "^8.5.16",
-        "tailwindcss": "^4.3.1",
+        "postcss": "^8.5.20",
+        "tailwindcss": "^4.3.3",
         "tailwindcss-animate": "^1.0.7"
       }
     },
@@ -204,9 +204,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -221,9 +218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -238,9 +232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -255,9 +246,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -876,9 +864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -896,9 +881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -916,9 +898,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -936,9 +915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1768,7 +1744,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1884,9 +1860,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1902,9 +1875,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1922,9 +1892,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1941,9 +1908,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,9 +1923,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4882,9 +4843,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4900,9 +4858,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4920,9 +4875,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4938,9 +4890,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4958,9 +4907,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4976,9 +4922,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5340,9 +5283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5360,9 +5300,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5380,9 +5317,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5400,9 +5334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12324,8 +12255,8 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/typography": "^0.5.20",
         "autoprefixer": "^10.5.4",
-        "postcss": "^8.5.16",
-        "tailwindcss": "^4.3.1",
+        "postcss": "^8.5.20",
+        "tailwindcss": "^4.3.3",
         "tailwindcss-animate": "^1.0.7"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "website"
       ],
       "dependencies": {
-        "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.8",
-        "@earendil-works/pi-ai": ">=0.80.2 <0.80.8",
-        "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.8",
+        "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.11",
+        "@earendil-works/pi-ai": ">=0.80.2 <0.80.11",
+        "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.11",
         "better-sqlite3": "^12.11.1",
         "duck-duck-scrape": "^2.2.7",
         "yahoo-finance2": "^3.15.3"
@@ -1160,12 +1160,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
-      "integrity": "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": ">=0.80.2 <0.80.11",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1220,15 +1220,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1691,11 +1691,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1705,8 +1705,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1729,8 +1729,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.8",
         "better-sqlite3": "^12.11.1",
         "duck-duck-scrape": "^2.2.7",
-        "yahoo-finance2": "^3.15.3"
+        "yahoo-finance2": "^4.0.0"
       },
       "bin": {
         "opencandle": "dist/cli.js"
@@ -7455,15 +7455,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -7742,13 +7733,16 @@
       }
     },
     "node_modules/fetch-mock-cache": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-2.3.1.tgz",
-      "integrity": "sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-3.1.0.tgz",
+      "integrity": "sha512-VxdIstx7qhqW9+9AOjYAlxEguX9HnBFdSaydlwLiZR+xAldGdZMLmSn8pYLd6hNh3vjcIcqUkgFgcdcPomctFg==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "filenamify-url": "2.1.2"
+        "filenamify-url": "4.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -7758,42 +7752,43 @@
       "license": "MIT"
     },
     "node_modules/filename-reserved-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-4.0.0.tgz",
+      "integrity": "sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/filenamify": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
-      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-7.0.2.tgz",
+      "integrity": "sha512-fz10TUqSZ1lG7ftW1KnRotJzMD8YRb6kaAQKpZJBLvqXXfFgIEpuazy1w2lK3zhMiBSdH/uF9LFlv5smJ2Jl1w==",
       "license": "MIT",
       "dependencies": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.1",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/filenamify-url": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
-      "integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-4.0.0.tgz",
+      "integrity": "sha512-dhK3TuWC6dbKMgL3Li3qlsd6wHZ2bXJXt2VJw+D8mPIXCTLtet+sRmK6/t1cseuWjYRdMa4gNb7c2H6D8J0Jig==",
       "license": "MIT",
       "dependencies": {
-        "filenamify": "^4.3.0",
-        "humanize-url": "^2.1.1"
+        "filenamify": "^7.0.0",
+        "humanize-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8233,15 +8228,18 @@
       }
     },
     "node_modules/humanize-url": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
-      "integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-3.0.0.tgz",
+      "integrity": "sha512-oWcYrKNVa+bCX9ACFZ85H8l1+QcwBJ64xH5+PHYoLe/Y5aToOfw3s3OZqRA/OyJPcWOXuDLo3qil5CYvTMtp0A==",
       "license": "MIT",
       "dependencies": {
-        "normalize-url": "^4.5.1"
+        "normalize-url": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/iconv-lite": {
@@ -8521,39 +8519,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/tldts": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
-      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.4.9"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/jsdom/node_modules/tldts-core": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
-      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
-      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/json-bigint": {
@@ -9941,12 +9906,15 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
+      "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -10289,18 +10257,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -10315,6 +10271,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10335,12 +10292,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
@@ -10688,12 +10639,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/reselect": {
       "version": "5.2.0",
@@ -11206,18 +11151,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/strip-outer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -11377,21 +11310,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "license": "MIT"
     },
     "node_modules/toidentifier": {
@@ -11404,42 +11337,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tough-cookie-file-store": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-2.0.3.tgz",
-      "integrity": "sha512-sMpZVcmFf6EYFHFFl+SYH4W1/OnXBYMGDsv2IlbQ2caHyFElW/UR/gpj/KYU1JwmP4dE9xqwv2+vWcmlXHojSw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-3.3.0.tgz",
+      "integrity": "sha512-FbO/cOi/jp4wweo8soVNG/ZjDsgpBZWqaxWwu7gRKvsjg/Qt44kStp87VLfJnin749DlTbZDYvV1wuSr5jly2g==",
       "license": "MIT",
       "dependencies": {
-        "tough-cookie": "^4.0.0"
+        "tough-cookie": "^6.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie-file-store/node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -11463,18 +11381,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trim-repeated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/trough": {
@@ -11695,15 +11601,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11742,16 +11639,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -12211,18 +12098,18 @@
       "license": "MIT"
     },
     "node_modules/yahoo-finance2": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.15.4.tgz",
-      "integrity": "sha512-90eOw76iqS//ksQGL4d/VcchbysnpWzFXVuiBtG7uuImlBDdxBA0BtccxCuTvVZDDu1aXm1TqBGc+MPr6wNkyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-4.0.0.tgz",
+      "integrity": "sha512-3AUMLycIxGSKEf99nEedmsccBLAXyVajCfKlY+Vxsxx6ntsDlFYN1UdL6APGMFiRs8IBivn62eJT4Zj3WQdrlw==",
       "license": "MIT",
       "dependencies": {
         "@deno/shim-deno": "~0.18.0",
         "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.26.0",
-        "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
+        "fetch-mock-cache": "npm:fetch-mock-cache@^3.1.0",
         "json-schema": "^0.4.0",
-        "tough-cookie": "npm:tough-cookie@^5.1.1",
-        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3",
-        "zod": "npm:zod@^3.25.0"
+        "tough-cookie": "npm:tough-cookie@^6.0.0",
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^3.0.0",
+        "zod": "npm:zod@^4.0.0"
       },
       "bin": {
         "yahoo-finance": "esm/bin/yahoo-finance.js",
@@ -12230,16 +12117,7 @@
         "yahoo-finance2": "esm/bin/yahoo-finance.js"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/yahoo-finance2/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "lightweight-charts": "^5.0.0",
-        "lucide-react": "^1.24.0",
+        "lucide-react": "^1.25.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "recharts": "^3.9.2",
@@ -8911,9 +8911,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
-      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -123,9 +123,9 @@
     "node": "^22.19.0 || >=24.0.0 <27"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.11",
-    "@earendil-works/pi-ai": ">=0.80.2 <0.80.11",
-    "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.11",
+    "@earendil-works/pi-agent-core": "^0.80.10",
+    "@earendil-works/pi-ai": "^0.80.10",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
     "better-sqlite3": "^12.11.1",
     "duck-duck-scrape": "^2.2.7",
     "yahoo-finance2": "^4.0.0"
@@ -135,17 +135,17 @@
   },
   "devDependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.59.0",
-    "@agentclientprotocol/codex-acp": "^1.0.1",
-    "@biomejs/biome": "^2.5.1",
-    "@sinclair/typebox": "^0.34.49",
+    "@agentclientprotocol/codex-acp": "^1.1.4",
+    "@biomejs/biome": "^2.5.4",
+    "@sinclair/typebox": "^0.34.52",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.1",
     "acpx": "^0.12.0",
     "jsdom": "^29.1.1",
     "playwright-core": "^1.61.1",
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.1",
     "typescript": "^7.0.2",
-    "vite": "^8.1.0",
-    "vitest": "^4.1.9"
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.8",
     "better-sqlite3": "^12.11.1",
     "duck-duck-scrape": "^2.2.7",
-    "yahoo-finance2": "^3.15.3"
+    "yahoo-finance2": "^4.0.0"
   },
   "peerDependencies": {
     "@sinclair/typebox": "*"

--- a/package.json
+++ b/package.json
@@ -134,14 +134,14 @@
     "@sinclair/typebox": "*"
   },
   "devDependencies": {
-    "@agentclientprotocol/claude-agent-acp": "^0.58.1",
+    "@agentclientprotocol/claude-agent-acp": "^0.59.0",
     "@agentclientprotocol/codex-acp": "^1.0.1",
     "@biomejs/biome": "^2.5.1",
     "@sinclair/typebox": "^0.34.49",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.0.1",
     "acpx": "^0.12.0",
-    "jsdom": "^27.0.0",
+    "jsdom": "^29.1.1",
     "playwright-core": "^1.61.1",
     "tsx": "^4.22.4",
     "typescript": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -123,9 +123,9 @@
     "node": "^22.19.0 || >=24.0.0 <27"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.8",
-    "@earendil-works/pi-ai": ">=0.80.2 <0.80.8",
-    "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.8",
+    "@earendil-works/pi-agent-core": ">=0.80.2 <0.80.11",
+    "@earendil-works/pi-ai": ">=0.80.2 <0.80.11",
+    "@earendil-works/pi-coding-agent": ">=0.80.2 <0.80.11",
     "better-sqlite3": "^12.11.1",
     "duck-duck-scrape": "^2.2.7",
     "yahoo-finance2": "^3.15.3"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -6,7 +6,6 @@ import { dirname, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import {
-  AuthStorage,
   createAgentSessionRuntime,
   createAgentSessionServices,
   DefaultPackageManager,
@@ -14,6 +13,7 @@ import {
   InteractiveMode,
   initTheme,
   ModelRegistry,
+  ModelRuntime,
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -202,8 +202,11 @@ async function main(): Promise<void> {
 
   // Default: start the OpenCandle interactive agent
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const modelRuntime = await ModelRuntime.create({
+    authPath: resolve(agentDir, "auth.json"),
+    modelsPath: resolve(agentDir, "models.json"),
+  });
+  const modelRegistry = new ModelRegistry(modelRuntime);
   const shouldSuppressFallbackMessage = modelRegistry.getAvailable().length === 0;
 
   initTheme(settingsManager.getTheme(), true);
@@ -225,7 +228,7 @@ async function main(): Promise<void> {
       if (!model) {
         return "Connect an AI model before chat can run. Paste a Google Gemini, OpenAI, or Anthropic API key in the setup panel.";
       }
-      if (!session.modelRegistry.hasConfiguredAuth(model)) {
+      if (!session.modelRuntime.hasConfiguredAuth(model.provider)) {
         return "Connect an AI model before chat can run. Paste a Google Gemini, OpenAI, or Anthropic API key in the setup panel.";
       }
       return null;
@@ -271,16 +274,14 @@ async function main(): Promise<void> {
         const services = await createAgentSessionServices({
           cwd: opts.cwd,
           agentDir: opts.agentDir,
-          authStorage,
           settingsManager,
-          modelRegistry,
+          modelRuntime,
         });
         const result = await createOpenCandleSession({
           cwd: opts.cwd,
           agentDir: opts.agentDir,
           settingsManager,
-          authStorage,
-          modelRegistry,
+          modelRuntime,
           sessionManager: opts.sessionManager,
           bindExtensions: false,
         });

--- a/src/doctor/cli-command.ts
+++ b/src/doctor/cli-command.ts
@@ -1,4 +1,4 @@
-import { AuthStorage, ModelRegistry, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry, ModelRuntime, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { getProvider, type ProviderId } from "../onboarding/providers.js";
 import {
   clearProviderOnboardingEntry,
@@ -35,8 +35,11 @@ export async function handleDoctorCommand(
     if (!json) console.log(`Re-enabled ${providerId}.`);
   }
 
-  const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const modelRuntime = await ModelRuntime.create({
+    authPath: `${agentDir}/auth.json`,
+    modelsPath: `${agentDir}/models.json`,
+  });
+  const modelRegistry = new ModelRegistry(modelRuntime);
   const settingsManager = SettingsManager.create(cwd, agentDir);
   const includeSessions = args.includes("--sessions");
   if (includeSessions) {
@@ -60,7 +63,7 @@ function buildCliModelSetupState(
   modelRegistry: ModelRegistry,
   settingsManager: SettingsManager,
 ): DoctorModelSetupState {
-  modelRegistry.refresh();
+  void modelRegistry.refresh();
   const provider = settingsManager.getDefaultProvider();
   const modelId = settingsManager.getDefaultModel();
   const activeModel = provider && modelId ? modelRegistry.find(provider, modelId) : undefined;

--- a/src/pi/opencandle-extension.ts
+++ b/src/pi/opencandle-extension.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import {
   buildComprehensiveAnalysisDefinition,
   isAnalysisRequest,
@@ -51,6 +51,7 @@ import {
 import { getOpenCandleToolDefinitions } from "./tool-adapter.js";
 
 export interface OpenCandleExtensionOptions {
+  modelRuntime?: ModelRuntime;
   askUserHandler?: AskUserHandler;
   /**
    * Optional router LLM client. When provided, this instance is used instead
@@ -143,7 +144,7 @@ export default function openCandleExtension(
   pi.registerCommand("setup", {
     description: "Reconfigure the OpenCandle AI model (sign-in or API key)",
     handler: async (_args, ctx) => {
-      const result = await coordinator.runSetup(pi, ctx, { mode: "manual" });
+      const result = await coordinator.runSetup(pi, ctx, { mode: "manual" }, options?.modelRuntime);
       if (result === "ready") {
         ctx.ui.notify("OpenCandle setup complete.", "info");
       }

--- a/src/pi/session.ts
+++ b/src/pi/session.ts
@@ -1,10 +1,9 @@
 import {
-  type AuthStorage,
   type CreateAgentSessionResult,
   createAgentSession,
   DefaultResourceLoader,
   getAgentDir,
-  type ModelRegistry,
+  type ModelRuntime,
   type SessionManager,
   type SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -16,8 +15,7 @@ import openCandleExtension from "./opencandle-extension.js";
 export interface CreateOpenCandleSessionOptions {
   cwd?: string;
   agentDir?: string;
-  authStorage?: AuthStorage;
-  modelRegistry?: ModelRegistry;
+  modelRuntime?: ModelRuntime;
   settingsManager?: SettingsManager;
   sessionManager?: SessionManager;
   useInlineExtension?: boolean;
@@ -40,7 +38,11 @@ export async function createOpenCandleSession(
         agentDir,
         settingsManager: options.settingsManager,
         extensionFactories: [
-          (pi) => openCandleExtension(pi, { askUserHandler: options.askUserHandler }),
+          (pi) =>
+            openCandleExtension(pi, {
+              askUserHandler: options.askUserHandler,
+              modelRuntime: options.modelRuntime,
+            }),
         ],
       })
     : undefined;
@@ -52,8 +54,7 @@ export async function createOpenCandleSession(
   const result = await createAgentSession({
     cwd,
     agentDir,
-    authStorage: options.authStorage,
-    modelRegistry: options.modelRegistry,
+    modelRuntime: options.modelRuntime,
     sessionManager: options.sessionManager,
     settingsManager: options.settingsManager,
     resourceLoader,
@@ -74,8 +75,9 @@ async function applySavedDefaultModel(result: CreateAgentSessionResult): Promise
   const modelId = result.session.settingsManager.getDefaultModel();
   if (!provider || !modelId) return;
 
-  const savedDefault = result.session.modelRegistry.find(provider, modelId);
-  if (!savedDefault || !result.session.modelRegistry.hasConfiguredAuth(savedDefault)) return;
+  const savedDefault = result.session.modelRuntime.getModel(provider, modelId);
+  if (!savedDefault || !result.session.modelRuntime.hasConfiguredAuth(savedDefault.provider))
+    return;
 
   const current = result.session.model;
   if (current?.provider === savedDefault.provider && current.id === savedDefault.id) return;

--- a/src/pi/setup.ts
+++ b/src/pi/setup.ts
@@ -1,8 +1,9 @@
-import type { Api, Model, OAuthProviderId } from "@earendil-works/pi-ai";
+import type { Api, AuthEvent, AuthPrompt, Model } from "@earendil-works/pi-ai";
 import {
   type ExtensionAPI,
   type ExtensionContext,
   LoginDialogComponent,
+  type ModelRuntime,
 } from "@earendil-works/pi-coding-agent";
 import { validateModelKey } from "../onboarding/validate-model-key.js";
 
@@ -107,8 +108,11 @@ async function selectProviderForLogin(
   }
 }
 
-async function selectAdvancedOAuthProvider(ctx: ExtensionContext): Promise<string | undefined> {
-  const providers = ctx.modelRegistry.authStorage.getOAuthProviders();
+async function selectAdvancedOAuthProvider(
+  ctx: ExtensionContext,
+  modelRuntime: ModelRuntime,
+): Promise<string | undefined> {
+  const providers = modelRuntime.getProviders().filter((provider) => provider.auth.oauth?.login);
   if (providers.length === 0) {
     ctx.ui.notify("No sign-in providers are available.", "warning");
     return undefined;
@@ -118,12 +122,13 @@ async function selectAdvancedOAuthProvider(ctx: ExtensionContext): Promise<strin
   return providers.find((provider) => provider.name === choice)?.id;
 }
 
-async function runLoginDialog(ctx: ExtensionContext, providerId: string): Promise<boolean> {
-  const provider = ctx.modelRegistry.authStorage
-    .getOAuthProviders()
-    .find((item) => item.id === providerId);
+async function runLoginDialog(
+  ctx: ExtensionContext,
+  providerId: string,
+  modelRuntime: ModelRuntime,
+): Promise<boolean> {
+  const provider = modelRuntime.getProvider(providerId);
   const providerName = provider?.name ?? providerId;
-  const usesCallbackServer = provider?.usesCallbackServer ?? false;
 
   const success = await ctx.ui.custom<boolean>((tui, _theme, _keybindings, done) => {
     let finished = false;
@@ -137,55 +142,36 @@ async function runLoginDialog(ctx: ExtensionContext, providerId: string): Promis
       finish(completed);
     });
 
-    let manualCodeResolve: ((value: string) => void) | undefined;
-    let manualCodeReject: ((error: Error) => void) | undefined;
-    const manualCodePromise = new Promise<string>((resolve, reject) => {
-      manualCodeResolve = resolve;
-      manualCodeReject = reject;
-    });
+    const prompt = async (request: AuthPrompt): Promise<string> => {
+      if (request.type === "select") {
+        const options = request.options
+          .map((option, index) => `${index + 1}. ${option.label}`)
+          .join("\n");
+        const answer = await dialog.showPrompt(
+          `${request.message}\n\n${options}`,
+          "Enter a number",
+        );
+        const selectedIndex = Number.parseInt(answer.trim(), 10) - 1;
+        return request.options[selectedIndex]?.id ?? "";
+      }
+      return dialog.showPrompt(request.message, request.placeholder);
+    };
+    const notify = (event: AuthEvent): void => {
+      if (event.type === "auth_url") dialog.showAuth(event.url, event.instructions);
+      else if (event.type === "device_code") {
+        dialog.showDeviceCode({
+          userCode: event.userCode,
+          verificationUri: event.verificationUri,
+        });
+        dialog.showWaiting("Waiting for authentication...");
+      } else if (event.type === "progress" || event.type === "info")
+        dialog.showProgress(event.message);
+    };
 
-    // Cast required: advanced providers return dynamic IDs outside the SDK's static union type
-    void ctx.modelRegistry.authStorage
-      .login(providerId as OAuthProviderId, {
-        onAuth: (info) => {
-          dialog.showAuth(info.url, info.instructions);
-          if (usesCallbackServer) {
-            void dialog
-              .showManualInput("Paste redirect URL below, or complete login in your browser:")
-              .then((value) => {
-                if (value && manualCodeResolve) {
-                  manualCodeResolve(value);
-                  manualCodeResolve = undefined;
-                }
-              })
-              .catch(() => {
-                if (manualCodeReject) {
-                  manualCodeReject(new Error("Login cancelled"));
-                  manualCodeReject = undefined;
-                }
-              });
-          } else if (providerId === "github-copilot") {
-            dialog.showWaiting("Waiting for browser authentication...");
-          }
-        },
-        onDeviceCode: (info) => {
-          dialog.showDeviceCode(info);
-          dialog.showWaiting("Waiting for authentication...");
-        },
-        onPrompt: async (prompt) => dialog.showPrompt(prompt.message, prompt.placeholder),
-        onProgress: (message) => dialog.showProgress(message),
-        onSelect: async (prompt) => {
-          const options = prompt.options
-            .map((option, index) => `${index + 1}. ${option.label}`)
-            .join("\n");
-          const answer = await dialog.showPrompt(
-            `${prompt.message}\n\n${options}`,
-            "Enter a number",
-          );
-          const selectedIndex = Number.parseInt(answer.trim(), 10) - 1;
-          return prompt.options[selectedIndex]?.id;
-        },
-        onManualCodeInput: () => manualCodePromise,
+    void modelRuntime
+      .login(providerId, "oauth", {
+        prompt,
+        notify,
         signal: dialog.signal,
       })
       .then(() => finish(true))
@@ -212,6 +198,7 @@ async function runLoginDialog(ctx: ExtensionContext, providerId: string): Promis
 export async function runApiKeySetup(
   ctx: ExtensionContext,
   provider: ApiKeyProviderId,
+  modelRuntime: ModelRuntime,
 ): Promise<boolean> {
   const label = API_KEY_PROVIDER_LABELS[provider];
   ctx.ui.notify(
@@ -232,8 +219,11 @@ export async function runApiKeySetup(
     );
     return false;
   }
-  ctx.modelRegistry.authStorage.set(provider, { type: "api_key", key: trimmed });
-  ctx.modelRegistry.refresh();
+  await modelRuntime.login(provider, "api_key", {
+    prompt: async () => trimmed,
+    notify: () => {},
+  });
+  await ctx.modelRegistry.refresh();
   ctx.ui.notify(
     validation.status === "transient"
       ? `Saved — couldn't verify (network issue). ${label} API key saved to OpenCandle.`
@@ -315,6 +305,7 @@ async function runLlmSetup(
   api: ExtensionAPI,
   ctx: ExtensionContext,
   mode: SetupMode,
+  modelRuntime?: ModelRuntime,
 ): Promise<SetupResult> {
   while (true) {
     const requirement = getLlmSetupRequirement(ctx);
@@ -354,18 +345,24 @@ async function runLlmSetup(
     }
 
     if (choice === "Sign in with browser") {
+      if (!modelRuntime) {
+        ctx.ui.notify("Model authentication is unavailable in this session.", "error");
+        return "cancelled";
+      }
       const providerChoice = await selectProviderForLogin(ctx);
       if (!providerChoice) {
         continue;
       }
 
       const providerId =
-        providerChoice === "advanced" ? await selectAdvancedOAuthProvider(ctx) : providerChoice;
+        providerChoice === "advanced"
+          ? await selectAdvancedOAuthProvider(ctx, modelRuntime)
+          : providerChoice;
       if (!providerId) {
         continue;
       }
 
-      const loggedIn = await runLoginDialog(ctx, providerId);
+      const loggedIn = await runLoginDialog(ctx, providerId, modelRuntime);
       if (!loggedIn) {
         continue;
       }
@@ -387,7 +384,11 @@ async function runLlmSetup(
       continue;
     }
 
-    const saved = await runApiKeySetup(ctx, provider);
+    if (!modelRuntime) {
+      ctx.ui.notify("Model authentication is unavailable in this session.", "error");
+      return "cancelled";
+    }
+    const saved = await runApiKeySetup(ctx, provider, modelRuntime);
     if (!saved) {
       continue;
     }
@@ -407,10 +408,11 @@ export async function runOpenCandleSetup(
   api: ExtensionAPI,
   ctx: ExtensionContext,
   options: { mode: SetupMode } = { mode: "startup" },
+  modelRuntime?: ModelRuntime,
 ): Promise<SetupResult> {
   const initialRequirement = getLlmSetupRequirement(ctx);
   if (initialRequirement !== "ready" || options.mode === "manual") {
-    return runLlmSetup(api, ctx, options.mode);
+    return runLlmSetup(api, ctx, options.mode, modelRuntime);
   }
   return "ready";
 }

--- a/src/runtime/session-coordinator.ts
+++ b/src/runtime/session-coordinator.ts
@@ -2,6 +2,7 @@ import type {
   ExtensionAPI,
   ExtensionCommandContext,
   ExtensionContext,
+  ModelRuntime,
   SessionEntry,
 } from "@earendil-works/pi-coding-agent";
 import { isAnalystSplit, parseAnalystOutput, parseDebateOutput } from "../analysts/contracts.js";
@@ -195,8 +196,9 @@ export class SessionCoordinator {
     pi: ExtensionAPI,
     ctx: ExtensionContext | ExtensionCommandContext,
     options: { mode: "startup" | "manual" },
+    modelRuntime?: ModelRuntime,
   ): Promise<"ready" | "shutdown" | "cancelled"> {
-    return runOpenCandleSetup(pi, ctx, options);
+    return runOpenCandleSetup(pi, ctx, options, modelRuntime);
   }
 
   /** Extract and persist user preferences from natural language. */

--- a/tests/harness/opencandle-runner.ts
+++ b/tests/harness/opencandle-runner.ts
@@ -3,8 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import {
-  type AuthStorage,
-  type ModelRegistry,
+  type ModelRuntime,
   SessionManager as PiSessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -58,8 +57,7 @@ export interface RunOpenCandleSessionOptions {
   jsonlPath?: string;
   defaultProvider?: string;
   defaultModel?: string;
-  authStorage?: AuthStorage;
-  modelRegistry?: ModelRegistry;
+  modelRuntime?: ModelRuntime;
 }
 
 export interface RunOpenCandleSessionResult {
@@ -91,8 +89,7 @@ export async function runOpenCandleSession(
 
     const created = await createOpenCandleSession({
       cwd: options.cwd ?? process.cwd(),
-      authStorage: options.authStorage,
-      modelRegistry: options.modelRegistry,
+      modelRuntime: options.modelRuntime,
       sessionManager: PiSessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
         defaultProvider: options.defaultProvider ?? "google",

--- a/tests/helpers/pi-model-runtime.ts
+++ b/tests/helpers/pi-model-runtime.ts
@@ -1,0 +1,21 @@
+import { type Credential, InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
+
+export async function createTestModelRuntime(
+  credentialsByProvider: Record<string, Credential> = {},
+) {
+  const credentials = new InMemoryCredentialStore();
+  for (const [providerId, credential] of Object.entries(credentialsByProvider)) {
+    await credentials.modify(providerId, async () => credential);
+  }
+  const modelRuntime = await ModelRuntime.create({
+    credentials,
+    modelsPath: null,
+    allowModelNetwork: false,
+  });
+  return {
+    credentials,
+    modelRuntime,
+    modelRegistry: new ModelRegistry(modelRuntime),
+  };
+}

--- a/tests/scripts/run-competitive-finance-eval.ts
+++ b/tests/scripts/run-competitive-finance-eval.ts
@@ -21,7 +21,7 @@ import {
   type Model,
   registerBuiltInApiProviders,
 } from "@earendil-works/pi-ai/compat";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { loadEnv } from "../../src/config.js";
 import { getOpenCandleHomeDir } from "../../src/infra/opencandle-paths.js";
 import {
@@ -125,8 +125,8 @@ process.on("exit", () => {
 mkdirSync(competitorCwd, { recursive: true });
 
 registerBuiltInApiProviders();
-const authStorage = AuthStorage.create();
-const modelRegistry = ModelRegistry.create(authStorage);
+const modelRuntime = await ModelRuntime.create();
+const modelRegistry = new ModelRegistry(modelRuntime);
 const competitorAnswerCache = loadCompetitiveReportCache();
 const judgeModel = await resolveModelWithAuth(
   requestedProvider,
@@ -416,8 +416,7 @@ async function runOpenCandle(prompt: string): Promise<EvalTrace> {
   const parsedSettleGraceMs = Number(settleGraceMs);
   const result = await runOpenCandleSession({
     prompt,
-    authStorage,
-    modelRegistry,
+    modelRuntime,
     defaultProvider: judgeModel.model.provider,
     defaultModel: judgeModel.model.id,
     openCandleHome,
@@ -764,7 +763,7 @@ async function resolveModelWithAuth(
     resolveRequestAuth: () => modelRegistry.getApiKeyAndHeaders(model),
     getEnvApiKey: (modelProvider) => getEnvApiKey(modelProvider),
     setRuntimeApiKey: (modelProvider, apiKey) =>
-      authStorage.setRuntimeApiKey(modelProvider, apiKey),
+      modelRuntime.setRuntimeApiKey(modelProvider, apiKey),
   });
   if (!requestAuth.ok) {
     throw new Error(`${requestAuth.error}\n${missingAuthMessage}`);
@@ -788,7 +787,7 @@ function resolveModel(provider: string | undefined, modelId: string | undefined)
     return getModel(provider as never, modelId as never) as Model<Api>;
   }
 
-  if (!provider && authStorage.hasAuth("google")) {
+  if (!provider && modelRuntime.getProviderAuthStatus("google").configured) {
     return getModel("google", "gemini-2.5-flash") as Model<Api>;
   }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -60,16 +60,22 @@ vi.mock("@earendil-works/pi-coding-agent", () => {
     };
   }
 
+  function ModelRegistryMock() {
+    return {
+      find: vi.fn(),
+      getAvailable: vi.fn(() => []),
+      hasConfiguredAuth: vi.fn(() => false),
+      refresh: vi.fn(),
+    };
+  }
+
   return {
-    AuthStorage: { create: vi.fn() },
     DefaultPackageManager: vi.fn(DefaultPackageManagerMock),
     InteractiveMode: piMocks.InteractiveMode,
-    ModelRegistry: {
-      create: vi.fn(() => ({
-        find: vi.fn(),
-        getAvailable: vi.fn(() => []),
+    ModelRegistry: vi.fn(ModelRegistryMock),
+    ModelRuntime: {
+      create: vi.fn(async () => ({
         hasConfiguredAuth: vi.fn(() => false),
-        refresh: vi.fn(),
       })),
     },
     SettingsManager: {

--- a/tests/unit/gui-server/coordinator-convergence-smoke.test.ts
+++ b/tests/unit/gui-server/coordinator-convergence-smoke.test.ts
@@ -138,10 +138,12 @@ function fakeSession(sessionManager: SessionManager): AgentSession {
   return {
     sessionManager,
     model,
-    modelRegistry: {
-      refresh: vi.fn(),
-      getAvailable: () => [model],
+    modelRuntime: {
+      refresh: vi.fn(async () => {}),
+      reloadConfig: vi.fn(async () => {}),
+      getAvailableSnapshot: () => [model],
       hasConfiguredAuth: () => true,
+      getModel: () => model,
     },
     isStreaming: false,
     pendingMessageCount: 0,

--- a/tests/unit/gui-server/model-setup.test.ts
+++ b/tests/unit/gui-server/model-setup.test.ts
@@ -92,16 +92,21 @@ describe("GUI model setup", () => {
     const entries: unknown[] = [];
     const selectedModels: Model<Api>[] = [];
     const auth = new Map<string, unknown>();
-    const session = {
-      modelRegistry: {
-        ...registry([preferred]),
-        authStorage: {
-          set(provider: string, credential: unknown) {
-            auth.set(provider, credential);
-          },
-        },
-        find: () => preferred,
+    const modelRuntime = {
+      login: async (
+        provider: string,
+        _type: string,
+        interaction: { prompt(input: unknown): Promise<string> },
+      ) => {
+        auth.set(provider, { type: "api_key", key: await interaction.prompt({}) });
       },
+      getAvailableSnapshot: () => [preferred],
+      hasConfiguredAuth: () => true,
+      getModel: () => preferred,
+      refresh: async () => {},
+    };
+    const session = {
+      modelRuntime,
       setModel: async (selected: Model<Api>) => {
         selectedModels.push(selected);
       },
@@ -139,12 +144,12 @@ describe("GUI model setup", () => {
     ) as unknown as typeof fetch;
     const auth = new Map<string, unknown>();
     const session = {
-      modelRegistry: {
-        ...registry([model("openai", "gpt-5-mini")]),
-        authStorage: {
-          set: (provider: string, credential: unknown) => auth.set(provider, credential),
-        },
-        find: () => model("openai", "gpt-5-mini"),
+      modelRuntime: {
+        login: async () => {},
+        getAvailableSnapshot: () => [model("openai", "gpt-5-mini")],
+        hasConfiguredAuth: () => true,
+        getModel: () => model("openai", "gpt-5-mini"),
+        refresh: async () => {},
       },
       setModel: async () => {},
       settingsManager: { flush: async () => {} },
@@ -167,11 +172,14 @@ describe("GUI model setup", () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
     const entries: unknown[] = [];
+    const anthropic = model("anthropic", "claude-haiku-4-5");
     const session = {
-      modelRegistry: {
-        ...registry([model("anthropic", "claude-haiku-4-5")]),
-        authStorage: { set: () => {} },
-        find: () => model("anthropic", "claude-haiku-4-5"),
+      modelRuntime: {
+        login: async () => {},
+        getAvailableSnapshot: () => [anthropic],
+        hasConfiguredAuth: () => true,
+        getModel: () => anthropic,
+        refresh: async () => {},
       },
       setModel: async () => {},
       settingsManager: { flush: async () => {} },

--- a/tests/unit/gui-server/server-route-guards.test.ts
+++ b/tests/unit/gui-server/server-route-guards.test.ts
@@ -26,7 +26,7 @@ describe("GUI server route guards", () => {
     },
     {
       route: 'url.pathname === "/api/model-setup/refresh"',
-      handler: "options.getSession().modelRegistry.refresh();",
+      handler: "options.getSession().modelRuntime.refresh();",
       guard: 'allowTrustedGuiRequest(req, res, "Model setup API", options)',
     },
     {
@@ -191,15 +191,18 @@ describe("GUI server route guards", () => {
       'url.pathname === "/api/local-coordinator/tool-invoke"',
       'url.pathname === "/api/local-coordinator/ask-user"',
     ],
-  ])("returns an error response when $route reports a failed tool invocation", (route, nextRoute) => {
-    const source = readFileSync(resolve("gui/server/http-routes.ts"), "utf-8");
-    const routeStart = source.indexOf(route);
-    const routeEnd = source.indexOf(nextRoute, routeStart + route.length);
-    const routeSource = source.slice(routeStart, routeEnd);
+  ])(
+    "returns an error response when $route reports a failed tool invocation",
+    (route, nextRoute) => {
+      const source = readFileSync(resolve("gui/server/http-routes.ts"), "utf-8");
+      const routeStart = source.indexOf(route);
+      const routeEnd = source.indexOf(nextRoute, routeStart + route.length);
+      const routeSource = source.slice(routeStart, routeEnd);
 
-    expect(routeSource).toContain("const result = asRecord(message.result);");
-    expect(routeSource).toContain("if (message.ok === true && result.toolCallId)");
-  });
+      expect(routeSource).toContain("const result = asRecord(message.result);");
+      expect(routeSource).toContain("if (message.ok === true && result.toolCallId)");
+    },
+  );
 
   it("requires local coordinator authorization before accepting proxied ask_user actions", () => {
     const routeBlock = routeBlockBefore(

--- a/tests/unit/gui-web/alert-sentences.test.ts
+++ b/tests/unit/gui-web/alert-sentences.test.ts
@@ -122,13 +122,12 @@ describe("formatAlertObservedValue", () => {
       value: 50,
       expected: "price $50.00 · below $55.00, waiting for next downward cross",
     },
-  ])("describes the observed edge state for $conditionType at $value", ({
-    conditionType,
-    value,
-    expected,
-  }) => {
-    expect(formatAlertObservedValue(conditionType, { threshold: 55 }, { value })).toBe(expected);
-  });
+  ])(
+    "describes the observed edge state for $conditionType at $value",
+    ({ conditionType, value, expected }) => {
+      expect(formatAlertObservedValue(conditionType, { threshold: 55 }, { value })).toBe(expected);
+    },
+  );
 
   it("uses condition context and human units for every alert condition", () => {
     expect(

--- a/tests/unit/gui-web/instrument-search.test.ts
+++ b/tests/unit/gui-web/instrument-search.test.ts
@@ -124,16 +124,15 @@ describe("instrument search UI helpers", () => {
     ]);
   });
 
-  it.each([
-    "EURUSD",
-    "NOKAMD=X",
-    "EUR/USD",
-  ])("preserves provider order for the FX-looking query %s", (query) => {
-    const mixedCandidates = [
-      { symbol: "EURUSD=X", quoteType: "CURRENCY" },
-      { symbol: "EUR", quoteType: "EQUITY" },
-    ];
+  it.each(["EURUSD", "NOKAMD=X", "EUR/USD"])(
+    "preserves provider order for the FX-looking query %s",
+    (query) => {
+      const mixedCandidates = [
+        { symbol: "EURUSD=X", quoteType: "CURRENCY" },
+        { symbol: "EUR", quoteType: "EQUITY" },
+      ];
 
-    expect(rankInstrumentCandidates(mixedCandidates, query)).toEqual(mixedCandidates);
-  });
+      expect(rankInstrumentCandidates(mixedCandidates, query)).toEqual(mixedCandidates);
+    },
+  );
 });

--- a/tests/unit/gui-web/symbol-page-render.test.ts
+++ b/tests/unit/gui-web/symbol-page-render.test.ts
@@ -117,42 +117,45 @@ describe("symbol page", () => {
   it.each([
     [2.5, 0.6, "up", "+$2.50", "+0.60%"],
     [-3.25, -0.75, "down", "−$3.25", "−0.75%"],
-  ])("renders a signed, icon-labeled %s header change", (change, percent, direction, money, pct) => {
-    const html = renderToStaticMarkup(
-      React.createElement(SymbolHeader, {
-        ticker: "MSFT",
-        overview: { status: "ok", name: "Microsoft Corporation" },
-        quote: {
-          status: "ok",
-          symbol: "MSFT",
-          price: 420.5,
-          change,
-          changePercent: percent,
-          currency: "USD",
-          marketState: "REGULAR",
-          fetchedAt: new Date().toISOString(),
-        },
-      }),
-    );
+  ])(
+    "renders a signed, icon-labeled %s header change",
+    (change, percent, direction, money, pct) => {
+      const html = renderToStaticMarkup(
+        React.createElement(SymbolHeader, {
+          ticker: "MSFT",
+          overview: { status: "ok", name: "Microsoft Corporation" },
+          quote: {
+            status: "ok",
+            symbol: "MSFT",
+            price: 420.5,
+            change,
+            changePercent: percent,
+            currency: "USD",
+            marketState: "REGULAR",
+            fetchedAt: new Date().toISOString(),
+          },
+        }),
+      );
 
-    expect(html).toContain("<h1");
-    expect(html).toContain('data-slot="panel-card"');
-    expect(html).toContain('data-slot="panel-header"');
-    expect(html.indexOf('data-slot="panel-header"')).toBeLessThan(
-      html.indexOf('data-slot="symbol-price-row"'),
-    );
-    expect(html).toContain("text-balance");
-    expect(html).toContain("Microsoft Corporation");
-    expect(html).toContain("MSFT");
-    expect(html).toContain("$420.50");
-    expect(html).toContain("tabular-nums");
-    expect(html).toContain(`Price moved ${direction}:`);
-    expect(html).toContain(money);
-    expect(html).toContain(pct);
-    expect(html).toContain("USD");
-    expect(html).toContain("Regular market");
-    expect(html).not.toContain('data-slot="extended-hours-quote"');
-  });
+      expect(html).toContain("<h1");
+      expect(html).toContain('data-slot="panel-card"');
+      expect(html).toContain('data-slot="panel-header"');
+      expect(html.indexOf('data-slot="panel-header"')).toBeLessThan(
+        html.indexOf('data-slot="symbol-price-row"'),
+      );
+      expect(html).toContain("text-balance");
+      expect(html).toContain("Microsoft Corporation");
+      expect(html).toContain("MSFT");
+      expect(html).toContain("$420.50");
+      expect(html).toContain("tabular-nums");
+      expect(html).toContain(`Price moved ${direction}:`);
+      expect(html).toContain(money);
+      expect(html).toContain(pct);
+      expect(html).toContain("USD");
+      expect(html).toContain("Regular market");
+      expect(html).not.toContain('data-slot="extended-hours-quote"');
+    },
+  );
 
   it("reuses ExtendedHoursQuote for pre-market quotes", () => {
     const html = renderToStaticMarkup(

--- a/tests/unit/gui-web/symbol-route-resolution.test.ts
+++ b/tests/unit/gui-web/symbol-route-resolution.test.ts
@@ -21,15 +21,12 @@ describe("tickerFromPath", () => {
     expect(tickerFromPath(symbolPageHref(symbol))).toBe(symbol);
   });
 
-  it.each([
-    "/symbol/",
-    "/symbol/A/B",
-    "/watchlists",
-    "/",
-    "/symbol/%3Cscript%3E",
-  ])("does not resolve %s", (pathname) => {
-    expect(tickerFromPath(pathname)).toBe("");
-  });
+  it.each(["/symbol/", "/symbol/A/B", "/watchlists", "/", "/symbol/%3Cscript%3E"])(
+    "does not resolve %s",
+    (pathname) => {
+      expect(tickerFromPath(pathname)).toBe("");
+    },
+  );
 });
 
 describe("symbol route", () => {

--- a/tests/unit/harness/opencandle-runner.test.ts
+++ b/tests/unit/harness/opencandle-runner.test.ts
@@ -1,4 +1,4 @@
-import { AuthStorage, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   drainOpenCandleCustomEntries,
@@ -6,6 +6,7 @@ import {
   toEvalTrace,
 } from "../../harness/opencandle-runner.js";
 import type { AgentTrace } from "../../harness/types.js";
+import { createTestModelRuntime } from "../../helpers/pi-model-runtime.js";
 
 const { createOpenCandleSessionMock } = vi.hoisted(() => ({
   createOpenCandleSessionMock: vi.fn(),
@@ -139,15 +140,13 @@ describe("runOpenCandleSession", () => {
     };
     createOpenCandleSessionMock.mockResolvedValue({ session });
 
-    const authStorage = AuthStorage.inMemory({
+    const { modelRuntime } = await createTestModelRuntime({
       google: { type: "api_key", key: "test-key" },
     });
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
 
     await runOpenCandleSession({
       prompt: "What is AAPL trading at?",
-      authStorage,
-      modelRegistry,
+      modelRuntime,
       defaultProvider: "google",
       defaultModel: "gemini-2.5-flash",
       settleGraceMs: 0,
@@ -155,8 +154,7 @@ describe("runOpenCandleSession", () => {
     });
 
     const options = createOpenCandleSessionMock.mock.calls[0]?.[0];
-    expect(options.authStorage).toBe(authStorage);
-    expect(options.modelRegistry).toBe(modelRegistry);
+    expect(options.modelRuntime).toBe(modelRuntime);
     expect(options.useInlineExtension).toBe(true);
     expect(options.settingsManager.getDefaultProvider()).toBe("google");
     expect(options.settingsManager.getDefaultModel()).toBe("gemini-2.5-flash");

--- a/tests/unit/pi/session.test.ts
+++ b/tests/unit/pi/session.test.ts
@@ -2,15 +2,11 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  AuthStorage,
-  ModelRegistry,
-  SessionManager,
-  SettingsManager,
-} from "@earendil-works/pi-coding-agent";
+import { SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createOpenCandleSession } from "../../../src/pi/session.js";
 import { getOpenCandleToolDefinitions } from "../../../src/pi/tool-adapter.js";
+import { createTestModelRuntime } from "../../helpers/pi-model-runtime.js";
 
 describe("createOpenCandleSession", () => {
   const originalEnv = { ...process.env };
@@ -55,9 +51,8 @@ describe("createOpenCandleSession", () => {
     process.env.OPENAI_API_KEY = "openai-key";
     process.env.ANTHROPIC_API_KEY = "anthropic-key";
 
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
-    const available = await modelRegistry.getAvailable();
+    const { modelRuntime } = await createTestModelRuntime();
+    const available = await modelRuntime.getAvailable();
 
     expect(available.some((model) => model.provider === "google")).toBe(true);
     expect(available.some((model) => model.provider === "openai")).toBe(true);
@@ -89,9 +84,9 @@ describe("createOpenCandleSession", () => {
         timestamp: Date.now(),
       });
 
-      const authStorage = AuthStorage.inMemory();
-      authStorage.set("google", { type: "api_key", key: "test-key" });
-      const modelRegistry = ModelRegistry.inMemory(authStorage);
+      const { modelRuntime } = await createTestModelRuntime({
+        google: { type: "api_key", key: "test-key" },
+      });
       const settingsManager = SettingsManager.inMemory({
         defaultProvider: "google",
         defaultModel: "gemini-3.1-pro-preview",
@@ -99,8 +94,7 @@ describe("createOpenCandleSession", () => {
 
       const result = await createOpenCandleSession({
         cwd,
-        authStorage,
-        modelRegistry,
+        modelRuntime,
         settingsManager,
         sessionManager: SessionManager.continueRecent(cwd, sessionDir),
       });

--- a/tests/unit/pi/setup.test.ts
+++ b/tests/unit/pi/setup.test.ts
@@ -4,12 +4,12 @@ vi.mock("../../../src/infra/open-url.js", async () => ({
   openInBrowser: vi.fn(async () => {}),
 }));
 
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import {
   getLlmSetupRequirement,
   runApiKeySetup,
   runOpenCandleSetup,
 } from "../../../src/pi/setup.js";
+import { createTestModelRuntime } from "../../helpers/pi-model-runtime.js";
 
 function createUi(overrides: Partial<any> = {}) {
   return {
@@ -46,17 +46,16 @@ describe("OpenCandle setup", () => {
   // tests will land in Task Group 14 (auto-model-select) and Task Group 17 (e2e
   // for the full just-in-time flow).
 
-  it("requires auth when there is no usable model", () => {
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+  it("requires auth when there is no usable model", async () => {
+    const { modelRegistry } = await createTestModelRuntime();
 
     expect(getLlmSetupRequirement({ model: undefined, modelRegistry })).toBe("connect_auth");
   });
 
-  it("requires model selection when auth exists but no current model is usable", () => {
-    const authStorage = AuthStorage.inMemory();
-    authStorage.set("anthropic", { type: "api_key", key: "sk-ant-test" });
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+  it("requires model selection when auth exists but no current model is usable", async () => {
+    const { modelRegistry } = await createTestModelRuntime({
+      anthropic: { type: "api_key", key: "sk-ant-test" },
+    });
 
     expect(getLlmSetupRequirement({ model: undefined, modelRegistry })).toBe("select_model");
   });
@@ -65,13 +64,13 @@ describe("OpenCandle setup", () => {
     globalThis.fetch = vi.fn(
       async () => new Response("Forbidden", { status: 403 }),
     ) as unknown as typeof fetch;
-    const authStorage = AuthStorage.inMemory();
+    const { credentials, modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi({ input: vi.fn().mockResolvedValue("bad-key") });
-    const ctx = { ui, modelRegistry: ModelRegistry.inMemory(authStorage) };
+    const ctx = { ui, modelRegistry };
 
-    await expect(runApiKeySetup(ctx as any, "openai")).resolves.toBe(false);
+    await expect(runApiKeySetup(ctx as any, "openai", modelRuntime)).resolves.toBe(false);
 
-    expect(authStorage.get("openai")).toBeUndefined();
+    expect(await credentials.read("openai")).toBeUndefined();
     expect(ui.notify).toHaveBeenCalledWith(
       "Key was rejected by OpenAI. Paste a different key.",
       "error",
@@ -82,8 +81,7 @@ describe("OpenCandle setup", () => {
     // 14.1 — with a defaultModelId that's available in getAvailable(), setModel should be
     // called exactly once without the model picker opening. The UI should receive only two
     // `select` calls total (choose entry method, choose provider).
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { credentials, modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi();
     ui.select.mockResolvedValueOnce("Paste API key").mockResolvedValueOnce("Google Gemini API");
     ui.input.mockResolvedValueOnce("test-google-key");
@@ -97,10 +95,15 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    const result = await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "manual" });
+    const result = await runOpenCandleSetup(
+      { setModel } as any,
+      ctx as any,
+      { mode: "manual" },
+      modelRuntime,
+    );
 
     expect(result).toBe("ready");
-    expect(authStorage.get("google")).toEqual({ type: "api_key", key: "test-google-key" });
+    expect(await credentials.read("google")).toEqual({ type: "api_key", key: "test-google-key" });
     expect(setModel).toHaveBeenCalledTimes(1);
     const activated = setModel.mock.calls[0]?.[0];
     expect(activated?.provider).toBe("google");
@@ -113,10 +116,9 @@ describe("OpenCandle setup", () => {
     // 14.2 — if the registry lookup for (provider, defaultModelId) fails, the existing
     // picker path should still open. We force this by registering a fake provider that
     // has no default in our DEFAULT_LLM_MODELS map.
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { credentials, modelRuntime, modelRegistry } = await createTestModelRuntime();
     // Register a throwaway provider with a single model whose id is NOT in our defaults.
-    modelRegistry.registerProvider("custom-llm", {
+    modelRuntime.registerProvider("custom-llm", {
       api: "openai-completions",
       baseUrl: "https://example.test/v1",
       apiKey: "fake",
@@ -132,8 +134,8 @@ describe("OpenCandle setup", () => {
         },
       ],
     });
-    authStorage.set("custom-llm" as any, { type: "api_key", key: "fake" });
-    modelRegistry.refresh();
+    await credentials.modify("custom-llm", async () => ({ type: "api_key", key: "fake" }));
+    await modelRuntime.refresh({ allowNetwork: false });
 
     const ui = createUi();
     // Directly invoke the picker path by starting from the "select_model" requirement.
@@ -148,7 +150,12 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    const result = await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "startup" });
+    const result = await runOpenCandleSetup(
+      { setModel } as any,
+      ctx as any,
+      { mode: "startup" },
+      modelRuntime,
+    );
 
     expect(result).toBe("ready");
     expect(setModel).toHaveBeenCalledTimes(1);
@@ -160,8 +167,7 @@ describe("OpenCandle setup", () => {
     // 14.3 — regression guard: after the finance-setup phase was removed, startup with
     // no model configured must not emit any data-provider picker. The first select call
     // must be the LLM entry-method picker.
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi({ select: vi.fn().mockResolvedValue("Exit setup") });
     const ctx = {
       hasUI: true,
@@ -171,7 +177,12 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    await runOpenCandleSetup({ setModel: vi.fn() } as any, ctx as any, { mode: "startup" });
+    await runOpenCandleSetup(
+      { setModel: vi.fn() } as any,
+      ctx as any,
+      { mode: "startup" },
+      modelRuntime,
+    );
 
     // The first select call should be the LLM entry-method question.
     const firstSelectCall = ui.select.mock.calls[0];
@@ -188,9 +199,9 @@ describe("OpenCandle setup", () => {
   it("subsequent startup with LLM already configured shows zero setup screens", async () => {
     // 14.4 — when getLlmSetupRequirement returns "ready" and mode === "startup",
     // runOpenCandleSetup should short-circuit without touching ctx.ui at all.
-    const authStorage = AuthStorage.inMemory();
-    authStorage.set("google", { type: "api_key", key: "pre-existing" });
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { modelRuntime, modelRegistry } = await createTestModelRuntime({
+      google: { type: "api_key", key: "pre-existing" },
+    });
     const models = modelRegistry.getAvailable();
     const seeded = models.find((m) => m.provider === "google" && m.id === "gemini-2.5-flash");
     expect(seeded).toBeDefined();
@@ -205,7 +216,12 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    const result = await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "startup" });
+    const result = await runOpenCandleSetup(
+      { setModel } as any,
+      ctx as any,
+      { mode: "startup" },
+      modelRuntime,
+    );
 
     expect(result).toBe("ready");
     expect(ui.select).not.toHaveBeenCalled();
@@ -219,8 +235,7 @@ describe("OpenCandle setup", () => {
     // LoginDialogComponent (which is instantiated inside ctx.ui.custom). The copy
     // surfaced to the user must reference OpenCandle so users understand where
     // the key is stored.
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi();
     ui.select.mockResolvedValueOnce("Paste API key").mockResolvedValueOnce("Anthropic API");
     ui.input.mockResolvedValueOnce("sk-ant-test-abc");
@@ -234,7 +249,12 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    const result = await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "manual" });
+    const result = await runOpenCandleSetup(
+      { setModel } as any,
+      ctx as any,
+      { mode: "manual" },
+      modelRuntime,
+    );
 
     expect(result).toBe("ready");
     // 15.1 — LoginDialogComponent is only invoked via ctx.ui.custom. API-key path
@@ -251,8 +271,7 @@ describe("OpenCandle setup", () => {
   it("does not call ctx.ui.setHeader or setStatus anywhere in the setup flow", async () => {
     // 15.5 — renderSetupHeader / setSetupChrome / clearSetupChrome were deleted,
     // so the UI surface should never receive a header or a per-setup status string.
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi();
     ui.select.mockResolvedValueOnce("Paste API key").mockResolvedValueOnce("Google Gemini API");
     ui.input.mockResolvedValueOnce("test-google-key-2");
@@ -266,15 +285,14 @@ describe("OpenCandle setup", () => {
       shutdown: vi.fn(),
     };
 
-    await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "manual" });
+    await runOpenCandleSetup({ setModel } as any, ctx as any, { mode: "manual" }, modelRuntime);
 
     expect(ui.setHeader).not.toHaveBeenCalled();
     expect(ui.setStatus).not.toHaveBeenCalled();
   });
 
   it("exits startup setup cleanly when the user declines LLM setup", async () => {
-    const authStorage = AuthStorage.inMemory();
-    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    const { modelRuntime, modelRegistry } = await createTestModelRuntime();
     const ui = createUi({ select: vi.fn().mockResolvedValue("Exit setup") });
     const shutdown = vi.fn();
     const ctx = {
@@ -285,9 +303,12 @@ describe("OpenCandle setup", () => {
       shutdown,
     };
 
-    const result = await runOpenCandleSetup({ setModel: vi.fn() } as any, ctx as any, {
-      mode: "startup",
-    });
+    const result = await runOpenCandleSetup(
+      { setModel: vi.fn() } as any,
+      ctx as any,
+      { mode: "startup" },
+      modelRuntime,
+    );
 
     expect(result).toBe("shutdown");
     expect(shutdown).toHaveBeenCalled();

--- a/tests/unit/providers/lse.test.ts
+++ b/tests/unit/providers/lse.test.ts
@@ -107,25 +107,26 @@ describe("LSE provider", () => {
     );
   });
 
-  it.each([
-    401, 403,
-  ])("throws a stale credential error before serving stale cache on %i", async (status) => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-16T12:00:00Z"));
-    rateLimiter.configure("lse", 100, 1.66);
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse(candlesFixture))
-      .mockResolvedValueOnce(jsonResponse({ detail: "Invalid API key" }, status));
-    vi.stubGlobal("fetch", fetchMock);
+  it.each([401, 403])(
+    "throws a stale credential error before serving stale cache on %i",
+    async (status) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-16T12:00:00Z"));
+      rateLimiter.configure("lse", 100, 1.66);
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(candlesFixture))
+        .mockResolvedValueOnce(jsonResponse({ detail: "Invalid API key" }, status));
+      vi.stubGlobal("fetch", fetchMock);
 
-    await getLseCandles("AAPL", "1d");
-    vi.setSystemTime(new Date("2026-07-16T13:00:00.001Z"));
+      await getLseCandles("AAPL", "1d");
+      vi.setSystemTime(new Date("2026-07-16T13:00:00.001Z"));
 
-    const error = await getLseCandles("AAPL", "1d").catch((caught: unknown) => caught);
-    expect(error).toBeInstanceOf(ProviderCredentialError);
-    expect(error).toMatchObject({ provider: "lse", reason: "stale", httpStatus: status });
-  });
+      const error = await getLseCandles("AAPL", "1d").catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(ProviderCredentialError);
+      expect(error).toMatchObject({ provider: "lse", reason: "stale", httpStatus: status });
+    },
+  );
 
   it("fails before fetching when the API key is missing", async () => {
     mockedGetConfig.mockReturnValue({});

--- a/website/package.json
+++ b/website/package.json
@@ -26,8 +26,8 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
     "autoprefixer": "^10.5.4",
-    "postcss": "^8.5.16",
-    "tailwindcss": "^4.3.1",
+    "postcss": "^8.5.20",
+    "tailwindcss": "^4.3.3",
     "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -23,9 +23,9 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.3.2",
+    "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
-    "autoprefixer": "^10.5.2",
+    "autoprefixer": "^10.5.4",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.1",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
Integrates all six open Dependabot updates, upgrades every remaining workspace dependency, migrates OpenCandle to the Pi 0.80.10 model runtime API, and refreshes formatter output.\n\nVerified locally:\n- npm test (2,921 passed, 1 skipped)\n- npm run lint\n- npx tsc --noEmit\n- npm run test:scripts:typecheck\n- npm run test:agent-tools\n- npm run build\n- npm run gui:web:build\n- npm run docs:site:build\n- npm audit (0 vulnerabilities)\n- agent-browser audit: 6 GUI routes + 15 docs pages, desktop/mobile\n\nLive TUI harness and harness-dcf reached the runtime but were credential-gated because no LLM key is configured in this environment.