### PR TITLE
refactor: consolidate duplicated code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Consolidated duplicated provider CLI normalization, social cashtag aggregation, stateful-intent detection, memory preference suppression, evidence serialization, and large-number tool formatting behind focused shared helpers, reducing the pinned production duplicate scan from 67 groups and 1.00% duplicated lines to 59 groups and 0.86% without changing public behavior.
 - Updated supported runtime, agent, GUI, provider-relay, documentation, and video dependencies to their latest compatible releases, including Pi 0.84.2; regenerated the first-class model catalog, removed vulnerable transitive dependency versions from both lockfiles, and kept hosted SQLite imports on the canonical WASM asset path after the Vite upgrade.
 
 ## [0.14.0] - 2026-08-13

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1,3 +1,4 @@
+import { preferenceKeysForOverriddenSlots } from "./preference-suppression.js";
 import type { MemoryStorage } from "./storage.js";
 import type { MemoryCategory, MemoryEntry } from "./types.js";
 import {
@@ -16,16 +17,6 @@ export interface MemoryRetrievalResult {
   entries: MemoryEntry[];
   filtered: FilteredMemoryEntry[];
 }
-
-/** Slot name → preference key(s) mapping for suppression. */
-const SLOT_TO_PREF_KEYS: Record<string, string[]> = {
-  riskProfile: ["risk_profile"],
-  assetScope: ["asset_scope"],
-  timeHorizon: ["time_horizon"],
-  dteTarget: ["dte_target"],
-  moneynessPreference: ["moneyness_preference"],
-  liquidityMinimum: ["liquidity_minimum", "options_liquidity"],
-};
 
 const MAX_WORKFLOW_HISTORY_PER_TYPE = 3;
 const MAX_PREFERENCE_LINES = 15;
@@ -57,18 +48,7 @@ export class MemoryManager {
     const relevantCategories =
       WORKFLOW_RELEVANT_CATEGORIES[workflowType] ?? WORKFLOW_RELEVANT_CATEGORIES.unclassified;
 
-    // Build set of preference keys to suppress
-    const suppressedKeys = new Set<string>();
-    if (overriddenSlots) {
-      for (const slot of overriddenSlots) {
-        const keys = SLOT_TO_PREF_KEYS[slot];
-        if (keys) {
-          for (const key of keys) {
-            suppressedKeys.add(key);
-          }
-        }
-      }
-    }
+    const suppressedKeys = preferenceKeysForOverriddenSlots(overriddenSlots);
 
     const entries: MemoryEntry[] = [];
     const filtered: FilteredMemoryEntry[] = [];

--- a/src/memory/preference-suppression.ts
+++ b/src/memory/preference-suppression.ts
@@ -1,0 +1,18 @@
+const SLOT_TO_PREF_KEYS: Readonly<Record<string, readonly string[]>> = {
+  riskProfile: ["risk_profile"],
+  assetScope: ["asset_scope"],
+  timeHorizon: ["time_horizon"],
+  dteTarget: ["dte_target"],
+  moneynessPreference: ["moneyness_preference"],
+  liquidityMinimum: ["liquidity_minimum", "options_liquidity"],
+};
+
+export function preferenceKeysForOverriddenSlots(overriddenSlots?: string[]): Set<string> {
+  const suppressedKeys = new Set<string>();
+  for (const slot of overriddenSlots ?? []) {
+    for (const key of SLOT_TO_PREF_KEYS[slot] ?? []) {
+      suppressedKeys.add(key);
+    }
+  }
+  return suppressedKeys;
+}

--- a/src/memory/retrieval.ts
+++ b/src/memory/retrieval.ts
@@ -1,17 +1,8 @@
+import { preferenceKeysForOverriddenSlots } from "./preference-suppression.js";
 import type { MemoryStorage } from "./storage.js";
 
 const MAX_PREFERENCE_LINES = 15;
 const MAX_WORKFLOW_SUMMARY_LINES = 12;
-
-/** Slot name → preference key(s) mapping for suppression. */
-const SLOT_TO_PREF_KEYS: Record<string, string[]> = {
-  riskProfile: ["risk_profile"],
-  assetScope: ["asset_scope"],
-  timeHorizon: ["time_horizon"],
-  dteTarget: ["dte_target"],
-  moneynessPreference: ["moneyness_preference"],
-  liquidityMinimum: ["liquidity_minimum", "options_liquidity"],
-};
 
 /**
  * Build compact memory context for agent injection.
@@ -22,18 +13,7 @@ const SLOT_TO_PREF_KEYS: Record<string, string[]> = {
 export function buildMemoryContext(storage: MemoryStorage, overriddenSlots?: string[]): string {
   const sections: string[] = [];
 
-  // Build set of preference keys to suppress
-  const suppressedKeys = new Set<string>();
-  if (overriddenSlots) {
-    for (const slot of overriddenSlots) {
-      const keys = SLOT_TO_PREF_KEYS[slot];
-      if (keys) {
-        for (const key of keys) {
-          suppressedKeys.add(key);
-        }
-      }
-    }
-  }
+  const suppressedKeys = preferenceKeysForOverriddenSlots(overriddenSlots);
 
   // Preferences
   const prefs = storage.getPreferencesByNamespace("global");

--- a/src/providers/external-cli-utils.ts
+++ b/src/providers/external-cli-utils.ts
@@ -1,0 +1,32 @@
+export interface CliErrorEnvelope {
+  code?: string;
+  message: string;
+}
+
+export function parseCliErrorEnvelope(stdout: string): CliErrorEnvelope | null {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      ok?: unknown;
+      error?: { code?: unknown; message?: unknown };
+    };
+    if (parsed.ok !== false || typeof parsed.error?.message !== "string") return null;
+    return {
+      code: typeof parsed.error.code === "string" ? parsed.error.code : undefined,
+      message: parsed.error.message,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeExternalTimestamp(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const millis = value > 1_000_000_000_000 ? value : value * 1000;
+    return new Date(millis).toISOString();
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const millis = Date.parse(value);
+    if (!Number.isNaN(millis)) return new Date(millis).toISOString();
+  }
+  return new Date(0).toISOString();
+}

--- a/src/providers/reddit-cli.ts
+++ b/src/providers/reddit-cli.ts
@@ -1,3 +1,4 @@
+import { normalizeExternalTimestamp, parseCliErrorEnvelope } from "./external-cli-utils.js";
 import { type ExternalToolCommandResult, runExternalToolCommand } from "./external-tool-command.js";
 import { ExternalToolError, ExternalToolNotInstalled } from "./external-tool-error.js";
 import type { RedditComment } from "./reddit.js";
@@ -196,22 +197,6 @@ async function runRdt<T>(args: readonly string[]): Promise<T> {
   return envelope.data;
 }
 
-function parseCliErrorEnvelope(stdout: string): { code?: string; message: string } | null {
-  try {
-    const parsed = JSON.parse(stdout) as {
-      ok?: unknown;
-      error?: { code?: unknown; message?: unknown };
-    };
-    if (parsed.ok !== false || typeof parsed.error?.message !== "string") return null;
-    return {
-      code: typeof parsed.error.code === "string" ? parsed.error.code : undefined,
-      message: parsed.error.message,
-    };
-  } catch {
-    return null;
-  }
-}
-
 function adaptPost(raw: RawRdtPost): RdtPost {
   const permalink = stringValue(raw.permalink);
   const url = stringValue(raw.url) || (permalink ? `https://reddit.com${permalink}` : "");
@@ -225,7 +210,7 @@ function adaptPost(raw: RawRdtPost): RdtPost {
     subreddit: stringValue(raw.subreddit) || undefined,
     url,
     permalink: permalink || undefined,
-    created: normalizeCreatedAt(raw.created_utc),
+    created: normalizeExternalTimestamp(raw.created_utc),
   };
 }
 
@@ -242,18 +227,6 @@ function adaptComment(
     score: numberValue(raw.score),
     permalink: permalink ? `https://reddit.com${permalink}` : "",
   };
-}
-
-function normalizeCreatedAt(value: unknown): string {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    const millis = value > 1_000_000_000_000 ? value : value * 1000;
-    return new Date(millis).toISOString();
-  }
-  if (typeof value === "string" && value.length > 0) {
-    const millis = Date.parse(value);
-    if (!Number.isNaN(millis)) return new Date(millis).toISOString();
-  }
-  return new Date(0).toISOString();
 }
 
 function stringValue(value: unknown): string {

--- a/src/providers/reddit.ts
+++ b/src/providers/reddit.ts
@@ -3,6 +3,7 @@ import { rateLimiter } from "../infra/rate-limiter.js";
 import { BEARISH_TERMS, BULLISH_TERMS } from "../sentiment/keywords.js";
 import type { RedditSentimentResult } from "../types/sentiment.js";
 import { listSubredditPosts, readRedditPost, searchRedditPosts } from "./reddit-cli.js";
+import { topCashtagMentions } from "./social-mentions.js";
 
 export async function getSubredditPosts(
   subreddit: string,
@@ -19,19 +20,7 @@ export async function getSubredditPosts(
       ? await searchRedditPosts(query, { subreddit, limit })
       : await listSubredditPosts(subreddit, { limit });
 
-    // Extract ticker-like mentions ($AAPL, $TSLA, etc.)
-    const tickerRegex = /\$([A-Z]{1,5})\b/g;
-    const mentionCounts = new Map<string, number>();
-    for (const post of posts) {
-      for (const match of post.title.matchAll(tickerRegex)) {
-        const ticker = match[1];
-        mentionCounts.set(ticker, (mentionCounts.get(ticker) ?? 0) + 1);
-      }
-    }
-    const topMentions = [...mentionCounts.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 10)
-      .map(([ticker]) => ticker);
+    const topMentions = topCashtagMentions(posts.map((post) => post.title));
 
     const sentiment = scoreSentiment(posts);
 

--- a/src/providers/social-mentions.ts
+++ b/src/providers/social-mentions.ts
@@ -1,0 +1,20 @@
+export function topCashtagMentions(
+  texts: Iterable<string>,
+  options: { exclude?: string; limit?: number } = {},
+): string[] {
+  const mentionCounts = new Map<string, number>();
+  const tickerRegex = /\$([A-Z]{1,5})\b/g;
+
+  for (const text of texts) {
+    for (const match of text.matchAll(tickerRegex)) {
+      const ticker = match[1];
+      if (ticker === options.exclude) continue;
+      mentionCounts.set(ticker, (mentionCounts.get(ticker) ?? 0) + 1);
+    }
+  }
+
+  return [...mentionCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, options.limit ?? 10)
+    .map(([ticker]) => ticker);
+}

--- a/src/providers/twitter-cli.ts
+++ b/src/providers/twitter-cli.ts
@@ -1,4 +1,5 @@
 import type { TwitterTweet } from "../types/sentiment.js";
+import { normalizeExternalTimestamp, parseCliErrorEnvelope } from "./external-cli-utils.js";
 import { type ExternalToolCommandResult, runExternalToolCommand } from "./external-tool-command.js";
 import { ExternalToolError, ExternalToolNotInstalled } from "./external-tool-error.js";
 
@@ -126,22 +127,6 @@ async function runTwitterCli<T>(args: readonly string[]): Promise<T> {
   }
 }
 
-function parseCliErrorEnvelope(stdout: string): { code?: string; message: string } | null {
-  try {
-    const parsed = JSON.parse(stdout) as {
-      ok?: unknown;
-      error?: { code?: unknown; message?: unknown };
-    };
-    if (parsed.ok !== false || typeof parsed.error?.message !== "string") return null;
-    return {
-      code: typeof parsed.error.code === "string" ? parsed.error.code : undefined,
-      message: parsed.error.message,
-    };
-  } catch {
-    return null;
-  }
-}
-
 function adaptRawTweet(raw: RawTweet): TwitterTweet {
   return {
     id: stringValue(raw.id),
@@ -156,20 +141,8 @@ function adaptRawTweet(raw: RawTweet): TwitterTweet {
     replies: numberValue(raw.metrics?.replies ?? raw.replyCount ?? raw.replies),
     views: nullableNumberValue(raw.metrics?.views ?? raw.viewCount ?? raw.views),
     url: stringValue(raw.url ?? raw.permanentUrl),
-    created: normalizeCreatedAt(raw.createdAt ?? raw.created_at),
+    created: normalizeExternalTimestamp(raw.createdAt ?? raw.created_at),
   };
-}
-
-function normalizeCreatedAt(value: string | number | undefined): string {
-  if (typeof value === "number") {
-    const millis = value > 1_000_000_000_000 ? value : value * 1000;
-    return new Date(millis).toISOString();
-  }
-  if (typeof value === "string" && value.length > 0) {
-    const millis = Date.parse(value);
-    if (!Number.isNaN(millis)) return new Date(millis).toISOString();
-  }
-  return new Date(0).toISOString();
 }
 
 function stringValue(value: unknown): string {

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -1,6 +1,7 @@
 import { cache, STALE_LIMIT, TTL } from "../infra/cache.js";
 import { rateLimiter } from "../infra/rate-limiter.js";
 import type { TwitterSentimentResult, TwitterTweet } from "../types/sentiment.js";
+import { topCashtagMentions } from "./social-mentions.js";
 import { searchTweets } from "./twitter-cli.js";
 
 // ── Sentiment scoring ────────────────────────────────────
@@ -62,22 +63,12 @@ export async function getTwitterSentiment(
       .filter((tweet) => new Date(tweet.created) >= cutoff)
       .slice(0, limit);
 
-    // Extract co-mentioned cashtags
-    const tickerRegex = /\$([A-Z]{1,5})\b/g;
-    const mentionCounts = new Map<string, number>();
     // Exclude the searched ticker itself from co-mentions
     const searchedTicker = normalizedQuery.startsWith("$") ? normalizedQuery.slice(1) : null;
-    for (const t of tweets) {
-      for (const match of t.text.matchAll(tickerRegex)) {
-        const ticker = match[1];
-        if (ticker === searchedTicker) continue;
-        mentionCounts.set(ticker, (mentionCounts.get(ticker) ?? 0) + 1);
-      }
-    }
-    const topMentions = [...mentionCounts.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 10)
-      .map(([ticker]) => ticker);
+    const topMentions = topCashtagMentions(
+      tweets.map((tweet) => tweet.text),
+      { exclude: searchedTicker ?? undefined },
+    );
 
     const sentiment = scoreTwitterSentiment(tweets);
 

--- a/src/routing/classify-intent.ts
+++ b/src/routing/classify-intent.ts
@@ -1,4 +1,5 @@
 import { extractEntities } from "./entity-extractor.js";
+import { isStatefulTrackingRequest } from "./stateful-intent.js";
 import type { ClassificationResult, ExtractedEntities, WorkflowType } from "./types.js";
 
 interface Rule {
@@ -300,28 +301,6 @@ function hasOptionKeywordsInText(lower: string): boolean {
     /\boption(?:s)?\s*chain\b/.test(lower) ||
     /\boptions?\b/.test(lower)
   );
-}
-
-function isStatefulTrackingRequest(input: string): boolean {
-  const lower = input.toLowerCase();
-  const hasPortfolioConstructionIntent =
-    /\b(?:build|create|construct|put\s+together)\b/.test(lower) &&
-    /\bportfolio\b/.test(lower) &&
-    /\$\s*\d|\b\d+(?:\.\d+)?\s*k\b|\bbudget\b|\bcapital\b/.test(lower);
-  const hasStateVerb =
-    /\b(?:add|remove|update|record|track|create|configure|check|show|list|view|cancel)\b/.test(
-      lower,
-    );
-  const hasStateObject =
-    /\b(?:watchlist|portfolio|holding|holdings|position|positions|alert|alerts|daily\s+report|watchlist\s+report|report\s+history)\b/.test(
-      lower,
-    );
-  const hasPortfolioLotShape =
-    /\b(?:add|record|track)\b/.test(lower) &&
-    /\b\d+(?:\.\d+)?\s+shares?\b/.test(lower) &&
-    /\b(?:portfolio|holding|holdings|position|positions)\b/.test(lower);
-  if (hasPortfolioConstructionIntent) return false;
-  return (hasStateVerb && hasStateObject) || hasPortfolioLotShape;
 }
 
 const FINANCE_SIGNAL_TERMS = [

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -27,6 +27,7 @@ import type {
   ToolBundleName,
 } from "./router-types.js";
 import { mapDteHintToTarget } from "./slot-resolver.js";
+import { isStatefulTrackingRequest } from "./stateful-intent.js";
 import { disambiguateSymbols } from "./symbol-disambiguator.js";
 import type { ExtractedEntities, WorkflowType } from "./types.js";
 
@@ -1108,28 +1109,6 @@ function isPortfolioEvaluationRequest(text: string): boolean {
     !hasExplicitConstructionIntent &&
     !hasFundedConstructionIntent
   );
-}
-
-function isStatefulTrackingRequest(text: string): boolean {
-  const lower = text.toLowerCase();
-  const hasPortfolioConstructionIntent =
-    /\b(?:build|create|construct|put\s+together)\b/.test(lower) &&
-    /\bportfolio\b/.test(lower) &&
-    /\$\s*\d|\b\d+(?:\.\d+)?\s*k\b|\bbudget\b|\bcapital\b/.test(lower);
-  const hasStateVerb =
-    /\b(?:add|remove|update|record|track|create|configure|check|show|list|view|cancel)\b/.test(
-      lower,
-    );
-  const hasStateObject =
-    /\b(?:watchlist|portfolio|holding|holdings|position|positions|alert|alerts|daily\s+report|watchlist\s+report|report\s+history)\b/.test(
-      lower,
-    );
-  const hasPortfolioLotShape =
-    /\b(?:add|record|track)\b/.test(lower) &&
-    /\b\d+(?:\.\d+)?\s+shares?\b/.test(lower) &&
-    /\b(?:portfolio|holding|holdings|position|positions)\b/.test(lower);
-  if (hasPortfolioConstructionIntent) return false;
-  return (hasStateVerb && hasStateObject) || hasPortfolioLotShape;
 }
 
 function filterCurrencyUnitSymbols(text: string, symbols: string[]): string[] {

--- a/src/routing/stateful-intent.ts
+++ b/src/routing/stateful-intent.ts
@@ -1,0 +1,21 @@
+export function isStatefulTrackingRequest(input: string): boolean {
+  const lower = input.toLowerCase();
+  const hasPortfolioConstructionIntent =
+    /\b(?:build|create|construct|put\s+together)\b/.test(lower) &&
+    /\bportfolio\b/.test(lower) &&
+    /\$\s*\d|\b\d+(?:\.\d+)?\s*k\b|\bbudget\b|\bcapital\b/.test(lower);
+  const hasStateVerb =
+    /\b(?:add|remove|update|record|track|create|configure|check|show|list|view|cancel)\b/.test(
+      lower,
+    );
+  const hasStateObject =
+    /\b(?:watchlist|portfolio|holding|holdings|position|positions|alert|alerts|daily\s+report|watchlist\s+report|report\s+history)\b/.test(
+      lower,
+    );
+  const hasPortfolioLotShape =
+    /\b(?:add|record|track)\b/.test(lower) &&
+    /\b\d+(?:\.\d+)?\s+shares?\b/.test(lower) &&
+    /\b(?:portfolio|holding|holdings|position|positions)\b/.test(lower);
+  if (hasPortfolioConstructionIntent) return false;
+  return (hasStateVerb && hasStateObject) || hasPortfolioLotShape;
+}

--- a/src/runtime/prompt-step.ts
+++ b/src/runtime/prompt-step.ts
@@ -1,6 +1,7 @@
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import type { FreshnessStamp } from "../infra/freshness.js";
 import type { EvidenceRecord } from "./evidence.js";
+import { serializeToolValue, truncateToolValue } from "./tool-evidence-utils.js";
 import type { StepOutput, WorkflowStep } from "./workflow-types.js";
 
 /**
@@ -99,15 +100,15 @@ export function captureToolEvidence(entries: SessionEntry[]): EvidenceRecord[] {
     if (!tool) continue;
     const resultValue = message.details ?? message.content ?? "";
     const freshness = extractFreshness(resultValue);
-    const serializedResult = serialize(resultValue);
+    const serializedResult = serializeToolValue(resultValue);
     evidence.push({
       label: `tool:${tool}`,
       value: {
         tool,
-        args: truncate(serialize(pending?.args ?? {}), 500),
+        args: truncateToolValue(serializeToolValue(pending?.args ?? {}), 500),
         ...(freshness ? { freshness } : {}),
         resultDigest: {
-          preview: truncate(serializedResult, 500),
+          preview: truncateToolValue(serializedResult, 500),
           totalLength: serializedResult.length,
         },
         startedAt: pending?.startedAt ?? entry.timestamp,
@@ -152,19 +153,6 @@ export function extractAssistantText(entries: SessionEntry[]): string {
  */
 export function toStepDefinitions(steps: PromptStep[]): Omit<WorkflowStep, "status">[] {
   return steps.map(({ prompt: _prompt, outputValidation: _outputValidation, ...step }) => step);
-}
-
-function serialize(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function truncate(value: string, maxLength: number): string {
-  return value.length > maxLength ? value.slice(0, maxLength) : value;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/runtime/session-coordinator.ts
+++ b/src/runtime/session-coordinator.ts
@@ -45,6 +45,7 @@ import {
 import { ProviderTracker } from "./provider-tracker.js";
 import { clearRunContext, type RunContextToken, setRunContext } from "./run-context.js";
 import type { StateDatabase } from "./state-database.js";
+import { serializeToolValue, truncateToolValue } from "./tool-evidence-utils.js";
 import { checkNumberMatch } from "./validation.js";
 import { WorkflowEventLogger } from "./workflow-events.js";
 import { WorkflowRunner } from "./workflow-runner.js";
@@ -993,16 +994,16 @@ function toolEvidenceRecord(input: {
   completedAt: string;
   isError: boolean;
 }): EvidenceRecord {
-  const serializedResult = serialize(input.result);
+  const serializedResult = serializeToolValue(input.result);
   const freshness = extractFreshness(input.result);
   return {
     label: `tool:${input.tool}`,
     value: {
       tool: input.tool,
-      args: truncate(serialize(input.args), 500),
+      args: truncateToolValue(serializeToolValue(input.args), 500),
       ...(freshness ? { freshness } : {}),
       resultDigest: {
-        preview: truncate(serializedResult, 500),
+        preview: truncateToolValue(serializedResult, 500),
         totalLength: serializedResult.length,
       },
       startedAt: input.startedAt,
@@ -1019,19 +1020,6 @@ function toolEvidenceRecord(input: {
 
 function summarizeStepEvidence(evidence: EvidenceRecord[]): unknown[] {
   return evidence.map((record) => (isPlainObject(record.value) ? record.value : record));
-}
-
-function serialize(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function truncate(value: string, maxLength: number): string {
-  return value.length > maxLength ? value.slice(0, maxLength) : value;
 }
 
 function extractFreshness(value: unknown): FreshnessStamp | undefined {

--- a/src/runtime/tool-evidence-utils.ts
+++ b/src/runtime/tool-evidence-utils.ts
@@ -1,0 +1,12 @@
+export function serializeToolValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function truncateToolValue(value: string, maxLength: number): string {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -1,0 +1,6 @@
+export function formatLargeNumber(value: number): string {
+  if (value >= 1e12) return `${(value / 1e12).toFixed(2)}T`;
+  if (value >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(2)}M`;
+  return value.toLocaleString();
+}

--- a/src/tools/fundamentals/company-overview.ts
+++ b/src/tools/fundamentals/company-overview.ts
@@ -5,6 +5,7 @@ import { withCredentialCheck } from "../../onboarding/tool-helpers.js";
 import { getOverview } from "../../providers/alpha-vantage.js";
 import { wrapProvider } from "../../providers/wrap-provider.js";
 import type { CompanyOverview } from "../../types/fundamentals.js";
+import { formatLargeNumber } from "../formatting.js";
 
 const params = Type.Object({
   symbol: Type.String({ description: "Stock ticker symbol (e.g. AAPL, MSFT)" }),
@@ -56,10 +57,3 @@ export const companyOverviewTool: AgentTool<
     });
   },
 };
-
-function formatLargeNumber(n: number): string {
-  if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
-  if (n >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
-  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
-  return n.toLocaleString();
-}

--- a/src/tools/market/crypto-price.ts
+++ b/src/tools/market/crypto-price.ts
@@ -4,6 +4,7 @@ import { buildFreshnessStamp, type FreshnessStamp, formatAsOfLine } from "../../
 import { getCryptoPrice } from "../../providers/coingecko.js";
 import { wrapProvider } from "../../providers/wrap-provider.js";
 import type { CryptoPrice } from "../../types/market.js";
+import { formatLargeNumber } from "../formatting.js";
 
 const params = Type.Object({
   id: Type.String({
@@ -55,11 +56,4 @@ function formatPrice(n: number): string {
   if (n >= 1) return n.toFixed(2);
   if (n >= 0.01) return n.toFixed(4);
   return n.toFixed(8);
-}
-
-function formatLargeNumber(n: number): string {
-  if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
-  if (n >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
-  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
-  return n.toLocaleString();
 }

--- a/src/tools/market/stock-quote.ts
+++ b/src/tools/market/stock-quote.ts
@@ -6,6 +6,7 @@ import { getGlobalQuote } from "../../providers/alpha-vantage.js";
 import { withFallback } from "../../providers/with-fallback.js";
 import { getQuote } from "../../providers/yahoo-finance.js";
 import type { StockQuote } from "../../types/market.js";
+import { formatLargeNumber } from "../formatting.js";
 
 const params = Type.Object({
   symbol: Type.String({ description: "Stock ticker symbol (e.g. AAPL, MSFT, TSLA)" }),
@@ -66,10 +67,3 @@ export const stockQuoteTool: AgentTool<
     return { content: [{ type: "text", text }], details: { ...quote, freshness } };
   },
 };
-
-function formatLargeNumber(n: number): string {
-  if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
-  if (n >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
-  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
-  return n.toLocaleString();
-}

--- a/tests/unit/memory/preference-suppression.test.ts
+++ b/tests/unit/memory/preference-suppression.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { preferenceKeysForOverriddenSlots } from "../../../src/memory/preference-suppression.js";
+
+describe("preference suppression", () => {
+  it("maps overridden workflow slots to all affected preference keys", () => {
+    expect(
+      preferenceKeysForOverriddenSlots(["riskProfile", "liquidityMinimum", "unknown"]),
+    ).toEqual(new Set(["risk_profile", "liquidity_minimum", "options_liquidity"]));
+    expect(preferenceKeysForOverriddenSlots()).toEqual(new Set());
+  });
+});

--- a/tests/unit/providers/external-cli-utils.test.ts
+++ b/tests/unit/providers/external-cli-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeExternalTimestamp,
+  parseCliErrorEnvelope,
+} from "../../../src/providers/external-cli-utils.js";
+
+describe("external CLI normalization", () => {
+  it("parses structured CLI errors without accepting unrelated JSON", () => {
+    expect(
+      parseCliErrorEnvelope(
+        JSON.stringify({
+          ok: false,
+          error: { code: "session_missing", message: "Sign in again" },
+        }),
+      ),
+    ).toEqual({ code: "session_missing", message: "Sign in again" });
+    expect(parseCliErrorEnvelope(JSON.stringify({ ok: true, error: { message: "ignored" } }))).toBe(
+      null,
+    );
+    expect(parseCliErrorEnvelope("not-json")).toBe(null);
+  });
+
+  it("normalizes seconds, milliseconds, and date strings to ISO timestamps", () => {
+    expect(normalizeExternalTimestamp(1_700_000_000)).toBe("2023-11-14T22:13:20.000Z");
+    expect(normalizeExternalTimestamp(1_700_000_000_000)).toBe("2023-11-14T22:13:20.000Z");
+    expect(normalizeExternalTimestamp("2024-01-02T03:04:05Z")).toBe("2024-01-02T03:04:05.000Z");
+    expect(normalizeExternalTimestamp(Number.NaN)).toBe("1970-01-01T00:00:00.000Z");
+    expect(normalizeExternalTimestamp("invalid")).toBe("1970-01-01T00:00:00.000Z");
+  });
+});

--- a/tests/unit/providers/social-mentions.test.ts
+++ b/tests/unit/providers/social-mentions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { topCashtagMentions } from "../../../src/providers/social-mentions.js";
+
+describe("social cashtag aggregation", () => {
+  it("ranks cashtags by frequency and can exclude the searched ticker", () => {
+    expect(
+      topCashtagMentions(["$AAPL and $TSLA", "$TSLA then $NVDA", "$TSLA $AAPL"], {
+        exclude: "AAPL",
+        limit: 2,
+      }),
+    ).toEqual(["TSLA", "NVDA"]);
+  });
+});

--- a/tests/unit/routing/stateful-intent.test.ts
+++ b/tests/unit/routing/stateful-intent.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isStatefulTrackingRequest } from "../../../src/routing/stateful-intent.js";
+
+describe("stateful tracking intent", () => {
+  it("recognizes state mutations and portfolio lot recording", () => {
+    expect(isStatefulTrackingRequest("add AAPL to my watchlist")).toBe(true);
+    expect(isStatefulTrackingRequest("record 25 shares of MSFT in my holdings")).toBe(true);
+    expect(isStatefulTrackingRequest("show my alert history")).toBe(true);
+  });
+
+  it("does not intercept funded portfolio construction", () => {
+    expect(isStatefulTrackingRequest("build a portfolio with a $10,000 budget")).toBe(false);
+  });
+});

--- a/tests/unit/runtime/tool-evidence-utils.test.ts
+++ b/tests/unit/runtime/tool-evidence-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { serializeToolValue, truncateToolValue } from "../../../src/runtime/tool-evidence-utils.js";
+
+describe("tool evidence utilities", () => {
+  it("serializes strings, structured values, and circular values safely", () => {
+    expect(serializeToolValue("already text")).toBe("already text");
+    expect(serializeToolValue({ symbol: "AAPL", price: 123 })).toBe(
+      '{"symbol":"AAPL","price":123}',
+    );
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(serializeToolValue(circular)).toBe("[object Object]");
+  });
+
+  it("caps evidence previews without changing shorter values", () => {
+    expect(truncateToolValue("abcdef", 3)).toBe("abc");
+    expect(truncateToolValue("abc", 3)).toBe("abc");
+  });
+});

--- a/tests/unit/tools/formatting.test.ts
+++ b/tests/unit/tools/formatting.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { formatLargeNumber } from "../../../src/tools/formatting.js";
+
+describe("tool output formatting", () => {
+  it("formats large financial values with stable magnitude suffixes", () => {
+    expect(formatLargeNumber(1_250_000)).toBe("1.25M");
+    expect(formatLargeNumber(2_500_000_000)).toBe("2.50B");
+    expect(formatLargeNumber(3_750_000_000_000)).toBe("3.75T");
+    expect(formatLargeNumber(1_234)).toBe((1_234).toLocaleString());
+  });
+});


### PR DESCRIPTION
## Summary

- consolidate eight coherent duplicate-code clusters identified in issue #174
- add focused unit coverage for each extracted helper
- reduce the scoped jscpd result from 67 groups / 764 duplicated lines (1.00%) to 59 groups / 656 lines (0.86%)

## Verification

- competitive harness (saved-state portfolio review across routing, memory, providers, formatting, and evidence): OpenCandle 9, Claude 7, Codex 6, Gemini 5; 1 win, 0 losses, 0 ties
- npm run review:pr: clean, no actionable findings
- npm run gates: passed (358 test files; 3,839 passed, 1 skipped; relay 76 passed; agent-tool 27 passed)

Related to #174.