### PR TITLE
fix(ci): grant Codex review gate pull-requests write for PR comments

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -12,7 +12,9 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  # write: commenting `@codex review` on a PR goes through the issues API,
+  # which requires pull-requests write when the target issue is a PR.
+  pull-requests: write
   statuses: write
 
 jobs:


### PR DESCRIPTION
## Summary

One-line permission fix: the Codex review gate 403s posting its `@codex review` comment because commenting on a PR via the issues API requires `pull-requests: write`; the workflow declared only `read`.

## Why

First live gate run (PR #130) failed before ever requesting a review, and the gate is a required check on main — every PR is blocked until this lands. Evidence: the gate's `statuses: write` call succeeded (so declared permissions are honored) while the comment POST returned 403 with `x-accepted-github-permissions: issues=write; pull_requests=write`; `issues: write` covers only non-PR issues.

## Validation

- [x] Focused check is enough: workflow-only change, no runtime code; validated against the failed run's API evidence (run 29698931320)
- [x] Docs updated if behavior or workflow changed (inline comment in the workflow)

Note: this PR cannot itself pass the gate it fixes (pull_request_target runs main's copy) — merging requires an admin bypass or temporarily lifting the required check.

## Risks / Follow-ups

Grants the gate workflow PR-write scope; it is comment-posting only and the script makes no other PR mutations.

## Issue / Discussion

Failed run: https://github.com/Kahtaf/OpenCandle/actions/runs/29698931320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzDzXfaweYDGnN7SdM3Y1
