### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.14.0] - 2026-08-13
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencandle",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencandle",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "workspaces": [
         "gui/hosted",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencandle",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Open source financial investigator: evidence-first market research agent for your terminal and local GUI",
   "license": "MIT",
   "homepage": "https://opencandle.app",


### PR DESCRIPTION
## Summary

Prepare OpenCandle v0.14.0 by promoting the accumulated Unreleased changelog and synchronizing the package version and lockfile.

## Why

The hosted PWA, settings experience, routing fixes, and release-eval hardening since v0.13.0 constitute a user-facing minor release.

## Validation

- [x] `npm test`
- [x] Release-facing gates and evals reviewed before version mutation
- [x] `npm run review:pr` completed for the functional changes in #165
- [x] Docs updated if behavior or workflow changed
- [x] Tests added or updated for behavior changes

Runtime/eval proof for behavior changes:

- Required CI passed on #165 across Node 22, 24, and 26, including packaged CLI and hosted PWA browser smoke.
- DTE TUI harness verified explicit and default horizons before release preparation.

Autoreview findings accepted/rejected:

- N/A; this PR contains version and changelog promotion only. Functional review was completed in #165.

## Risks / Follow-ups

After merge, tag `v0.14.0` will trigger npm and GitHub release publication. A follow-up restores the Unreleased changelog heading.

## Issue / Discussion

#165
