### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -86,6 +86,33 @@ jobs:
                 return;
               }
 
+              const currentHeadRequests = issueComments.filter(
+                (comment) =>
+                  ["OWNER", "MEMBER", "COLLABORATOR"].includes(comment.author_association) &&
+                  comment.body?.includes("@codex review") &&
+                  comment.body?.includes(headSha.slice(0, 8)),
+              );
+              for (const request of currentHeadRequests) {
+                const reactions = await github.paginate(
+                  github.rest.reactions.listForIssueComment,
+                  {
+                    owner,
+                    repo,
+                    comment_id: request.id,
+                    per_page: 100,
+                  },
+                );
+                const cleanReaction = reactions.find(
+                  (reaction) =>
+                    reaction.user?.login === botLogin && reaction.content === "+1",
+                );
+                if (cleanReaction) {
+                  await publishStatus("success", "Codex completed a clean review of the current PR head");
+                  core.notice(`Codex returned a clean review reaction for current head ${headSha}.`);
+                  return;
+                }
+              }
+
               if (attempt < 50) {
                 await new Promise((resolve) => setTimeout(resolve, 30000));
               }

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -11,10 +11,8 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
-  # write: commenting `@codex review` on a PR goes through the issues API,
-  # which requires pull-requests write when the target issue is a PR.
-  pull-requests: write
+  issues: read
+  pull-requests: read
   statuses: write
 
 jobs:
@@ -24,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Request and await a Codex review of the current head
+      - name: Await a Codex review of the current head
         uses: actions/github-script@v8
         with:
           script: |
@@ -48,13 +46,6 @@ jobs:
 
             await publishStatus("pending", "Waiting for Codex to review the current PR head");
 
-            const request = await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pull_number,
-              body: `@codex review\n\nAutomated merge-gate review request for head \`${headSha}\`.`,
-            });
-            const requestedAt = Date.parse(request.data.created_at);
             for (let attempt = 1; attempt <= 50; attempt += 1) {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
@@ -86,34 +77,12 @@ jobs:
               const cleanCompletion = issueComments.find(
                 (comment) =>
                   comment.user?.login === botLogin &&
-                  Date.parse(comment.created_at) >= requestedAt &&
                   comment.body?.includes("Codex Review: Didn't find any major issues") &&
                   reviewedHeadPattern.test(comment.body),
               );
               if (cleanCompletion) {
                 await publishStatus("success", "Codex completed a clean review of the current PR head");
                 core.notice(`Codex returned a clean review for current head ${headSha}.`);
-                return;
-              }
-
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssueComment,
-                {
-                  owner,
-                  repo,
-                  comment_id: request.data.id,
-                  per_page: 100,
-                },
-              );
-              const cleanReaction = reactions.find(
-                (reaction) =>
-                  reaction.user?.login === botLogin &&
-                  reaction.content === "+1" &&
-                  Date.parse(reaction.created_at) >= requestedAt,
-              );
-              if (cleanReaction) {
-                await publishStatus("success", "Codex completed a clean review of the current PR head");
-                core.notice(`Codex returned a clean review reaction for current head ${headSha}.`);
                 return;
               }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-19
+
 ### Added
 
 - The GUI home empty state is now a market dashboard: a fixed indices strip (S&P 500, Nasdaq Composite, Dow Jones, Bitcoin) with sparklines served by a new guarded read-only `GET /api/market-state/indices` endpoint with stale-while-revalidate caching, watchlist top movers, a portfolio summary stat row with a derived intraday move, an alerts status card, and new-user affordance cards — all rendered below the composer, which keeps its fresh-session run flow and model-setup gating unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "workspaces": [
         "gui/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Open source financial investigator: evidence-first market research agent for your terminal and local GUI",
   "license": "MIT",
   "homepage": "https://opencandle.app",

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -39,6 +39,9 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain("(?:\\\\*\\\\*)?Reviewed commit:(?:\\\\*\\\\*)?\\\\s+`");
     expect(source).toContain("reviewedHeadPattern.test(comment.body)");
     expect(source).not.toContain("github.rest.issues.createComment");
-    expect(source).not.toContain("github.rest.reactions.listForIssueComment");
+    expect(source).toContain("github.rest.reactions.listForIssueComment");
+    expect(source).toContain('reaction.content === "+1"');
+    expect(source).toContain("comment.body?.includes(headSha.slice(0, 8))");
+    expect(source).not.toContain('reaction.content === "eyes"');
   });
 });

--- a/tests/unit/pi/model-runtime-migration-guards.test.ts
+++ b/tests/unit/pi/model-runtime-migration-guards.test.ts
@@ -38,8 +38,7 @@ describe("Pi model runtime migration guards", () => {
     expect(source).toContain("Codex Review: Didn't find any major issues");
     expect(source).toContain("(?:\\\\*\\\\*)?Reviewed commit:(?:\\\\*\\\\*)?\\\\s+`");
     expect(source).toContain("reviewedHeadPattern.test(comment.body)");
-    expect(source).toContain("github.rest.reactions.listForIssueComment");
-    expect(source).toContain('reaction.content === "+1"');
-    expect(source).not.toContain('reaction.content === "eyes"');
+    expect(source).not.toContain("github.rest.issues.createComment");
+    expect(source).not.toContain("github.rest.reactions.listForIssueComment");
   });
 });


### PR DESCRIPTION
## Release v0.13.0

Minor release containing the recent GUI market dashboard, symbol pages, shared charts, portfolio/watchlist improvements, responsive interaction polish, provider additions, documentation refresh, dependency migration, and Codex merge gate.

## Verification
- `npm run release:check`
- release eval reviewed: product 95.7% (14/15), frozen competitive 4/5 OpenCandle wins, corrected Gemini router-live 29/32, targeted Fear & Greed rerun passed
- current `main` CI and Pages green

After merge, tag `v0.13.0` will trigger npm publication and GitHub Release creation.