### PR TITLE
fix: address PR #128 review and gate Codex feedback

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  statuses: write
 
 jobs:
   gate:
@@ -30,6 +31,20 @@ jobs:
             const pull_number = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
             const botLogin = "chatgpt-codex-connector[bot]";
+            const statusContext = "Codex review gate";
+            const targetUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const publishStatus = (state, description) =>
+              github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha: headSha,
+                state,
+                context: statusContext,
+                description,
+                target_url: targetUrl,
+              });
+
+            await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
             const request = await github.rest.issues.createComment({
               owner,
@@ -53,6 +68,7 @@ jobs:
                   ["COMMENTED", "APPROVED"].includes(review.state),
               );
               if (currentReview) {
+                await publishStatus("success", "Codex reviewed the current PR head");
                 core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
                 return;
               }
@@ -73,6 +89,7 @@ jobs:
                   Date.parse(reaction.created_at) >= requestedAt,
               );
               if (cleanReviewReaction) {
+                await publishStatus("success", "Codex returned a clean review for the current PR head");
                 core.notice(`Codex returned a clean review for current head ${headSha}.`);
                 return;
               }
@@ -82,4 +99,5 @@ jobs:
               }
             }
 
+            await publishStatus("failure", "Codex review timed out for the current PR head");
             core.setFailed(`Codex did not review current head ${headSha} within 25 minutes.`);

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -46,7 +46,7 @@ jobs:
 
             await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
-            await github.rest.issues.createComment({
+            const request = await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pull_number,
@@ -68,6 +68,31 @@ jobs:
               if (currentReview) {
                 await publishStatus("success", "Codex reviewed the current PR head");
                 core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
+                return;
+              }
+
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssueComment,
+                {
+                  owner,
+                  repo,
+                  comment_id: request.data.id,
+                  per_page: 100,
+                },
+              );
+              const acknowledgement = reactions.find(
+                (reaction) => reaction.user?.login === botLogin && reaction.content === "eyes",
+              );
+              const cleanCompletion = reactions.find(
+                (reaction) =>
+                  reaction.user?.login === botLogin &&
+                  reaction.content === "+1" &&
+                  acknowledgement &&
+                  Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at),
+              );
+              if (cleanCompletion) {
+                await publishStatus("success", "Codex completed a clean review of the current PR head");
+                core.notice(`Codex returned a clean review for current head ${headSha}.`);
                 return;
               }
 

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -94,6 +94,27 @@ jobs:
                 return;
               }
 
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssueComment,
+                {
+                  owner,
+                  repo,
+                  comment_id: request.data.id,
+                  per_page: 100,
+                },
+              );
+              const cleanReaction = reactions.find(
+                (reaction) =>
+                  reaction.user?.login === botLogin &&
+                  reaction.content === "+1" &&
+                  Date.parse(reaction.created_at) >= requestedAt,
+              );
+              if (cleanReaction) {
+                await publishStatus("success", "Codex completed a clean review of the current PR head");
+                core.notice(`Codex returned a clean review reaction for current head ${headSha}.`);
+                return;
+              }
+
               if (attempt < 50) {
                 await new Promise((resolve) => setTimeout(resolve, 30000));
               }

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -46,7 +46,7 @@ jobs:
 
             await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
-            const request = await github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pull_number,
@@ -68,31 +68,6 @@ jobs:
               if (currentReview) {
                 await publishStatus("success", "Codex reviewed the current PR head");
                 core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
-                return;
-              }
-
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssueComment,
-                {
-                  owner,
-                  repo,
-                  comment_id: request.data.id,
-                  per_page: 100,
-                },
-              );
-              const acknowledgement = reactions.find(
-                (reaction) => reaction.user?.login === botLogin && reaction.content === "eyes",
-              );
-              const cleanCompletion = reactions.find(
-                (reaction) =>
-                  reaction.user?.login === botLogin &&
-                  reaction.content === "+1" &&
-                  acknowledgement &&
-                  Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at),
-              );
-              if (cleanCompletion) {
-                await publishStatus("success", "Codex completed a clean review of the current PR head");
-                core.notice(`Codex returned a clean review for current head ${headSha}.`);
                 return;
               }
 

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -46,14 +46,12 @@ jobs:
 
             await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
-            const request = await github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pull_number,
               body: `@codex review\n\nAutomated merge-gate review request for head \`${headSha}\`.`,
             });
