### PR TITLE
docs(website): polish public site and navigation

### DIFF
--- a/.hallmark/log.json
+++ b/.hallmark/log.json
@@ -1,0 +1,10 @@
+[
+  {
+    "date": "2026-07-26",
+    "scope": "app",
+    "macrostructure": "Workbench",
+    "theme": "OpenCandle Research Desk",
+    "enrichment": "H7 demo video",
+    "brief": "Impactful minimal homepage focused on product evidence"
+  }
+]

--- a/tests/unit/website/public-site-build.test.ts
+++ b/tests/unit/website/public-site-build.test.ts
@@ -118,6 +118,37 @@ describe("public site build contract", () => {
     }
   });
 
+  it("extends the desktop documentation sidebar surface to the viewport edge", async () => {
+    const docsHtml = await readFile(join(root, "website/dist/docs/index.html"), "utf8");
+    const docsDocument = new JSDOM(docsHtml, {
+      url: "https://opencandle.app/docs/index.html",
+    }).window.document;
+    const sidebar = docsDocument.querySelector("aside[data-docs-sidebar]");
+
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.classList.contains("docs-sidebar")).toBe(true);
+    expect(sidebar?.classList.contains("overflow-hidden")).toBe(false);
+    expect(sidebar?.querySelector('nav[aria-label="Documentation"]')).not.toBeNull();
+  });
+
+  it("extends the desktop table of contents surface to the viewport edge", async () => {
+    const docsHtml = await readFile(join(root, "website/dist/docs/index.html"), "utf8");
+    const docsDocument = new JSDOM(docsHtml, {
+      url: "https://opencandle.app/docs/index.html",
+    }).window.document;
+    const sidebar = docsDocument.querySelector("aside[data-docs-toc-sidebar]");
+    const nav = sidebar?.querySelector('nav[aria-label="On this page"]');
+    const firstLink = nav?.querySelector("a");
+
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.classList.contains("docs-toc-sidebar")).toBe(true);
+    expect(nav).not.toBeNull();
+    expect(nav?.parentElement?.classList.contains("px-3")).toBe(true);
+    expect(nav?.parentElement?.classList.contains("py-5")).toBe(true);
+    expect(firstLink?.classList.contains("hover:bg-tertiary")).toBe(true);
+    expect(firstLink?.classList.contains("hover:bg-secondary")).toBe(false);
+  });
+
   it("presents the GUI as primary and the TUI as equally complete across the docs journey", async () => {
     const overviewHtml = await readFile(join(root, "website/dist/docs/index.html"), "utf8");
     const gettingStartedHtml = await readFile(
@@ -139,16 +170,21 @@ describe("public site build contract", () => {
 
   it("does not keep the old decorative landing-page shell in generated output", async () => {
     const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
+    const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
 
     expect(homeHtml).not.toContain("hero-grid");
     expect(homeHtml).not.toContain("float-tile");
-    expect(homeHtml).toContain("Ask any market question.");
-    expect(homeHtml).toContain("Check every number.");
+    expect(homeDocument.querySelector(".landing-hero h1")?.textContent).toBe(
+      "Market research that shows its work.",
+    );
+    expect(homeHtml).not.toContain("Ask any market question.");
+    expect(homeHtml).not.toContain("Check every number.");
   });
 
   it("puts the install command and the free/local proof line in the hero", async () => {
     const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
     const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
+    const hero = homeDocument.querySelector(".landing-hero");
     const heroCommand = homeDocument.querySelector(".landing-hero [data-surface-command]");
 
     // The one-line install is the fastest path to value, so it must appear
@@ -156,9 +192,12 @@ describe("public site build contract", () => {
     expect(homeHtml.indexOf("npx opencandle@latest gui")).toBeLessThan(
       homeHtml.indexOf('data-surface-demo=""'),
     );
-    expect(homeHtml).toContain(
-      "MIT licensed · runs on your machine · no account · market data needs no keys",
+    expect(hero?.textContent).toContain(
+      "OpenCandle is an open source financial investigator. It fetches live quotes, filings, options, and macro data before answering, then shows where the result came from.",
     );
+    expect(hero?.textContent).toContain("Free and open source · runs locally · bring your own AI");
+    expect(hero?.textContent).not.toContain("core market data needs no key");
+    expect(hero?.textContent).not.toContain("no account");
     expect(homeHtml).not.toContain("local-first financial research workspace");
     expect(homeHtml).not.toContain("Start in the visual GUI");
     expect(heroCommand?.querySelector("code")?.textContent).toBe("npx opencandle@latest gui");
@@ -172,9 +211,16 @@ describe("public site build contract", () => {
   it("renders the homepage product journey and switchable product demos", async () => {
     const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
 
-    expect(homeHtml).toContain("The tools behind every answer");
-    expect(homeHtml).toContain("Ask. Gather. Verify.");
-    expect(homeHtml).toContain("Same question. Different evidence.");
+    expect(homeHtml).toContain("The best tools behind every answer.");
+    expect(homeHtml).toContain(
+      "OpenCandle picks the relevant sources for the question and keeps each one attached to the result.",
+    );
+    expect(homeHtml).not.toContain("Ask. Gather. Verify.");
+    expect(homeHtml).toContain("Same question.");
+    expect(homeHtml).toContain("Different results.");
+    expect(homeHtml).toContain(
+      "Why not ask another AI? OpenCandle can use live financial tools before it answers, so you get current numbers you can inspect.",
+    );
     expect(homeHtml).toContain('aria-label="OpenCandle terminal demonstration"');
     expect(homeHtml).toContain('data-cli-demo=""');
     expect(homeHtml).toContain('data-surface-demo=""');
@@ -185,7 +231,7 @@ describe("public site build contract", () => {
     expect(homeHtml).toContain('data-surface-video="gui"');
     expect(homeHtml.match(/controls=""/g)).toHaveLength(2);
     expect(homeHtml).toContain('data-legacy-cli-demo=""');
-    expect(homeHtml).toContain("equally complete terminal interface");
+    expect(homeHtml).toContain("It runs locally in a browser or terminal");
     expect(homeHtml.indexOf('data-surface-tab="gui"')).toBeLessThan(
       homeHtml.indexOf('data-surface-tab="tui"'),
     );
@@ -210,10 +256,90 @@ describe("public site build contract", () => {
     expect(homeHtml).toContain("Common questions");
   });
 
+  it("uses the same full footer on the homepage and docs pages", async () => {
+    const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
+    const docsHtml = await readFile(join(root, "website/dist/docs/index.html"), "utf8");
+    const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
+    const docsDocument = new JSDOM(docsHtml, {
+      url: "https://opencandle.app/docs/index.html",
+    }).window.document;
+    const homeFooter = homeDocument.querySelector(".site-footer");
+    const docsFooter = docsDocument.querySelector(".site-footer");
+
+    expect(homeFooter?.textContent.replace(/\s+/g, " ").trim()).toBe(
+      docsFooter?.textContent.replace(/\s+/g, " ").trim(),
+    );
+    expect(homeDocument.querySelector(".site-footer-minimal")).toBeNull();
+    expect(homeFooter?.textContent).toContain("Product");
+    expect(homeFooter?.textContent).toContain("Build");
+    expect(homeFooter?.textContent).toContain("Project");
+    expect(homeFooter?.textContent).toContain("Open source financial investigator.");
+    expect(homeFooter?.textContent).not.toContain("Local-first financial research");
+  });
+
+  it("renders both product videos as accessible sides of the hero switcher", async () => {
+    const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
+    const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
+    const demo = homeDocument.querySelector<HTMLElement>("[data-surface-demo]");
+    const flipper = demo?.querySelector("[data-surface-flipper]");
+    const browserPanel = flipper?.querySelector<HTMLElement>('[data-surface-panel="gui"]');
+    const cliPanel = flipper?.querySelector<HTMLElement>('[data-surface-panel="tui"]');
+
+    expect(demo?.dataset.surfaceActive).toBe("gui");
+    expect(flipper).not.toBeNull();
+    expect(flipper?.classList.contains("surface-demo-stage")).toBe(true);
+    expect(browserPanel?.getAttribute("aria-hidden")).toBe("false");
+    expect(browserPanel?.hasAttribute("inert")).toBe(false);
+    expect(cliPanel?.getAttribute("aria-hidden")).toBe("true");
+    expect(cliPanel?.hasAttribute("inert")).toBe(true);
+    expect(browserPanel?.hidden).toBe(false);
+    expect(cliPanel?.hidden).toBe(false);
+  });
+
+  it("keeps the expanded hero demo within the available desktop viewport gutter", async () => {
+    const siteCss = await readFile(join(root, "website/src/site.css"), "utf8");
+    const desktopHeroRule = siteCss.match(
+      /@media \(min-width: 60rem\)[\s\S]*?\.landing-hero-media\s*\{([\s\S]*?)\}/,
+    )?.[1];
+    const normalizedRule = desktopHeroRule
+      ?.replace(/\s+/g, " ")
+      .replace(/\(\s+/g, "(")
+      .replace(/\s+\)/g, ")")
+      .trim();
+
+    expect(normalizedRule).toContain(
+      "width: min(calc(100% + min(7vw, 6rem)), calc(100% + max(1.5rem, (100vw - 1320px) / 2 + 1.5rem)))",
+    );
+    expect(normalizedRule).not.toContain("width: calc(100% + min(7vw, 6rem))");
+  });
+
+  it("answers first-run and privacy questions without implementation jargon", async () => {
+    const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
+    const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
+    const faq = homeDocument.querySelector('[aria-label="FAQ"]');
+
+    expect(faq?.textContent).toContain("What do I need to get started?");
+    expect(faq?.textContent).toContain("Node.js");
+    expect(faq?.textContent).toContain("Where is my data stored?");
+    expect(faq?.textContent).toContain(
+      "Watchlists, portfolios, alerts, and sessions are stored on your machine.",
+    );
+    expect(faq?.textContent).toContain(
+      "Questions and research context are sent to the model provider you choose.",
+    );
+    expect(faq?.textContent).not.toContain("bundled Pi agent runtime");
+    expect(faq?.textContent).not.toContain("typed finance tools");
+    expect(faq?.textContent).not.toContain("Which data sources does OpenCandle use?");
+  });
+
   it("keeps the homepage focused on product evidence instead of decorative filler", async () => {
     const homeHtml = await readFile(join(root, "website/dist/index.html"), "utf8");
     const homeDocument = new JSDOM(homeHtml, { url: "https://opencandle.app/" }).window.document;
     const guiTab = homeDocument.querySelector("#surface-tab-gui");
+    const hero = homeDocument.querySelector(".landing-hero");
+    const evidenceMap = homeDocument.querySelector(".evidence-map");
+    const comparison = homeDocument.querySelector(".answer-comparison");
+    const faq = homeDocument.querySelector('[aria-label="FAQ"]');
 
     expect(homeHtml).not.toContain(">Local-first<");
     expect(homeHtml).not.toContain("One engine. Two complete interfaces.");
@@ -225,19 +351,35 @@ describe("public site build contract", () => {
     expect(homeHtml).not.toContain('class="landing-eyebrow"');
     expect(guiTab?.querySelector(".surface-demo-tab-icon")).toBeNull();
     expect(guiTab?.firstElementChild?.tagName).toBe("svg");
-    expect(homeHtml).toContain("Same question. Different evidence.");
+    expect(homeHtml).toContain("Same question.");
+    expect(homeHtml).toContain("Different results.");
     expect(homeHtml).toContain('data-answer-surface="chatgpt"');
     expect(homeHtml).toContain('data-answer-surface="claude"');
     expect(homeHtml).toContain('data-answer-surface="opencandle"');
     expect(homeHtml).not.toContain("Why not just ask a chatbot?");
     expect(homeHtml).not.toContain("Research in the browser or the terminal");
     expect(homeHtml).not.toContain("twitterSentimentTool");
-    expect(homeHtml).toContain('class="extension-path"');
+    expect(hero?.querySelector("[data-surface-command]")).not.toBeNull();
+    expect(hero?.querySelector("[data-surface-demo]")).not.toBeNull();
+    expect(evidenceMap).not.toBeNull();
+    expect(comparison).not.toBeNull();
+    expect(faq).not.toBeNull();
+    expect(homeHtml).not.toContain("Ask. Gather. Verify.");
+    expect(homeHtml).not.toContain('class="research-steps"');
+    expect(homeHtml).not.toContain('class="builder-section');
+    expect(homeHtml).not.toContain('class="extension-path"');
+    expect(homeHtml).not.toContain('aria-label="Start locally"');
     expect(homeHtml).not.toContain("See the first run");
     expect(homeHtml).not.toContain("MIT licensed · Node.js");
     expect(homeHtml).not.toContain("MIT licensed · read-only");
-    expect(homeHtml.indexOf('aria-label="FAQ"')).toBeLessThan(
-      homeHtml.indexOf('aria-label="Start locally"'),
+    expect(homeHtml.indexOf('class="landing-hero')).toBeLessThan(
+      homeHtml.indexOf('class="evidence-map"'),
+    );
+    expect(homeHtml.indexOf('class="evidence-map"')).toBeLessThan(
+      homeHtml.indexOf('class="answer-comparison'),
+    );
+    expect(homeHtml.indexOf('class="answer-comparison')).toBeLessThan(
+      homeHtml.indexOf('aria-label="FAQ"'),
     );
   });
 
@@ -258,6 +400,7 @@ describe("public site build contract", () => {
     expect(tabs[0]?.querySelector('[data-brand-icon="chatgpt"]')).not.toBeNull();
     expect(tabs[1]?.querySelector('[data-brand-icon="claude"]')).not.toBeNull();
     expect(tabs[2]?.querySelector('img[src="assets/logo.svg"]')).not.toBeNull();
+    expect(tabs.every((tab) => !tab.hasAttribute("data-featured"))).toBe(true);
     expect(tabs[0]?.textContent).not.toContain("✣");
     expect(tabs[1]?.textContent).not.toContain("✳");
     expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
@@ -369,16 +512,18 @@ describe("public site build contract", () => {
             <code data-surface-command-text>npx opencandle@latest gui</code>
             <button data-command-copy>Copy</button>
           </div>
-          <div data-surface-demo>
+          <div data-surface-demo data-surface-active="gui">
             <div role="tablist">
               <button data-surface-tab="gui" aria-selected="true" tabindex="0">Browser</button>
               <button data-surface-tab="tui" aria-selected="false" tabindex="-1">Terminal</button>
             </div>
-            <div data-surface-panel="gui">
-              <video data-surface-video="gui" src="gui.mp4"></video>
-            </div>
-            <div data-surface-panel="tui" hidden>
-              <video data-surface-video="tui" data-src="tui.mp4"></video>
+            <div data-surface-flipper>
+              <div data-surface-panel="gui" aria-hidden="false">
+                <video data-surface-video="gui" src="gui.mp4"></video>
+              </div>
+              <div data-surface-panel="tui" aria-hidden="true" inert>
+                <video data-surface-video="tui" data-src="tui.mp4"></video>
+              </div>
             </div>
           </div>
         </body>
@@ -427,6 +572,29 @@ describe("public site build contract", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(terminalTab?.getAttribute("aria-selected")).toBe("true");
     expect(dom.window.document.activeElement).toBe(terminalTab);
+    expect(
+      dom.window.document.querySelector<HTMLElement>("[data-surface-demo]")?.dataset.surfaceActive,
+    ).toBe("tui");
+    expect(
+      dom.window.document
+        .querySelector<HTMLElement>('[data-surface-panel="gui"]')
+        ?.getAttribute("aria-hidden"),
+    ).toBe("true");
+    expect(
+      dom.window.document
+        .querySelector<HTMLElement>('[data-surface-panel="tui"]')
+        ?.getAttribute("aria-hidden"),
+    ).toBe("false");
+    expect(
+      dom.window.document
+        .querySelector<HTMLElement>('[data-surface-panel="gui"]')
+        ?.hasAttribute("inert"),
+    ).toBe(true);
+    expect(
+      dom.window.document
+        .querySelector<HTMLElement>('[data-surface-panel="tui"]')
+        ?.hasAttribute("inert"),
+    ).toBe(false);
     expect(dom.window.document.querySelector("[data-surface-command-text]")?.textContent).toBe(
       "npx opencandle@latest",
     );

--- a/website/scripts/prerender.jsx
+++ b/website/scripts/prerender.jsx
@@ -430,7 +430,7 @@ function SiteFooter({ output = "index.html" }) {
             <span>OpenCandle</span>
           </a>
           <p className="mt-4 text-muted-foreground text-sm leading-relaxed">
-            Local-first financial research that gathers the live record and shows its evidence.
+            Open source financial investigator.
           </p>
           <p className="mt-5 font-mono text-muted-foreground text-xs">MIT licensed</p>
         </div>
@@ -585,7 +585,7 @@ function LegacyCliDemo() {
 
 function SurfaceDemo() {
   return (
-    <div className="surface-demo" data-surface-demo="">
+    <div className="surface-demo" data-surface-demo="" data-surface-active="gui">
       <div className="surface-demo-toolbar">
         <div
           className="surface-demo-tabs icon-tabs"
@@ -620,11 +620,13 @@ function SurfaceDemo() {
           </button>
         </div>
       </div>
-      <div className="surface-demo-stage">
+      <div className="surface-demo-stage surface-demo-flipper" data-surface-flipper="">
         <div
+          className="surface-demo-face surface-demo-face-gui"
           id="surface-panel-gui"
           role="tabpanel"
           aria-labelledby="surface-tab-gui"
+          aria-hidden="false"
           data-surface-panel="gui"
         >
           {/* This labeled product walkthrough is intentionally silent. */}
@@ -641,11 +643,13 @@ function SurfaceDemo() {
           />
         </div>
         <div
+          className="surface-demo-face surface-demo-face-tui"
           id="surface-panel-tui"
           role="tabpanel"
           aria-labelledby="surface-tab-tui"
+          aria-hidden="true"
           data-surface-panel="tui"
-          hidden
+          inert
         >
           {/* This labeled product walkthrough is intentionally silent. */}
           <video
@@ -763,7 +767,10 @@ function DocsShell({ page, children }) {
     <>
       <SiteHeader output={page.output} />
       <div className="mx-auto flex w-full max-w-[1320px]">
-        <aside className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] w-[260px] shrink-0 overflow-hidden border-border border-r bg-secondary md:block">
+        <aside
+          className="docs-sidebar sticky top-14 hidden h-[calc(100dvh-3.5rem)] w-[260px] shrink-0 border-border border-r bg-secondary md:block"
+          data-docs-sidebar=""
+        >
           <DocsNav activeOutput={page.output} />
         </aside>
         <div className="flex min-w-0 flex-1 flex-col">{children}</div>
@@ -1324,22 +1331,22 @@ function HomePage({ buildDate, version }) {
     {
       question: "What is OpenCandle?",
       answer:
-        "OpenCandle is an open source AI stock and market research tool that runs on your own machine. It is built around a local browser GUI, with an equally complete terminal interface for users who prefer a keyboard-first workflow.",
+        "OpenCandle is an open source AI research app for stocks, portfolios, and markets. It runs locally in a browser or terminal and checks current financial data before it answers.",
     },
     {
       question: "Is it free?",
       answer:
-        "OpenCandle itself is free and MIT licensed, with no account and no subscription. You pay only your own model provider for the tokens a session uses. Core market data works without paying any data provider.",
+        "OpenCandle is free and MIT licensed, with no OpenCandle account or subscription. You pay your AI model provider for usage. Core market data does not require paid data APIs.",
     },
     {
       question: "How is this different from asking ChatGPT?",
       answer:
-        "A general chatbot can produce a confident market answer you have no way to check. OpenCandle calls typed finance tools first, then keeps the provider, the timestamp, and the data gaps attached to every claim, so you can audit the answer instead of trusting it.",
+        "OpenCandle gathers quotes, filings, option chains, macro data, and portfolio context before answering. It then shows the source and timestamp behind the result, including anything it could not verify.",
     },
     {
-      question: "Which model does it use?",
+      question: "What do I need to get started?",
       answer:
-        "You bring your own Anthropic, OpenAI, or Google model credentials through the bundled Pi agent runtime. Market data is separate: Yahoo Finance, SEC EDGAR, FRED, and CoinGecko work without any data-provider keys.",
+        "You need Node.js and access to an Anthropic, OpenAI, or Google model through an API key or supported sign-in. OpenCandle provides the app and core market-data connections, with no OpenCandle account or subscription.",
     },
     {
       question: "Does OpenCandle place trades?",
@@ -1347,9 +1354,9 @@ function HomePage({ buildDate, version }) {
         "No. OpenCandle is read-only research software. It gathers and organizes market evidence, but it does not place trades, route orders, or provide financial advice.",
     },
     {
-      question: "Which data sources does OpenCandle use?",
+      question: "Where is my data stored?",
       answer:
-        "OpenCandle integrates Yahoo Finance, TradingView scanner, Alpha Vantage, London Strategic Edge, FRED, Polymarket, CoinGecko, Reddit, SEC EDGAR, DuckDuckGo, Brave, Exa, Finnhub, and local portfolio state where configured.",
+        "Watchlists, portfolios, alerts, and sessions are stored on your machine. Questions and research context are sent to the model provider you choose.",
     },
   ];
   const dataSources = [
@@ -1406,24 +1413,6 @@ function HomePage({ buildDate, version }) {
     },
     { name: "Local portfolio", capability: "your positions", icons: [] },
   ];
-  const researchSteps = [
-    {
-      mark: "01",
-      title: "Ask in plain English",
-      body: "Start with a company, portfolio, market event, or thesis. OpenCandle turns the question into a research plan.",
-    },
-    {
-      mark: "02",
-      title: "Gather the live record",
-      body: "Typed tools fetch quotes, filings, options, macro series, news, and sentiment before the answer is written.",
-    },
-    {
-      mark: "03",
-      title: "Inspect every claim",
-      body: "Providers, timestamps, tool calls, and missing-data notes stay attached so you can verify the work.",
-    },
-  ];
-
   return (
     <HtmlDocument
       title="OpenCandle"
@@ -1477,39 +1466,41 @@ function HomePage({ buildDate, version }) {
     >
       <SiteHeader />
       <main>
-        <section className="landing-hero mx-auto max-w-[1100px] px-4 pt-16 pb-12 text-center sm:pt-24 lg:px-6">
-          <h1 className="mx-auto max-w-[860px] font-semibold text-4xl text-foreground tracking-[-0.045em] sm:text-6xl lg:text-7xl">
-            Ask any market question. <span className="text-accent">Check every number.</span>
-          </h1>
-          <p className="mx-auto mt-6 max-w-[660px] text-base text-muted-foreground leading-relaxed sm:text-lg">
-            OpenCandle is an open source financial investigator. It fetches live quotes, filings,
-            options, and macro data before answering, then shows the provider, the timestamp, and
-            what it could not find.
-          </p>
-          <div className="landing-command" data-surface-command="">
-            <span aria-hidden="true">$</span>
-            <code data-surface-command-text="">npx opencandle@latest gui</code>
-            <button type="button" aria-label="Copy install command" data-command-copy="">
-              <CopyIcon />
-            </button>
+        <section className="landing-hero">
+          <div className="landing-hero-copy">
+            <h1>
+              Market research that <span>shows its work.</span>
+            </h1>
+            <p>
+              OpenCandle is an open source financial investigator. It fetches live quotes, filings,
+              options, and macro data before answering, then shows where the result came from.
+            </p>
+            <div className="landing-command" data-surface-command="">
+              <span aria-hidden="true">$</span>
+              <code data-surface-command-text="">npx opencandle@latest gui</code>
+              <button type="button" aria-label="Copy install command" data-command-copy="">
+                <CopyIcon />
+              </button>
+            </div>
+            <p className="landing-hero-proof">
+              Free and open source · runs locally · bring your own AI
+            </p>
           </div>
-          <p className="mt-6 text-muted-foreground text-xs">
-            MIT licensed · runs on your machine · no account · market data needs no keys
-          </p>
+          <div className="landing-hero-media">
+            <SurfaceDemo />
+            <template data-legacy-cli-demo="">
+              <LegacyCliDemo />
+            </template>
+          </div>
         </section>
 
         <section
-          className="mx-auto max-w-[1100px] px-4 pb-24 lg:px-6"
-          aria-label="OpenCandle in the browser and terminal"
+          className="landing-evidence mx-auto max-w-[1100px] px-4 lg:px-6"
+          aria-labelledby="evidence-map-title"
         >
-          <SurfaceDemo />
-          <template data-legacy-cli-demo="">
-            <LegacyCliDemo />
-          </template>
-
           <div className="evidence-map">
             <div className="evidence-map-heading">
-              <h2>The tools behind every answer</h2>
+              <h2 id="evidence-map-title">The best tools behind every answer.</h2>
               <p>
                 OpenCandle picks the relevant sources for the question and keeps each one attached
                 to the result.
@@ -1596,32 +1587,17 @@ function HomePage({ buildDate, version }) {
           </div>
         </section>
 
-        <section
-          className="mx-auto max-w-[1100px] px-4 pb-24 lg:px-6"
-          aria-labelledby="research-flow-title"
-        >
-          <div className="landing-section-heading">
-            <h2 id="research-flow-title">Ask. Gather. Verify.</h2>
-            <p>Every step leaves a record you can open.</p>
-          </div>
-          <div className="research-steps">
-            {researchSteps.map((step) => (
-              <article key={step.mark} className="research-step">
-                <span className="research-step-mark" aria-hidden="true">
-                  {step.mark}
-                </span>
-                <h3>{step.title}</h3>
-                <p>{step.body}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
         <section className="answer-comparison border-border border-y bg-secondary/50">
           <div className="mx-auto max-w-[1100px] px-4 py-20 lg:px-6">
             <div className="answer-comparison-heading">
-              <h2>Same question. Different evidence.</h2>
-              <p>ChatGPT and Claude explain the choices. OpenCandle checks the market.</p>
+              <h2>
+                Same question.
+                <span>Different results.</span>
+              </h2>
+              <p>
+                Why not ask another AI? OpenCandle can use live financial tools before it answers,
+                so you get current numbers you can inspect.
+              </p>
             </div>
             <AnswerComparisonTabs />
             <p className="answer-comparison-link">
@@ -1635,78 +1611,22 @@ function HomePage({ buildDate, version }) {
           </div>
         </section>
 
-        <section
-          className="builder-section mx-auto max-w-[1100px] px-4 py-24 lg:px-6"
-          aria-label="For builders"
-        >
-          <div className="builder-intro">
-            <div>
-              <h2 className="font-semibold text-foreground text-xl tracking-[-0.01em]">
-                Built to be extended
-              </h2>
-              <p className="mt-3 text-muted-foreground text-sm leading-relaxed">
-                Extend OpenCandle at three layers: connect a provider, wrap it in a typed tool, then
-                expose it to workflows. Shared caching and rate limits come built in; keep the
-                extension local or publish it as an npm package.
-              </p>
+        <section className="faq-section mx-auto max-w-[1100px] px-4 lg:px-6" aria-label="FAQ">
+          <div className="faq-layout">
+            <div className="faq-heading">
+              <h2>Common questions</h2>
             </div>
-          </div>
-          <ol className="extension-path">
-            <li>
-              <span>01</span>
-              <div>
-                <a href="docs/system-architecture.html">Connect a provider</a>
-                <p>Normalize one API behind shared caching and rate limits.</p>
-              </div>
-            </li>
-            <li>
-              <span>02</span>
-              <div>
-                <a href="docs/build-a-tool.html">Declare a typed tool</a>
-                <p>Define its inputs and return evidence the agent can inspect.</p>
-              </div>
-            </li>
-            <li>
-              <span>03</span>
-              <div>
-                <a href="docs/testing-and-evals.html">Route, test, and ship</a>
-                <p>Expose it to workflows, verify it, then package it if others need it.</p>
-              </div>
-            </li>
-          </ol>
-        </section>
-
-        <section className="mx-auto max-w-[860px] px-4 py-24 lg:px-6" aria-label="FAQ">
-          <div className="landing-section-heading">
-            <h2>Common questions</h2>
-          </div>
-          <div className="faq-list">
-            {faqs.map((faq) => (
-              <details key={faq.question}>
-                <summary>
-                  {faq.question}
-                  <span aria-hidden="true">+</span>
-                </summary>
-                <p>{faq.answer}</p>
-              </details>
-            ))}
-          </div>
-        </section>
-
-        <section
-          className="landing-cta border-border border-y bg-secondary/60"
-          aria-label="Start locally"
-        >
-          <div className="mx-auto max-w-[1100px] px-4 py-20 text-center lg:px-6">
-            <h2>Start your first investigation.</h2>
-            <p>Bring an Anthropic, OpenAI, or Google model key. Market data needs no keys.</p>
-            <div className="landing-command">
-              <span aria-hidden="true">$</span>
-              <code>npx opencandle@latest gui</code>
+            <div className="faq-list">
+              {faqs.map((faq) => (
+                <details key={faq.question}>
+                  <summary>
+                    {faq.question}
+                    <span aria-hidden="true">+</span>
+                  </summary>
+                  <p>{faq.answer}</p>
+                </details>
+              ))}
             </div>
-            <p className="mt-6 text-muted-foreground text-xs">
-              The agent does the collection work. You keep the judgment.
-            </p>
           </div>
         </section>
       </main>
@@ -1765,15 +1685,18 @@ function DocsPage({ page, content, headings, buildDate }) {
             />
           </article>
           {toc.length > 0 ? (
-            <aside className="hidden w-[200px] shrink-0 xl:block">
-              <div className="sticky top-20 flex flex-col gap-0.5">
+            <aside
+              className="docs-toc-sidebar hidden w-[200px] shrink-0 xl:block"
+              data-docs-toc-sidebar=""
+            >
+              <div className="sticky top-14 flex flex-col gap-0.5 px-3 py-5">
                 <SectionLabel>On this page</SectionLabel>
                 <nav className="flex flex-col gap-0.5" aria-label="On this page">
                   {toc.map((heading) => (
                     <a
                       key={heading.id}
                       href={`#${heading.id}`}
-                      className="block rounded-md px-2 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="block rounded-md px-2 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-tertiary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       {heading.text}
                     </a>

--- a/website/src/entry-client.jsx
+++ b/website/src/entry-client.jsx
@@ -50,6 +50,8 @@ if (surfaceDemo) {
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
   function activateSurface(name, focus = false) {
+    surfaceDemo.dataset.surfaceActive = name;
+
     if (surfaceCommandText) {
       surfaceCommandText.textContent =
         name === "tui" ? "npx opencandle@latest" : "npx opencandle@latest gui";
@@ -63,7 +65,13 @@ if (surfaceDemo) {
     }
 
     for (const panel of surfacePanels) {
-      panel.hidden = panel.dataset.surfacePanel !== name;
+      const active = panel.dataset.surfacePanel === name;
+      panel.setAttribute("aria-hidden", String(!active));
+      if (active) {
+        panel.removeAttribute("inert");
+      } else {
+        panel.setAttribute("inert", "");
+      }
     }
 
     for (const video of surfaceVideos) {

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -1,3 +1,4 @@
+/* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4 · genre: modern-minimal · macrostructure: Workbench · design-system: design.md · nav: N1a · footer: Ft2 · contrast: pass (40–41) · slop: pass (42–45) · honest: pass (46) · chrome: pass (47) · tokens: pass (48) · responsive: pass (49) · icons: pass (30) · mobile: pass (34, 49, 50–57) */
 @import "tailwindcss";
 @import "@opencandle/ui/styles.css";
 @config "../tailwind.config.cjs";
@@ -9,12 +10,14 @@
 
   html {
     min-width: 320px;
+    overflow-x: clip;
     background: hsl(var(--tw-background));
   }
 
   body {
     margin: 0;
     min-width: 320px;
+    overflow-x: clip;
     background: hsl(var(--tw-background));
     color: hsl(var(--tw-foreground));
     -webkit-tap-highlight-color: hsl(var(--tw-foreground) / 0.08);
@@ -62,6 +65,14 @@
 @layer components {
   .landing-hero {
     position: relative;
+    display: grid;
+    width: min(100%, 1320px);
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2.75rem;
+    align-items: center;
+    margin-inline: auto;
+    padding: clamp(3.5rem, 8vw, 6.5rem) 1rem clamp(5rem, 9vw, 7.5rem);
     isolation: isolate;
   }
 
@@ -77,42 +88,54 @@
     opacity: 0.55;
   }
 
-  .landing-section-heading,
-  .evidence-map-heading {
-    margin-inline: auto;
-    max-width: 680px;
-    text-align: center;
+  .landing-hero-copy {
+    min-width: 0;
   }
 
-  .landing-section-heading h2,
-  .evidence-map-heading h2,
-  .landing-cta h2 {
+  .landing-hero-copy h1 {
     margin: 0;
     color: hsl(var(--tw-foreground));
-    font-size: clamp(2rem, 4.5vw, 3.25rem);
+    font-size: clamp(2.75rem, 4.25vw, 4.25rem);
     font-weight: 600;
-    letter-spacing: -0.045em;
-    line-height: 1.02;
+    letter-spacing: -0.055em;
+    line-height: 0.98;
+    overflow-wrap: anywhere;
   }
 
-  .landing-section-heading > p:last-child,
-  .evidence-map-heading > p:last-child,
-  .landing-cta > div > p {
-    margin: 1rem auto 0;
-    max-width: 600px;
+  .landing-hero-copy h1 span {
+    display: block;
+    margin-top: 0.12em;
+  }
+
+  .landing-hero-copy > p:first-of-type {
+    max-width: 520px;
+    margin: 1.5rem 0 0;
     color: hsl(var(--tw-muted-foreground));
-    font-size: 0.9375rem;
-    line-height: 1.65;
+    font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
+    line-height: 1.7;
+  }
+
+  .landing-hero-proof {
+    margin: 1.25rem 0 0;
+    color: hsl(var(--tw-muted-foreground));
+    font-size: 0.75rem;
+    line-height: 1.5;
+  }
+
+  .landing-hero-media {
+    min-width: 0;
+  }
+
+  .landing-hero .surface-demo {
+    max-width: none;
   }
 
   .surface-demo {
-    overflow: hidden;
+    overflow: visible;
     max-width: 980px;
     margin-inline: auto;
-    border: 1px solid hsl(var(--tw-border));
-    border-radius: calc(var(--radius) + 6px);
-    background: hsl(var(--tw-card));
-    box-shadow: var(--shadow-subtle-md);
+    background: transparent;
+    perspective: 1400px;
   }
 
   .surface-demo-toolbar {
@@ -120,9 +143,8 @@
     min-height: 62px;
     align-items: center;
     justify-content: center;
-    border-bottom: 1px solid hsl(var(--tw-border));
     padding: 0.45rem;
-    background: hsl(var(--tw-secondary));
+    background: transparent;
   }
 
   .icon-tabs {
@@ -177,17 +199,45 @@
 
   .surface-demo-stage {
     position: relative;
+    overflow: visible;
+    aspect-ratio: 16 / 9;
+    border: 1px solid hsl(var(--tw-border));
+    border-radius: calc(var(--radius) + 6px);
     background: #030303;
+    box-shadow: var(--shadow-subtle-md);
   }
 
-  .surface-demo-stage [role="tabpanel"][hidden] {
-    display: none;
+  .surface-demo-flipper {
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
+    transition: transform 600ms cubic-bezier(0.2, 0.75, 0.2, 1);
+  }
+
+  .surface-demo[data-surface-active="tui"] .surface-demo-flipper {
+    transform: rotateY(180deg);
+  }
+
+  .surface-demo-face {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    border-radius: inherit;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
+
+  .surface-demo-face-gui {
+    transform: rotateY(0deg) translateZ(1px);
+  }
+
+  .surface-demo-face-tui {
+    transform: rotateY(180deg) translateZ(1px);
   }
 
   .surface-demo-stage video {
     display: block;
+    height: 100%;
     width: 100%;
-    aspect-ratio: 16 / 9;
     background: #030303;
     object-fit: cover;
   }
@@ -341,8 +391,39 @@
     }
   }
 
+  .landing-evidence {
+    padding-block: clamp(5rem, 9vw, 7.5rem);
+  }
+
   .evidence-map {
-    margin-top: 6rem;
+    margin-top: 0;
+  }
+
+  .evidence-map-heading {
+    display: grid;
+    max-width: 760px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.25rem;
+    text-align: left;
+  }
+
+  .evidence-map-heading h2 {
+    max-width: 560px;
+    margin: 0;
+    color: hsl(var(--tw-foreground));
+    font-size: clamp(2.25rem, 4.5vw, 3.75rem);
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 0.98;
+    overflow-wrap: anywhere;
+  }
+
+  .evidence-map-heading p {
+    max-width: 480px;
+    margin: 0;
+    color: hsl(var(--tw-muted-foreground));
+    font-size: 0.9375rem;
+    line-height: 1.7;
   }
 
   .evidence-hub {
@@ -397,8 +478,8 @@
   }
 
   .evidence-branch-start {
-    stop-color: hsl(var(--tw-accent));
-    stop-opacity: 0.72;
+    stop-color: hsl(var(--tw-foreground));
+    stop-opacity: 0.34;
   }
 
   .evidence-branch-end {
@@ -477,6 +558,7 @@
     font-size: 0.75rem;
     font-weight: 500;
     text-align: center;
+    white-space: nowrap;
     transition:
       border-color 150ms ease,
       color 150ms ease,
@@ -489,46 +571,12 @@
     color: hsl(var(--tw-foreground));
   }
 
-  .research-steps {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    margin-top: 3.5rem;
-    border-block: 1px solid hsl(var(--tw-border));
-  }
-
-  .research-step {
-    padding: 2rem 2rem 2.25rem;
-  }
-
-  .research-step + .research-step {
-    border-left: 1px solid hsl(var(--tw-border));
-  }
-
-  .research-step-mark {
-    display: block;
-    color: hsl(var(--tw-accent));
-    font-family: "JetBrains Mono", ui-monospace, monospace;
-    font-size: 0.6875rem;
-    font-weight: 500;
-  }
-
-  .research-step h3 {
-    margin: 2rem 0 0;
-    font-size: 1rem;
-    font-weight: 600;
-  }
-
-  .research-step p {
-    margin: 0.75rem 0 0;
-    color: hsl(var(--tw-muted-foreground));
-    font-size: 0.8125rem;
-    line-height: 1.65;
-  }
-
   .answer-comparison-heading {
-    max-width: 680px;
-    margin-inline: auto;
-    text-align: center;
+    display: grid;
+    max-width: 760px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.25rem;
+    text-align: left;
   }
 
   .answer-comparison-heading h2 {
@@ -539,9 +587,13 @@
     line-height: 1.02;
   }
 
+  .answer-comparison-heading h2 span {
+    display: block;
+  }
+
   .answer-comparison-heading p {
-    max-width: 560px;
-    margin: 1rem auto 0;
+    max-width: 480px;
+    margin: 0;
     color: hsl(var(--tw-muted-foreground));
     font-size: 0.9375rem;
     line-height: 1.65;
@@ -2086,52 +2138,7 @@
   .answer-comparison-link {
     margin: 1.5rem 0 0;
     font-size: 0.8125rem;
-    text-align: center;
-  }
-
-  .builder-intro {
-    max-width: 680px;
-  }
-
-  .extension-path {
-    margin: 2.75rem 0 0;
-    border-top: 1px solid hsl(var(--tw-border));
-    padding: 0;
-    list-style: none;
-  }
-
-  .extension-path li {
-    display: grid;
-    grid-template-columns: 56px minmax(0, 1fr);
-    gap: 1rem;
-    border-bottom: 1px solid hsl(var(--tw-border));
-    padding: 1.35rem 0;
-  }
-
-  .extension-path li > span {
-    color: hsl(var(--tw-accent));
-    font-family: "JetBrains Mono", ui-monospace, monospace;
-    font-size: 0.6875rem;
-    font-weight: 500;
-  }
-
-  .extension-path a {
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-
-  .extension-path p {
-    margin: 0.35rem 0 0;
-    color: hsl(var(--tw-muted-foreground));
-    font-size: 0.75rem;
-    line-height: 1.55;
-  }
-
-  .landing-cta h2 {
-    max-width: 700px;
-    margin-inline: auto;
+    text-align: left;
   }
 
   .landing-command {
@@ -2149,7 +2156,7 @@
   }
 
   .landing-command > span {
-    color: hsl(var(--tw-accent));
+    color: hsl(var(--tw-background) / 0.62);
     font-family: "JetBrains Mono", ui-monospace, monospace;
   }
 
@@ -2185,8 +2192,33 @@
     height: 14px;
   }
 
+  .landing-hero .landing-command {
+    margin-inline: 0;
+  }
+
+  .faq-section {
+    padding-block: clamp(5rem, 9vw, 7.5rem);
+  }
+
+  .faq-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2.5rem;
+  }
+
+  .faq-heading h2 {
+    max-width: 440px;
+    margin: 0;
+    color: hsl(var(--tw-foreground));
+    font-size: clamp(2.25rem, 4.5vw, 3.75rem);
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 0.98;
+    overflow-wrap: anywhere;
+  }
+
   .faq-list {
-    margin-top: 2.5rem;
+    margin-top: 0;
     border-top: 1px solid hsl(var(--tw-border));
   }
 
@@ -2233,6 +2265,61 @@
     background: hsl(var(--tw-secondary) / 0.6);
   }
 
+  .docs-sidebar::before {
+    position: absolute;
+    top: 0;
+    right: 100%;
+    bottom: 0;
+    width: 100vw;
+    background: hsl(var(--tw-secondary));
+    content: "";
+    pointer-events: none;
+  }
+
+  .docs-toc-sidebar {
+    position: relative;
+    margin-block: -2.5rem;
+    isolation: isolate;
+  }
+
+  .docs-toc-sidebar::before {
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    background: hsl(var(--tw-secondary));
+    content: "";
+    pointer-events: none;
+  }
+
+  @media (min-width: 60rem) {
+    .landing-hero {
+      grid-template-columns: minmax(320px, 0.68fr) minmax(0, 1.45fr);
+      gap: clamp(2.5rem, 4vw, 4.5rem);
+      padding-inline: 1.5rem;
+    }
+
+    .landing-hero-media {
+      width: min(
+        calc(100% + min(7vw, 6rem)),
+        calc(100% + max(1.5rem, (100vw - 1320px) / 2 + 1.5rem))
+      );
+    }
+
+    .faq-layout {
+      grid-template-columns: minmax(260px, 0.65fr) minmax(0, 1.35fr);
+      gap: clamp(4rem, 8vw, 8rem);
+    }
+
+    .faq-heading {
+      position: sticky;
+      top: 5rem;
+      align-self: start;
+    }
+  }
+
   @media (max-width: 820px) {
     .evidence-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2251,15 +2338,6 @@
     .evidence-branch--mobile,
     .evidence-row-connector--mobile {
       display: block;
-    }
-
-    .research-steps {
-      grid-template-columns: 1fr;
-    }
-
-    .research-step + .research-step {
-      border-top: 1px solid hsl(var(--tw-border));
-      border-left: 0;
     }
 
     .answer-surfaces {
@@ -2311,6 +2389,10 @@
       min-height: 66px;
       padding: 0.65rem;
     }
+
+    .evidence-source-more {
+      grid-column: 1 / -1;
+    }
   }
 
   /* Mobile drawer state. The drawer markup is prerendered; these rules react
@@ -2357,6 +2439,10 @@
       animation: none;
       opacity: 1;
       transform: none;
+      transition: none;
+    }
+
+    .surface-demo-flipper {
       transition: none;
     }
 


### PR DESCRIPTION
## Summary

Refines the OpenCandle public site into a focused, evidence-led product page and brings the documentation navigation into the same visual system. The homepage now leads with the product demo, source fan-out, comparison experience, and FAQ, while the docs use symmetric full-bleed navigation rails.

## Why

The previous page mixed too many small headings, secondary sections, and uneven navigation treatments, making it harder for a new visitor to understand what OpenCandle does. This change clarifies that OpenCandle is an open source financial investigator that fetches current data and shows where results came from, while making the homepage and docs feel like one coherent product.

## Validation

- [x] `npm test`
- [x] `npm run release:check` for release-facing changes, or note why focused check is enough
- [x] `npm run review:pr` before merge for non-trivial changes
- [x] Docs updated if behavior or workflow changed
- [x] Tests added or updated for behavior changes

Additional checks:
- `npm run gates`
- Built the public site with `npm run docs:site:build`.
- Verified the homepage and docs in the live browser at desktop and mobile widths.
- Confirmed the expanded hero demo stays within the viewport at 1280px and 1440px widths.
- Confirmed both documentation rails extend to the viewport edge without horizontal overflow.
- Confirmed the right “On this page” navigation matches the left navigation spacing and link treatment.

Autoreview findings accepted/rejected:
- Accepted the initial responsive-layout finding and constrained the hero demo expansion to the available viewport gutter.
- Added a regression test and reran autoreview; the final review reported no actionable findings.

Runtime/eval proof for behavior changes:
- Browser and CLI hero tabs switch the command and flip the full media card.
- Desktop documentation rails render symmetrically; the right rail hides at its existing responsive breakpoint.

## Risks / Follow-ups

The landing page is static and deployment remains handled by the existing CI Pages workflow. Existing CSS descending-specificity warnings remain unchanged and are non-blocking.

## Issue / Discussion

N/A
