### PR TITLE
chore: add Unreleased section after v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.14.0] - 2026-08-13
 
 ### Added


### PR DESCRIPTION
## Summary

Restore the empty Unreleased changelog section after publishing v0.14.0.

## Why

Future changes need a canonical section to accumulate release notes without modifying the published v0.14.0 entry.

## Validation

- [x] `npm test` covered by the v0.14.0 release CI; this follow-up changes only the changelog heading
- [x] Release checks passed on #166
- [x] Functional autoreview completed on #165
- [x] Docs updated if behavior or workflow changed
- [x] Tests added or updated for behavior changes

Autoreview findings accepted/rejected: N/A; changelog-only follow-up.

Runtime/eval proof for behavior changes: N/A; no runtime behavior changes.

## Risks / Follow-ups

None.

## Issue / Discussion

#166