-            const requestedAt = Date.parse(request.data.created_at);
-
             for (let attempt = 1; attempt <= 50; attempt += 1) {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
@@ -70,27 +68,6 @@ jobs:
               if (currentReview) {
                 await publishStatus("success", "Codex reviewed the current PR head");
                 core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
-                return;
-              }
-
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssueComment,
-                {
-                  owner,
-                  repo,
-                  comment_id: request.data.id,
-                  per_page: 100,
-                },
-              );
-              const cleanReviewReaction = reactions.find(
-                (reaction) =>
-                  reaction.user?.login === botLogin &&
-                  reaction.content === "+1" &&
-                  Date.parse(reaction.created_at) >= requestedAt,
-              );
-              if (cleanReviewReaction) {
-                await publishStatus("success", "Codex returned a clean review for the current PR head");
-                core.notice(`Codex returned a clean review for current head ${headSha}.`);
                 return;
               }
 

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -46,7 +46,7 @@ jobs:
 
             await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
-            await github.rest.issues.createComment({
+            const request = await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pull_number,
@@ -68,6 +68,35 @@ jobs:
               if (currentReview) {
                 await publishStatus("success", "Codex reviewed the current PR head");
                 core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
+                return;
+              }
+
+              // In this repository the connector acknowledges with `eyes` and
+              // completes a no-findings review with a later `+1`. Requiring
+              // that ordering on this SHA-stamped request prevents an
+              // acknowledgement alone from satisfying the head status.
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssueComment,
+                {
+                  owner,
+                  repo,
+                  comment_id: request.data.id,
+                  per_page: 100,
+                },
+              );
+              const acknowledgement = reactions.find(
+                (reaction) => reaction.user?.login === botLogin && reaction.content === "eyes",
+              );
+              const cleanCompletion = reactions.find(
+                (reaction) =>
+                  reaction.user?.login === botLogin &&
+                  reaction.content === "+1" &&
+                  acknowledgement &&
+                  Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at),
+              );
+              if (cleanCompletion) {
+                await publishStatus("success", "Codex completed a clean review of the current PR head");
+                core.notice(`Codex returned a clean review for current head ${headSha}.`);
                 return;
               }
 

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -78,13 +78,15 @@ jobs:
                 issue_number: pull_number,
                 per_page: 100,
               });
-              const reviewedHeadMarker = `Reviewed commit:** \`${headSha.slice(0, 10)}\``;
+              const reviewedHeadPattern = new RegExp(
+                "(?:\\*\\*)?Reviewed commit:(?:\\*\\*)?\\s+`" + headSha.slice(0, 10) + "`",
+              );
               const cleanCompletion = issueComments.find(
                 (comment) =>
                   comment.user?.login === botLogin &&
                   Date.parse(comment.created_at) >= requestedAt &&
                   comment.body?.includes("Codex Review: Didn't find any major issues") &&
-                  comment.body.includes(reviewedHeadMarker),
+                  reviewedHeadPattern.test(comment.body),
               );
               if (cleanCompletion) {
                 await publishStatus("success", "Codex completed a clean review of the current PR head");

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,85 @@
+name: Codex review
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Codex review gate
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Request and await a Codex review of the current head
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+            const botLogin = "chatgpt-codex-connector[bot]";
+
+            const request = await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body: `@codex review\n\nAutomated merge-gate review request for head \`${headSha}\`.`,
+            });
+            const requestedAt = Date.parse(request.data.created_at);
+
+            for (let attempt = 1; attempt <= 50; attempt += 1) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              });
+              const currentReview = reviews.find(
+                (review) =>
+                  review.user?.login === botLogin &&
+                  review.commit_id === headSha &&
+                  ["COMMENTED", "APPROVED"].includes(review.state),
+              );
+              if (currentReview) {
+                core.notice(`Codex reviewed current head ${headSha} with state ${currentReview.state}.`);
+                return;
+              }
+
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssueComment,
+                {
+                  owner,
+                  repo,
+                  comment_id: request.data.id,
+                  per_page: 100,
+                },
+              );
+              const cleanReviewReaction = reactions.find(
+                (reaction) =>
+                  reaction.user?.login === botLogin &&
+                  reaction.content === "+1" &&
+                  Date.parse(reaction.created_at) >= requestedAt,
+              );
+              if (cleanReviewReaction) {
+                core.notice(`Codex returned a clean review for current head ${headSha}.`);
+                return;
+              }
+
+              if (attempt < 50) {
+                await new Promise((resolve) => setTimeout(resolve, 30000));
+              }
+            }
+
+            core.setFailed(`Codex did not review current head ${headSha} within 25 minutes.`);

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -52,6 +52,7 @@ jobs:
               issue_number: pull_number,
               body: `@codex review\n\nAutomated merge-gate review request for head \`${headSha}\`.`,
             });
+            const requestedAt = Date.parse(request.data.created_at);
             for (let attempt = 1; attempt <= 50; attempt += 1) {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
@@ -71,28 +72,19 @@ jobs:
                 return;
               }
 
-              // In this repository the connector acknowledges with `eyes` and
-              // completes a no-findings review with a later `+1`. Requiring
-              // that ordering on this SHA-stamped request prevents an
-              // acknowledgement alone from satisfying the head status.
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssueComment,
-                {
-                  owner,
-                  repo,
-                  comment_id: request.data.id,
-                  per_page: 100,
-                },
-              );
-              const acknowledgement = reactions.find(
-                (reaction) => reaction.user?.login === botLogin && reaction.content === "eyes",
-              );
-              const cleanCompletion = reactions.find(
-                (reaction) =>
-                  reaction.user?.login === botLogin &&
-                  reaction.content === "+1" &&
-                  acknowledgement &&
-                  Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at),
+              const issueComments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull_number,
+                per_page: 100,
+              });
+              const reviewedHeadMarker = `Reviewed commit:** \`${headSha.slice(0, 10)}\``;
+              const cleanCompletion = issueComments.find(
+                (comment) =>
+                  comment.user?.login === botLogin &&
+                  Date.parse(comment.created_at) >= requestedAt &&
+                  comment.body?.includes("Codex Review: Didn't find any major issues") &&
+                  comment.body.includes(reviewedHeadMarker),
               );
               if (cleanCompletion) {
                 await publishStatus("success", "Codex completed a clean review of the current PR head");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 
+- Pull requests now request and await an asynchronous Codex review for every head commit; the head-specific gate is designed to be required alongside CI and unresolved-conversation protection.
 - The README and public docs were refreshed for the recent chart, symbol-page, dashboard, and provider work: one 67-second launch video (hosted on GitHub's CDN) replaces the two 0.11-era demo clips in the README and is embedded on the docs-site homepage, the GUI quickstart documents the market dashboard home, symbol pages, chat charts, and sparklines with live screenshots, and London Strategic Edge setup and coverage now appear across the README, Data Sources, Configuration, Getting Started, and `/connect` docs. The retired demo MP4/poster assets were removed from the repo tree (release-tag-pinned CDN links keep serving them for old release READMEs).
 - The GUI dashboard and saved-market pages now use friendly index names, natural default-watchlist prompts, a balanced home grid, creation-first alert actions, an accessible token-colored portfolio donut, compact watchlist session details, aligned expandable holdings, a simplified watchlist tab, a mobile inspector sheet, human-readable report timestamps, and collision-safe notifications.
 - GUI interaction patterns are now consistent across pages: cards use shared header/divider anatomy and concentric radii; controls have named 40px touch targets, visible keyboard focus, and press feedback; dialogs, sheets, menus, and changing quotes use quick directional motion that respects reduced-motion preferences. Session threads also keep workflow orchestration out of user bubbles while retaining it in compact step cards, with readable synthesis spacing and a non-overlapping Latest control.
@@ -27,6 +28,7 @@
 
 ### Fixed
 
+- Saved GUI sessions and first-run TUI setup now share the migrated Pi model runtime, and GUI model refreshes finish before broadcasting and returning the refreshed setup state.
 - The public docs external-link check now retries transient network failures and records still-unreachable hosts (DNS/TLS/timeout) as non-blocking skips instead of build failures, so an external outage such as a `polymarket.com` fetch timeout no longer reds CI; a genuine HTTP error status (for example 404) still fails the gate. Retry count and delay are configurable via `OPENCANDLE_LINK_CHECK_ATTEMPTS`/`OPENCANDLE_LINK_CHECK_RETRY_DELAY_MS`.
 - GUI alert details now explain edge-triggered price states, Analyzing previews flatten markdown, non-FX instrument searches demote FX crosses, and non-indexed price charts clamp to their data ranges with axis-label breathing room.
 - Persisted GUI workflow transcripts now retain the final validation prompt as a structured step, label only the marker-bounded analyst prompt with its analyst stage, lazy-load portfolio allocation charts, preserve fractional holding quantities, clear stale range data during history refreshes, and expose correlation matrix row headers to assistive technology.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Fixed
 
-- Saved GUI sessions and first-run TUI setup now share the migrated Pi model runtime, and GUI model refreshes finish before broadcasting and returning the refreshed setup state.
+- Saved GUI sessions and first-run TUI setup now share the migrated Pi model runtime, and HTTP and WebSocket model refreshes finish before broadcasting and returning the refreshed setup state.
 - The public docs external-link check now retries transient network failures and records still-unreachable hosts (DNS/TLS/timeout) as non-blocking skips instead of build failures, so an external outage such as a `polymarket.com` fetch timeout no longer reds CI; a genuine HTTP error status (for example 404) still fails the gate. Retry count and delay are configurable via `OPENCANDLE_LINK_CHECK_ATTEMPTS`/`OPENCANDLE_LINK_CHECK_RETRY_DELAY_MS`.
 - GUI alert details now explain edge-triggered price states, Analyzing previews flatten markdown, non-FX instrument searches demote FX crosses, and non-indexed price charts clamp to their data ranges with axis-label breathing room.
 - Persisted GUI workflow transcripts now retain the final validation prompt as a structured step, label only the marker-bounded analyst prompt with its analyst stage, lazy-load portfolio allocation charts, preserve fractional holding quantities, clear stale range data during history refreshes, and expose correlation matrix row headers to assistive technology.

--- a/gui/server/http-routes.ts
+++ b/gui/server/http-routes.ts
@@ -173,9 +173,10 @@ export function createHttpRequestHandler(options: GuiHttpRouteOptions) {
 
     if (url.pathname === "/api/model-setup/refresh" && req.method === "POST") {
       if (!allowTrustedGuiRequest(req, res, "Model setup API", options)) return;
-      void options.getSession().modelRuntime.refresh();
-      options.wsHub.broadcastModelSetup();
-      writeJson(res, await options.wsHub.buildBootstrapPayload());
+      await handleTrustedGuiMutation(req, res, options, async () => {
+        await options.getSession().modelRuntime.refresh();
+        options.wsHub.broadcastModelSetup();
+      });
       return;
     }
 

--- a/gui/server/server.ts
+++ b/gui/server/server.ts
@@ -234,8 +234,7 @@ const httpRequestHandler = createHttpRequestHandler({
     createOpenCandleSession({
       cwd,
       agentDir,
-      authStorage,
-      modelRegistry,
+      modelRuntime,
       settingsManager,
       sessionManager: targetSessionManager,
       askUserHandler: askUserBridge.askForSession(targetSessionManager.getSessionId()),

--- a/gui/server/ws-hub.ts
+++ b/gui/server/ws-hub.ts
@@ -138,7 +138,7 @@ export function createWsHub({
           client.send({ type: "catalog", catalog: buildCatalog() });
           break;
         case "model.setup.refresh":
-          void getSession().modelRuntime.refresh();
+          await getSession().modelRuntime.refresh();
           broadcastModelSetup();
           break;
         case "model.setup.save_api_key":

--- a/src/pi/opencandle-extension.ts
+++ b/src/pi/opencandle-extension.ts
@@ -252,7 +252,7 @@ export default function openCandleExtension(
     // reinjects as a `role:"user"` message every turn).
     ctx.ui.setStatus("opencandle-disclaimer", DISCLAIMER_TEXT);
 
-    const result = await coordinator.runSetup(pi, ctx, { mode: "startup" });
+    const result = await coordinator.runSetup(pi, ctx, { mode: "startup" }, options?.modelRuntime);
     if (result === "shutdown") {
       return;
     }

--- a/tests/unit/gui-server/server-route-guards.test.ts
+++ b/tests/unit/gui-server/server-route-guards.test.ts
@@ -266,6 +266,33 @@ describe("GUI server route guards", () => {
     );
   });
 
+  it("reuses the shared model runtime for saved GUI sessions", () => {
+    const source = readFileSync(resolve("gui/server/server.ts"), "utf-8");
+    const factoryStart = source.indexOf("createSessionForManager:");
+    const factoryEnd = source.indexOf("wsHub,", factoryStart);
+    const factorySource = source.slice(factoryStart, factoryEnd);
+
+    expect(factorySource).toContain("modelRuntime,");
+    expect(factorySource).not.toContain("authStorage,");
+    expect(factorySource).not.toContain("modelRegistry,");
+  });
+
+  it("waits for a model refresh before broadcasting its result", () => {
+    const source = readFileSync(resolve("gui/server/http-routes.ts"), "utf-8");
+    const routeStart = source.indexOf('url.pathname === "/api/model-setup/refresh"');
+    const routeEnd = source.indexOf('url.pathname === "/api/model-setup/api-key"', routeStart);
+    const routeSource = source.slice(routeStart, routeEnd);
+
+    expect(routeSource).toContain(
+      "await handleTrustedGuiMutation(req, res, options, async () => {",
+    );
+    expect(routeSource).toContain("await options.getSession().modelRuntime.refresh();");
+    expect(routeSource.indexOf("await options.getSession().modelRuntime.refresh();")).toBeLessThan(
+      routeSource.indexOf("options.wsHub.broadcastModelSetup();"),
+    );
+    expect(routeSource).not.toContain("writeJson(res,");
+  });
+
   it("migrates current-session writer locks before broadcasting current run snapshots", () => {
     const source = readFileSync(resolve("gui/server/http-routes.ts"), "utf-8");
     const broadcastStart = source.indexOf("function broadcastRunSessionSnapshot");

--- a/tests/unit/gui-server/server-route-guards.test.ts
+++ b/tests/unit/gui-server/server-route-guards.test.ts
@@ -293,6 +293,18 @@ describe("GUI server route guards", () => {
     expect(routeSource).not.toContain("writeJson(res,");
   });
 
+  it("waits for WebSocket model refreshes before broadcasting their result", () => {
+    const source = readFileSync(resolve("gui/server/ws-hub.ts"), "utf-8");
+    const routeStart = source.indexOf('case "model.setup.refresh"');
+    const routeEnd = source.indexOf('case "model.setup.save_api_key"', routeStart);
+    const routeSource = source.slice(routeStart, routeEnd);
+
+    expect(routeSource).toContain("await getSession().modelRuntime.refresh();");
+    expect(routeSource.indexOf("await getSession().modelRuntime.refresh();")).toBeLessThan(
+      routeSource.indexOf("broadcastModelSetup();"),
+    );
+  });
+
   it("migrates current-session writer locks before broadcasting current run snapshots", () => {
     const source = readFileSync(resolve("gui/server/http-routes.ts"), "utf-8");
     const broadcastStart = source.indexOf("function broadcastRunSessionSnapshot");

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -30,11 +30,14 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain('await publishStatus("success"');
   });
 
-  it("requires a submitted Codex review rather than any reaction", () => {
+  it("requires a clean reaction to follow acknowledgement on the SHA-stamped request", () => {
     const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
 
     expect(source).toContain("github.rest.pulls.listReviews");
-    expect(source).not.toContain("listForIssueComment");
-    expect(source).not.toContain("cleanCompletion");
+    expect(source).toContain('reaction.content === "eyes"');
+    expect(source).toContain('reaction.content === "+1"');
+    expect(source).toContain(
+      "Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at)",
+    );
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -38,6 +38,8 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain("Codex Review: Didn't find any major issues");
     expect(source).toContain("(?:\\\\*\\\\*)?Reviewed commit:(?:\\\\*\\\\*)?\\\\s+`");
     expect(source).toContain("reviewedHeadPattern.test(comment.body)");
-    expect(source).not.toContain("listForIssueComment");
+    expect(source).toContain("github.rest.reactions.listForIssueComment");
+    expect(source).toContain('reaction.content === "+1"');
+    expect(source).not.toContain('reaction.content === "eyes"');
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Pi model runtime migration guards", () => {
+  it("passes the shared model runtime to startup setup", () => {
+    const source = readFileSync(resolve("src/pi/opencandle-extension.ts"), "utf-8");
+    const handlerStart = source.indexOf('pi.on("session_start"');
+    const handlerEnd = source.indexOf("// One-shot welcome", handlerStart);
+    const handlerSource = source.slice(handlerStart, handlerEnd);
+
+    expect(handlerSource).toMatch(
+      /coordinator\.runSetup\([\s\S]*?\{ mode: "startup" \},\s*options\?\.modelRuntime,?\s*\)/,
+    );
+  });
+
+  it("does not accept dismissed Codex reviews at the merge gate", () => {
+    const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
+
+    expect(source).toContain('["COMMENTED", "APPROVED"].includes(review.state)');
+    expect(source).not.toContain('review.state !== "PENDING"');
+  });
+});

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -29,4 +29,12 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain("context: statusContext,");
     expect(source).toContain('await publishStatus("success"');
   });
+
+  it("waits for a submitted Codex review instead of an acknowledgement reaction", () => {
+    const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
+
+    expect(source).toContain("github.rest.pulls.listReviews");
+    expect(source).not.toContain("listForIssueComment");
+    expect(source).not.toContain("cleanReviewReaction");
+  });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -30,14 +30,11 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain('await publishStatus("success"');
   });
 
-  it("does not treat Codex acknowledgement alone as a completed review", () => {
+  it("requires a submitted Codex review rather than any reaction", () => {
     const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
 
     expect(source).toContain("github.rest.pulls.listReviews");
-    expect(source).toContain('reaction.content === "eyes"');
-    expect(source).toContain('reaction.content === "+1"');
-    expect(source).toContain(
-      "Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at)",
-    );
+    expect(source).not.toContain("listForIssueComment");
+    expect(source).not.toContain("cleanCompletion");
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -20,4 +20,13 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain('["COMMENTED", "APPROVED"].includes(review.state)');
     expect(source).not.toContain('review.state !== "PENDING"');
   });
+
+  it("publishes the Codex gate result to the PR head commit", () => {
+    const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
+
+    expect(source).toContain("github.rest.repos.createCommitStatus({");
+    expect(source).toContain("sha: headSha,");
+    expect(source).toContain("context: statusContext,");
+    expect(source).toContain('await publishStatus("success"');
+  });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -30,14 +30,13 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain('await publishStatus("success"');
   });
 
-  it("requires a clean reaction to follow acknowledgement on the SHA-stamped request", () => {
+  it("requires a head-specific review artifact for clean Codex completion", () => {
     const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
 
     expect(source).toContain("github.rest.pulls.listReviews");
-    expect(source).toContain('reaction.content === "eyes"');
-    expect(source).toContain('reaction.content === "+1"');
-    expect(source).toContain(
-      "Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at)",
-    );
+    expect(source).toContain("github.rest.issues.listComments");
+    expect(source).toContain("Codex Review: Didn't find any major issues");
+    expect(source).toContain("comment.body.includes(reviewedHeadMarker)");
+    expect(source).not.toContain("listForIssueComment");
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -36,7 +36,8 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain("github.rest.pulls.listReviews");
     expect(source).toContain("github.rest.issues.listComments");
     expect(source).toContain("Codex Review: Didn't find any major issues");
-    expect(source).toContain("comment.body.includes(reviewedHeadMarker)");
+    expect(source).toContain("(?:\\\\*\\\\*)?Reviewed commit:(?:\\\\*\\\\*)?\\\\s+`");
+    expect(source).toContain("reviewedHeadPattern.test(comment.body)");
     expect(source).not.toContain("listForIssueComment");
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -30,11 +30,14 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain('await publishStatus("success"');
   });
 
-  it("waits for a submitted Codex review instead of an acknowledgement reaction", () => {
+  it("does not treat Codex acknowledgement alone as a completed review", () => {
     const source = readFileSync(resolve(".github/workflows/codex-review-gate.yml"), "utf-8");
 
     expect(source).toContain("github.rest.pulls.listReviews");
-    expect(source).not.toContain("listForIssueComment");
-    expect(source).not.toContain("cleanReviewReaction");
+    expect(source).toContain('reaction.content === "eyes"');
+    expect(source).toContain('reaction.content === "+1"');
+    expect(source).toContain(
+      "Date.parse(reaction.created_at) > Date.parse(acknowledgement.created_at)",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- address all three asynchronous Codex findings from #128
- await model refresh safely through the GUI mutation error boundary
- add a current-head Codex review gate and regression guards
- retain required CI and conversation resolution without a human approver requirement

## Verification
- `npm test` (2,925 passed, 1 skipped)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:gui:release-smoke` (6 passed)
- repo-local Codex autoreview: clean

Follow-up to #128.